### PR TITLE
Standardize camel-casing of acronyms in codebase

### DIFF
--- a/src/adts.ts
+++ b/src/adts.ts
@@ -1,9 +1,9 @@
 import * as eitherUtilities from './adts/either-utilities.js'
-import * as eitherADT from './adts/either.js'
+import * as eitherAdt from './adts/either.js'
 import * as optionUtilities from './adts/option-utilities.js'
-import * as optionADT from './adts/option.js'
+import * as optionAdt from './adts/option.js'
 
 export type { Either } from './adts/either.js'
 export type { Option } from './adts/option.js'
-export const either = { ...eitherADT, ...eitherUtilities }
-export const option = { ...optionADT, ...optionUtilities }
+export const either = { ...eitherAdt, ...eitherUtilities }
+export const option = { ...optionAdt, ...optionUtilities }

--- a/src/language/cli/input.ts
+++ b/src/language/cli/input.ts
@@ -1,15 +1,15 @@
 import { parseArgs } from 'util'
 import { either, type Either } from '../../adts.js'
-import { type JSONValueForbiddingSymbolicKeys } from '../parsing.js'
+import { type JsonValueForbiddingSymbolicKeys } from '../parsing.js'
 
 export type InvalidJsonError = {
-  readonly kind: 'invalidJSON'
+  readonly kind: 'invalidJson'
   readonly message: string
 }
 
 export const handleInput = async <Result>(
   process: NodeJS.Process,
-  command: (input: JSONValueForbiddingSymbolicKeys) => Result,
+  command: (input: JsonValueForbiddingSymbolicKeys) => Result,
 ): Promise<Result> => {
   const args = parseArgs({
     args: process.argv.slice(2), // remove `execPath` and `filename`
@@ -25,7 +25,7 @@ export const handleInput = async <Result>(
       `Unsupported input format: "${args.values['input-format']}"`,
     )
   } else {
-    const input = await readJSON(process.stdin)
+    const input = await readJson(process.stdin)
     return either.match(input, {
       left: error => {
         throw new Error(error.message) // TODO: Improve error reporting.
@@ -35,10 +35,10 @@ export const handleInput = async <Result>(
   }
 }
 
-export const readJSON = async (
+export const readJson = async (
   stream: AsyncIterable<string>,
-): Promise<Either<InvalidJsonError, JSONValueForbiddingSymbolicKeys>> =>
-  parseJSON(await readString(stream))
+): Promise<Either<InvalidJsonError, JsonValueForbiddingSymbolicKeys>> =>
+  parseJson(await readString(stream))
 
 export const readString = async (
   stream: AsyncIterable<string>,
@@ -50,13 +50,13 @@ export const readString = async (
   return input
 }
 
-const parseJSON = (
+const parseJson = (
   source: string,
-): Either<InvalidJsonError, JSONValueForbiddingSymbolicKeys> =>
+): Either<InvalidJsonError, JsonValueForbiddingSymbolicKeys> =>
   either.mapLeft(
-    either.tryCatch((): JSONValueForbiddingSymbolicKeys => JSON.parse(source)),
+    either.tryCatch((): JsonValueForbiddingSymbolicKeys => JSON.parse(source)),
     jsonParseError => ({
-      kind: 'invalidJSON',
+      kind: 'invalidJson',
       message:
         jsonParseError instanceof Error
           ? jsonParseError.message

--- a/src/language/compiling/compiler.ts
+++ b/src/language/compiling/compiler.ts
@@ -1,12 +1,12 @@
 import { either, type Either } from '../../adts.js'
 import type { CompilationError } from '../errors.js'
-import type { JSONValueForbiddingSymbolicKeys } from '../parsing.js'
+import type { JsonValueForbiddingSymbolicKeys } from '../parsing.js'
 import { canonicalize } from '../parsing.js'
 import { elaborate, serialize, type Output } from '../semantics.js'
 import { keywordHandlers } from './semantics/keywords.js'
 
 export const compile = (
-  input: JSONValueForbiddingSymbolicKeys,
+  input: JsonValueForbiddingSymbolicKeys,
 ): Either<CompilationError, Output> => {
   const syntaxTree = canonicalize(input)
   const semanticGraphResult = elaborate(syntaxTree, keywordHandlers)

--- a/src/language/parsing.ts
+++ b/src/language/parsing.ts
@@ -2,6 +2,6 @@ export type { Atom } from './parsing/atom.js'
 export type { Molecule } from './parsing/molecule.js'
 export {
   canonicalize,
-  type JSONValueForbiddingSymbolicKeys,
+  type JsonValueForbiddingSymbolicKeys,
   type SyntaxTree,
 } from './parsing/syntax-tree.js'

--- a/src/language/parsing/syntax-tree.ts
+++ b/src/language/parsing/syntax-tree.ts
@@ -2,9 +2,9 @@ import { option, type Option } from '../../adts.js'
 import { parser, type Parser } from '../../parsing.js'
 import { withPhantomData, type WithPhantomData } from '../../phantom-data.js'
 import type {
-  JSONArray,
-  JSONRecord,
-  JSONValue,
+  JsonArray,
+  JsonRecord,
+  JsonValue,
   Writable,
 } from '../../utility-types.js'
 import type { KeyPath } from '../semantics.js'
@@ -47,7 +47,7 @@ export const applyKeyPathToSyntaxTree = (
  * The JSON value `["a", 1, null]` is canonicalized as `{ "0": "a", "1": "1", "2": "null" }`.
  */
 export const canonicalize = (
-  input: JSONValueForbiddingSymbolicKeys,
+  input: JsonValueForbiddingSymbolicKeys,
 ): SyntaxTree => {
   let canonicalized: Atom | Writable<Molecule>
   if (typeof input === 'object' && input !== null) {
@@ -66,15 +66,15 @@ export const canonicalize = (
  * (because symbolic keys can always be widened away), but will catch simple mistakes like directly
  * feeding an `Option<…>` into `canonicalize`.
  */
-export type JSONValueForbiddingSymbolicKeys =
-  | Exclude<JSONValue, JSONArray | JSONRecord>
-  | JSONArrayForbiddingSymbolicKeys
-  | JSONRecordForbiddingSymbolicKeys
+export type JsonValueForbiddingSymbolicKeys =
+  | Exclude<JsonValue, JsonArray | JsonRecord>
+  | JsonArrayForbiddingSymbolicKeys
+  | JsonRecordForbiddingSymbolicKeys
 
-type JSONArrayForbiddingSymbolicKeys =
-  readonly JSONValueForbiddingSymbolicKeys[]
-type JSONRecordForbiddingSymbolicKeys = {
-  readonly [key: string]: JSONValueForbiddingSymbolicKeys
+type JsonArrayForbiddingSymbolicKeys =
+  readonly JsonValueForbiddingSymbolicKeys[]
+type JsonRecordForbiddingSymbolicKeys = {
+  readonly [key: string]: JsonValueForbiddingSymbolicKeys
 } & Partial<{
   readonly [key: symbol]: undefined
 }>

--- a/src/language/runtime/evaluator.ts
+++ b/src/language/runtime/evaluator.ts
@@ -1,12 +1,12 @@
 import { either, type Either } from '../../adts.js'
 import type { RuntimeError } from '../errors.js'
-import type { JSONValueForbiddingSymbolicKeys } from '../parsing.js'
+import type { JsonValueForbiddingSymbolicKeys } from '../parsing.js'
 import { canonicalize } from '../parsing.js'
 import { elaborate, serialize, type Output } from '../semantics.js'
 import { keywordHandlers } from './keywords.js'
 
 export const evaluate = (
-  input: JSONValueForbiddingSymbolicKeys,
+  input: JsonValueForbiddingSymbolicKeys,
 ): Either<RuntimeError, Output> => {
   const syntaxTree = canonicalize(input)
   const semanticGraphResult = elaborate(syntaxTree, keywordHandlers)

--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -1,4 +1,4 @@
-import { option as optionADT } from '../../../adts.js'
+import { option as optionAdt } from '../../../adts.js'
 import {
   makeFunctionType,
   makeObjectType,
@@ -23,22 +23,22 @@ export const boolean = makeUnionType('boolean', ['false', 'true'])
 
 export const atom = makeOpaqueAtomType('atom', {
   isAssignableFromLiteralType: (_literalType: string) => true,
-  nearestOpaqueAssignableFrom: () => optionADT.makeSome(integer),
-  nearestOpaqueAssignableTo: () => optionADT.none,
+  nearestOpaqueAssignableFrom: () => optionAdt.makeSome(integer),
+  nearestOpaqueAssignableTo: () => optionAdt.none,
 })
 
 export const integer = makeOpaqueAtomType('natural_number', {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|-?[1-9](?:[0-9])*)+$/.test(literalType),
-  nearestOpaqueAssignableFrom: () => optionADT.makeSome(naturalNumber),
-  nearestOpaqueAssignableTo: () => optionADT.makeSome(atom),
+  nearestOpaqueAssignableFrom: () => optionAdt.makeSome(naturalNumber),
+  nearestOpaqueAssignableTo: () => optionAdt.makeSome(atom),
 })
 
 export const naturalNumber = makeOpaqueAtomType('natural_number', {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|[1-9](?:[0-9])*)+$/.test(literalType),
-  nearestOpaqueAssignableFrom: () => optionADT.none,
-  nearestOpaqueAssignableTo: () => optionADT.makeSome(integer),
+  nearestOpaqueAssignableFrom: () => optionAdt.none,
+  nearestOpaqueAssignableTo: () => optionAdt.makeSome(integer),
 })
 
 export const object = makeObjectType('object', {})

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,11 +1,11 @@
-export type JSONArray = readonly JSONValue[]
-export type JSONRecord = { readonly [key: string]: JSONValue }
-export type JSONValue =
+export type JsonArray = readonly JsonValue[]
+export type JsonRecord = { readonly [key: string]: JsonValue }
+export type JsonValue =
   | null
   | boolean
   | number
   | string
-  | JSONArray
-  | JSONRecord
+  | JsonArray
+  | JsonRecord
 
 export type Writable<T> = { -readonly [P in keyof T]: T[P] }


### PR DESCRIPTION
Previously there was a mix of `fooABC` and `fooAbc`. Now everything should use the latter style.