### PR TITLE
Fix argument order of `string.concatenate`

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -62,7 +62,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ['({ ((a): :(b)) ((b): B) })', either.makeRight({ a: 'B', b: 'B' })],
   ['{ (a: :(")")), (")": (B)) }', either.makeRight({ a: 'B', ')': 'B' })],
   [':match({ a: A })({ tag: a, value: {} })', either.makeRight('A')],
-  [':{string concatenate}(a)(b)', either.makeRight('ab')],
+  [':{string concatenate}(a)(b)', either.makeRight('ba')],
   [
     `{
         "static data":"blah blah blah"

--- a/src/language/compiling/semantics/prelude.ts
+++ b/src/language/compiling/semantics/prelude.ts
@@ -509,7 +509,7 @@ export const prelude: ObjectNode = makeObjectNode({
           return: types.string,
         }),
       },
-      string1 =>
+      string2 =>
         either.makeRight(
           makeFunctionNode(
             {
@@ -518,11 +518,11 @@ export const prelude: ObjectNode = makeObjectNode({
             },
             serializePartiallyAppliedFunction(
               ['string', 'concatenate'],
-              string1,
+              string2,
             ),
             option.none,
-            string2 => {
-              if (typeof string1 !== 'string' || typeof string2 !== 'string') {
+            string1 => {
+              if (typeof string1 !== 'string' || typeof string1 !== 'string') {
                 return either.makeLeft({
                   kind: 'panic',
                   message: 'concatenate received a non-string argument',


### PR DESCRIPTION
Higher-order non-commutative functions like this should always take their "first" argument in their last application to make function composition more natural. The function `:flow({ :string.concatenate(a) :string.concatenate(b) })` should add `ab` to the end of its argument.