### PR TITLE
Fix some unparser bugs

### DIFF
--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -59,6 +59,17 @@ testCases(
     },
     either.makeRight('(a => :a)("it works!")'),
   ],
+  [
+    {
+      0: '@runtime',
+      1: {
+        0: '@function',
+        parameter: 'context',
+        body: { 0: '@lookup', query: 'context.program.start_time' },
+      },
+    },
+    either.makeRight('{ @runtime, context => :context.program.start_time }'),
+  ],
 ])
 
 testCases(
@@ -107,6 +118,19 @@ testCases(
       argument: 'it works!',
     },
     either.makeRight('(a => :a)("it works!")'),
+  ],
+  [
+    {
+      0: '@runtime',
+      1: {
+        0: '@function',
+        parameter: 'context',
+        body: { 0: '@lookup', query: 'context.program.start_time' },
+      },
+    },
+    either.makeRight(
+      '{\n  @runtime\n  context => :context.program.start_time\n}',
+    ),
   ],
 ])
 

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -24,6 +24,7 @@ testCases(
   [{}, either.makeRight('{}')],
   ['a', either.makeRight('a')],
   ['Hello, world!', either.makeRight('"Hello, world!"')],
+  ['@test', either.makeRight('@test')],
   [{ 0: 'a' }, either.makeRight('{ a }')],
   [{ 1: 'a' }, either.makeRight('{ 1: a }')],
   [
@@ -67,6 +68,7 @@ testCases(
   [{}, either.makeRight('{}')],
   ['a', either.makeRight('a')],
   ['Hello, world!', either.makeRight('"Hello, world!"')],
+  ['@test', either.makeRight('@test')],
   [{ 0: 'a' }, either.makeRight('{\n  a\n}')],
   [{ 1: 'a' }, either.makeRight('{\n  1: a\n}')],
   [
@@ -115,6 +117,7 @@ testCases(
   [{}, either.makeRight('{}')],
   ['a', either.makeRight('"a"')],
   ['Hello, world!', either.makeRight('"Hello, world!"')],
+  ['@test', either.makeRight('"@test"')],
   [{ 0: 'a' }, either.makeRight('{\n  "0": "a"\n}')],
   [{ 1: 'a' }, either.makeRight('{\n  "1": "a"\n}')],
   [

--- a/src/language/semantics/expression.ts
+++ b/src/language/semantics/expression.ts
@@ -9,3 +9,11 @@ export const isExpression = (
   node: SemanticGraph | Molecule,
 ): node is Expression =>
   typeof node === 'object' && typeof node[0] === 'string' && node[0][0] === '@'
+
+export const isSpecificExpression = <Keyword extends `@${string}`>(
+  keyword: Keyword,
+  node: SemanticGraph | Molecule,
+): node is {
+  readonly 0: Keyword
+} =>
+  typeof node === 'object' && typeof node[0] === 'string' && node[0] === keyword

--- a/src/language/semantics/expressions/apply-expression.ts
+++ b/src/language/semantics/expressions/apply-expression.ts
@@ -1,7 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import type { Molecule } from '../../parsing.js'
-import { isExpression } from '../expression.js'
+import { isSpecificExpression } from '../expression.js'
 import { makeUnelaboratedObjectNode, type ObjectNode } from '../object-node.js'
 import { type SemanticGraph, type unelaboratedKey } from '../semantic-graph.js'
 import { readArgumentsFromExpression } from './expression-utilities.js'
@@ -15,7 +15,7 @@ export type ApplyExpression = ObjectNode & {
 export const readApplyExpression = (
   node: SemanticGraph | Molecule,
 ): Either<ElaborationError, ApplyExpression> =>
-  isExpression(node)
+  isSpecificExpression('@apply', node)
     ? either.map(
         readArgumentsFromExpression(node, [
           ['function', '1'],

--- a/src/language/semantics/expressions/check-expression.ts
+++ b/src/language/semantics/expressions/check-expression.ts
@@ -1,7 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import type { Molecule } from '../../parsing.js'
-import { isExpression } from '../expression.js'
+import { isSpecificExpression } from '../expression.js'
 import { makeUnelaboratedObjectNode, type ObjectNode } from '../object-node.js'
 import { type SemanticGraph, type unelaboratedKey } from '../semantic-graph.js'
 import { readArgumentsFromExpression } from './expression-utilities.js'
@@ -15,7 +15,7 @@ export type CheckExpression = ObjectNode & {
 export const readCheckExpression = (
   node: SemanticGraph | Molecule,
 ): Either<ElaborationError, CheckExpression> =>
-  isExpression(node)
+  isSpecificExpression('@check', node)
     ? either.map(
         readArgumentsFromExpression(node, [
           ['value', '1'],

--- a/src/language/semantics/expressions/function-expression.ts
+++ b/src/language/semantics/expressions/function-expression.ts
@@ -1,7 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import type { Atom, Molecule } from '../../parsing.js'
-import { isExpression } from '../expression.js'
+import { isSpecificExpression } from '../expression.js'
 import { makeUnelaboratedObjectNode, type ObjectNode } from '../object-node.js'
 import {
   serialize,
@@ -22,7 +22,7 @@ export type FunctionExpression = ObjectNode & {
 export const readFunctionExpression = (
   node: SemanticGraph | Molecule,
 ): Either<ElaborationError, FunctionExpression> =>
-  isExpression(node)
+  isSpecificExpression('@function', node)
     ? either.flatMap(
         readArgumentsFromExpression(node, [
           ['parameter', '1'],

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -1,7 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError, InvalidExpressionError } from '../../errors.js'
 import type { Molecule } from '../../parsing.js'
-import { isExpression } from '../expression.js'
+import { isSpecificExpression } from '../expression.js'
 import { isFunctionNode } from '../function-node.js'
 import { keyPathToMolecule, type KeyPath } from '../key-path.js'
 import {
@@ -23,7 +23,7 @@ export type LookupExpression = ObjectNode & {
 export const readLookupExpression = (
   node: SemanticGraph | Molecule,
 ): Either<ElaborationError, LookupExpression> =>
-  isExpression(node)
+  isSpecificExpression('@lookup', node)
     ? either.flatMap(
         readArgumentsFromExpression(node, [['query', '1']]),
         ([q]) => {

--- a/src/language/semantics/expressions/runtime-expression.ts
+++ b/src/language/semantics/expressions/runtime-expression.ts
@@ -1,7 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import type { Molecule } from '../../parsing.js'
-import { isExpression } from '../expression.js'
+import { isSpecificExpression } from '../expression.js'
 import { isFunctionNode } from '../function-node.js'
 import { makeUnelaboratedObjectNode, type ObjectNode } from '../object-node.js'
 import {
@@ -22,7 +22,7 @@ export type RuntimeExpression = ObjectNode & {
 export const readRuntimeExpression = (
   node: SemanticGraph | Molecule,
 ): Either<ElaborationError, RuntimeExpression> =>
-  isExpression(node)
+  isSpecificExpression('@runtime', node)
     ? either.flatMap(
         readArgumentsFromExpression(node, [['function', '1']]),
         ([f]) => {

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -113,9 +113,9 @@ export const sugarFreeMoleculeAsKeyValuePairStrings = (
 
 export const unparseAtom = (atom: string): Right<string> =>
   either.makeRight(
-    quoteIfNecessary(
-      /^@[^@]/.test(atom) ? kleur.bold(kleur.underline(atom)) : atom,
-    ),
+    /^@[^@]/.test(atom)
+      ? kleur.bold(kleur.underline(quoteIfNecessary(atom)))
+      : quoteIfNecessary(atom),
   )
 
 type UnparseAtomOrMolecule = (


### PR DESCRIPTION
- Keywords were always unnecessarily quoted.
- Syntax sugars were applied without checking the specific keyword (e.g. `{@a, b}` would become `:b` because `{ 1: b }` was readable by `readLookupExpression`).