### PR TITLE
Apply atom quoting fix to inline-plz too

### DIFF
--- a/src/language/unparsing/inline-plz.ts
+++ b/src/language/unparsing/inline-plz.ts
@@ -30,10 +30,17 @@ const arrow = kleur.dim('=>')
 const escapeStringContents = (value: string) =>
   value.replace('\\', '\\\\').replace('"', '\\"')
 
-const quoteIfNecessary = (value: string) =>
-  !either.isLeft(unquotedAtomParser(value))
-    ? value
-    : quote.concat(escapeStringContents(value)).concat(quote)
+const quoteIfNecessary = (value: string) => {
+  const unquotedAtomResult = unquotedAtomParser(value)
+  if (
+    either.isLeft(unquotedAtomResult) ||
+    unquotedAtomResult.value.remainingInput.length !== 0
+  ) {
+    return quote.concat(escapeStringContents(value)).concat(quote)
+  } else {
+    return value
+  }
+}
 
 const atom = (node: string): Right<string> =>
   either.makeRight(


### PR DESCRIPTION
Same idea as #20 but for the inline-plz output format (which is used in diagnostics, etc). This really should have been part of #20, but was overlooked. I'm now more motivated to factor out common utilities for unparsers.