### PR TITLE
Separate `TypeKeyPath` from `KeyPath`

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
@@ -143,22 +143,14 @@ const lookup = ({
               ),
             right: functionExpression => {
               if (functionExpression.parameter === firstPathComponent) {
-                if (!relativePath.every(key => typeof key === 'string')) {
-                  return either.makeLeft({
-                    kind: 'invalidExpression',
-                    message:
-                      'dynamically-resolved lookup query contains symbolic key',
-                  })
-                } else {
-                  // Keep an unelaborated `@lookup` around for resolution when the `@function` is called.
-                  return either.makeRight(
-                    option.makeSome(
-                      makeLookupExpression(
-                        makeObjectNode(keyPathToMolecule(relativePath)),
-                      ),
+                // Keep an unelaborated `@lookup` around for resolution when the `@function` is called.
+                return either.makeRight(
+                  option.makeSome(
+                    makeLookupExpression(
+                      makeObjectNode(keyPathToMolecule(relativePath)),
                     ),
-                  )
-                }
+                  ),
+                )
               } else {
                 return either.makeRight(option.none)
               }

--- a/src/language/parsing/syntax-tree.ts
+++ b/src/language/parsing/syntax-tree.ts
@@ -26,9 +26,6 @@ export const applyKeyPathToSyntaxTree = (
   } else {
     if (typeof syntaxTree === 'string') {
       return option.none
-    } else if (typeof firstKey === 'symbol') {
-      // TODO: Treat this as an error? Or change the type of `keyPath`?
-      return option.none
     } else {
       const next = withPhantomData<Canonicalized>()(syntaxTree[firstKey])
       if (next === undefined) {

--- a/src/language/semantics/key-path.ts
+++ b/src/language/semantics/key-path.ts
@@ -3,19 +3,7 @@ import type { Atom, Molecule } from '../parsing.js'
 import { unparse } from '../unparsing.js'
 import { prettyPlz } from '../unparsing/pretty-plz.js'
 
-export const functionParameter = Symbol('functionParameter')
-export const functionReturn = Symbol('functionReturn')
-export const typeParameterAssignableToConstraint = Symbol(
-  'typeParameterAssignableToConstraint',
-)
-export type KeyPath = readonly (
-  | Atom
-  // These symbol keys are somewhat "internal" at the moment. If they end up not being expressible
-  // in the surface syntax then `KeyPath` should be split into two separate types.
-  | typeof functionParameter
-  | typeof functionReturn
-  | typeof typeParameterAssignableToConstraint
-)[]
+export type KeyPath = readonly Atom[]
 
 export const stringifyKeyPathForEndUser = (keyPath: KeyPath): string =>
   either.match(
@@ -28,8 +16,4 @@ export const stringifyKeyPathForEndUser = (keyPath: KeyPath): string =>
   )
 
 export const keyPathToMolecule = (keyPath: KeyPath): Molecule =>
-  Object.fromEntries(
-    keyPath.flatMap((key, index) =>
-      typeof key === 'symbol' ? [] : [[index, key]],
-    ),
-  )
+  Object.fromEntries(keyPath.flatMap((key, index) => [[index, key]]))

--- a/src/language/semantics/prelude.ts
+++ b/src/language/semantics/prelude.ts
@@ -2,7 +2,7 @@ import { either, option, type Either } from '../../adts.js'
 import type { DependencyUnavailable, Panic } from '../errors.js'
 import type { Atom } from '../parsing.js'
 import { isFunctionNode, makeFunctionNode } from './function-node.js'
-import { keyPathToMolecule } from './key-path.js'
+import { keyPathToMolecule, type KeyPath } from './key-path.js'
 import {
   isObjectNode,
   lookupPropertyOfObjectNode,
@@ -44,7 +44,7 @@ const handleUnavailableDependencies =
   }
 
 const serializePartiallyAppliedFunction =
-  (keyPath: readonly string[], argument: SemanticGraph) => () =>
+  (keyPath: KeyPath, argument: SemanticGraph) => () =>
     either.makeRight(
       makeUnelaboratedObjectNode({
         0: '@apply',
@@ -54,7 +54,7 @@ const serializePartiallyAppliedFunction =
     )
 
 const preludeFunction = (
-  keyPath: readonly string[],
+  keyPath: KeyPath,
   signature: FunctionType['signature'],
   f: (
     value: SemanticGraph,

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -35,18 +35,14 @@ export const applyKeyPathToSemanticGraph = (
       atom: _ => option.none,
       function: _ => option.none,
       object: graph => {
-        if (typeof firstKey === 'symbol') {
+        const next = graph[firstKey]
+        if (next === undefined) {
           return option.none
         } else {
-          const next = graph[firstKey]
-          if (next === undefined) {
-            return option.none
-          } else {
-            return applyKeyPathToSemanticGraph(
-              isSemanticGraph(next) ? next : syntaxTreeToSemanticGraph(next),
-              remainingKeyPath,
-            )
-          }
+          return applyKeyPathToSemanticGraph(
+            isSemanticGraph(next) ? next : syntaxTreeToSemanticGraph(next),
+            remainingKeyPath,
+          )
         }
       },
     })
@@ -106,28 +102,24 @@ export const updateValueAtKeyPathInSemanticGraph = (
       atom: _ => either.makeLeft(makePropertyNotFoundError(keyPath)),
       function: _ => either.makeLeft(makePropertyNotFoundError(keyPath)),
       object: node => {
-        if (typeof firstKey === 'symbol') {
+        const next = node[firstKey]
+        if (next === undefined) {
           return either.makeLeft(makePropertyNotFoundError(keyPath))
         } else {
-          const next = node[firstKey]
-          if (next === undefined) {
-            return either.makeLeft(makePropertyNotFoundError(keyPath))
-          } else {
-            return either.map(
-              updateValueAtKeyPathInSemanticGraph(
-                isSemanticGraph(next) ? next : syntaxTreeToSemanticGraph(next),
-                remainingKeyPath,
-                operation,
-              ),
-              updatedNode =>
-                (isUnelaborated(node)
-                  ? makeUnelaboratedObjectNode
-                  : makeObjectNode)({
-                  ...node,
-                  [firstKey]: updatedNode,
-                }),
-            )
-          }
+          return either.map(
+            updateValueAtKeyPathInSemanticGraph(
+              isSemanticGraph(next) ? next : syntaxTreeToSemanticGraph(next),
+              remainingKeyPath,
+              operation,
+            ),
+            updatedNode =>
+              (isUnelaborated(node)
+                ? makeUnelaboratedObjectNode
+                : makeObjectNode)({
+                ...node,
+                [firstKey]: updatedNode,
+              }),
+          )
         }
       },
     })

--- a/src/language/unparsing/pretty-plz.ts
+++ b/src/language/unparsing/pretty-plz.ts
@@ -85,9 +85,7 @@ const sugaredLookup = (keyPathAsNode: Molecule | SemanticGraph) => {
   if (
     keyPath !== 'invalid' &&
     Object.keys(keyPathAsNode).length === keyPath.length &&
-    keyPath.every(
-      key => typeof key === 'string' && !either.isLeft(unquotedAtomParser(key)),
-    )
+    keyPath.every(key => !either.isLeft(unquotedAtomParser(key)))
   ) {
     return either.makeRight(kleur.cyan(colon.concat(keyPath.join(dot))))
   } else {


### PR DESCRIPTION
Follows through on [this comment](https://github.com/mkantor/please-lang-prototype/blob/997cb9f63b2cf0da5ed9db6fe50ff2fc07df83d4/src/language/semantics/key-path.ts#L13-L14).