### PR TITLE
Add `@index` keyword expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ keyword expressions.
 Under the hood, keyword expressions are modeled as objects. For example, `:foo`
 desugars to `{@lookup query: foo}`. All such expressions have a key `0`
 referring to a value that is an `@`-prefixed atom (the keyword). Keywords
-include `@function`, `@lookup`, `@apply`, `@check`, and `@runtime`.
+include `@function`, `@lookup`, `@apply`, `@check`, `@index`, and `@runtime`.
 
 Currently only `@function`, `@lookup`, and `@apply` have syntax sugars.
 

--- a/src/language/compiling/semantics.test.ts
+++ b/src/language/compiling/semantics.test.ts
@@ -173,6 +173,34 @@ elaborationSuite('@check', [
   ],
 ])
 
+elaborationSuite('@index', [
+  [{ 0: '@index', 1: { foo: 'bar' }, 2: { 0: 'foo' } }, success('bar')],
+  [
+    { 0: '@index', object: { foo: 'bar' }, query: { 0: 'foo' } },
+    success('bar'),
+  ],
+  [
+    {
+      0: '@index',
+      object: { a: { b: { c: 'it works' } } },
+      query: { 0: 'a', 1: 'b', 2: 'c' },
+    },
+    success('it works'),
+  ],
+  [
+    {
+      0: '@index',
+      object: { a: { b: { c: 'it works' } } },
+      query: { 0: 'a', 1: 'b' },
+    },
+    success({ c: 'it works' }),
+  ],
+  [
+    { 0: '@index', object: {}, query: { 0: 'thisPropertyDoesNotExist' } },
+    output => assert(either.isLeft(output)),
+  ],
+])
+
 elaborationSuite('@lookup', [
   [
     {

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -1,0 +1,36 @@
+import either, { type Either } from '@matt.kantor/either'
+import option from '@matt.kantor/option'
+import type { ElaborationError } from '../../../errors.js'
+import {
+  applyKeyPathToSemanticGraph,
+  asSemanticGraph,
+  keyPathFromObjectNodeOrMolecule,
+  readIndexExpression,
+  stringifyKeyPathForEndUser,
+  type Expression,
+  type ExpressionContext,
+  type KeywordHandler,
+  type SemanticGraph,
+} from '../../../semantics.js'
+
+export const indexKeywordHandler: KeywordHandler = (
+  expression: Expression,
+  _context: ExpressionContext,
+): Either<ElaborationError, SemanticGraph> =>
+  either.flatMap(readIndexExpression(expression), ({ object, query }) =>
+    either.flatMap(keyPathFromObjectNodeOrMolecule(query), keyPath =>
+      option.match(
+        applyKeyPathToSemanticGraph(asSemanticGraph(object), keyPath),
+        {
+          none: () =>
+            either.makeLeft({
+              kind: 'invalidExpression',
+              message: `property \`${stringifyKeyPathForEndUser(
+                keyPath,
+              )}\` not found`,
+            }),
+          some: either.makeRight,
+        },
+      ),
+    ),
+  )

--- a/src/language/compiling/semantics/keywords.ts
+++ b/src/language/compiling/semantics/keywords.ts
@@ -2,6 +2,7 @@ import { type KeywordHandlers } from '../../semantics.js'
 import { applyKeywordHandler } from './keyword-handlers/apply-handler.js'
 import { checkKeywordHandler } from './keyword-handlers/check-handler.js'
 import { functionKeywordHandler } from './keyword-handlers/function-handler.js'
+import { indexKeywordHandler } from './keyword-handlers/index-handler.js'
 import { lookupKeywordHandler } from './keyword-handlers/lookup-handler.js'
 import { runtimeKeywordHandler } from './keyword-handlers/runtime-handler.js'
 import { todoKeywordHandler } from './keyword-handlers/todo-handler.js'
@@ -21,6 +22,11 @@ export const keywordHandlers: KeywordHandlers = {
    * Creates a function.
    */
   '@function': functionKeywordHandler,
+
+  /**
+   * Returns the value of a property within an object.
+   */
+  '@index': indexKeywordHandler,
 
   /**
    * Given a query, resolves the value of a property within the program.

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -28,6 +28,11 @@ export {
   type FunctionExpression,
 } from './semantics/expressions/function-expression.js'
 export {
+  makeIndexExpression,
+  readIndexExpression,
+  type IndexExpression,
+} from './semantics/expressions/index-expression.js'
+export {
   makeLookupExpression,
   readLookupExpression,
   type LookupExpression,
@@ -44,6 +49,7 @@ export {
   type FunctionNode,
 } from './semantics/function-node.js'
 export {
+  keyPathFromObjectNodeOrMolecule,
   keyPathToMolecule,
   stringifyKeyPathForEndUser,
   type KeyPath,

--- a/src/language/semantics/expressions/index-expression.ts
+++ b/src/language/semantics/expressions/index-expression.ts
@@ -1,0 +1,69 @@
+import either, { type Either } from '@matt.kantor/either'
+import type { ElaborationError } from '../../errors.js'
+import type { Molecule } from '../../parsing.js'
+import { isSpecificExpression } from '../expression.js'
+import { keyPathFromObjectNodeOrMolecule } from '../key-path.js'
+import {
+  isObjectNode,
+  makeUnelaboratedObjectNode,
+  type ObjectNode,
+} from '../object-node.js'
+import { type SemanticGraph, type unelaboratedKey } from '../semantic-graph.js'
+import {
+  asSemanticGraph,
+  readArgumentsFromExpression,
+} from './expression-utilities.js'
+
+export type IndexExpression = ObjectNode & {
+  readonly 0: '@index'
+  readonly object: ObjectNode | Molecule
+  readonly query: ObjectNode | Molecule
+}
+
+export const readIndexExpression = (
+  node: SemanticGraph | Molecule,
+): Either<ElaborationError, IndexExpression> =>
+  isSpecificExpression('@index', node)
+    ? either.flatMap(
+        readArgumentsFromExpression(node, [
+          ['object', '1'],
+          ['query', '2'],
+        ]),
+        ([o, q]) => {
+          const object = asSemanticGraph(o)
+          const query = asSemanticGraph(q)
+          if (!isObjectNode(object)) {
+            return either.makeLeft({
+              kind: 'invalidExpression',
+              message: 'object must be an object',
+            })
+          } else if (!isObjectNode(query)) {
+            return either.makeLeft({
+              kind: 'invalidExpression',
+              message: 'query must be an object',
+            })
+          } else {
+            return either.map(
+              keyPathFromObjectNodeOrMolecule(query),
+              _validKeyPath => makeIndexExpression({ object, query }),
+            )
+          }
+        },
+      )
+    : either.makeLeft({
+        kind: 'invalidExpression',
+        message: 'not an expression',
+      })
+
+export const makeIndexExpression = ({
+  query,
+  object,
+}: {
+  readonly query: ObjectNode | Molecule
+  readonly object: ObjectNode | Molecule
+}): IndexExpression & { readonly [unelaboratedKey]: true } =>
+  makeUnelaboratedObjectNode({
+    0: '@index',
+    object,
+    query,
+  })

--- a/src/language/semantics/key-path.ts
+++ b/src/language/semantics/key-path.ts
@@ -1,6 +1,8 @@
-import either from '@matt.kantor/either'
+import either, { type Either } from '@matt.kantor/either'
+import type { InvalidExpressionError } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
 import { inlinePlz, unparse } from '../unparsing.js'
+import type { ObjectNode } from './object-node.js'
 
 export type KeyPath = readonly Atom[]
 
@@ -12,3 +14,25 @@ export const stringifyKeyPathForEndUser = (keyPath: KeyPath): string =>
 
 export const keyPathToMolecule = (keyPath: KeyPath): Molecule =>
   Object.fromEntries(keyPath.flatMap((key, index) => [[index, key]]))
+
+export const keyPathFromObjectNodeOrMolecule = (
+  node: ObjectNode | Molecule,
+): Either<InvalidExpressionError, KeyPath> => {
+  const relativePath: string[] = []
+  let queryIndex = 0
+  // Consume numeric indexes ("0", "1", …) until exhausted, validating that each is an atom.
+  let key = node[queryIndex]
+  while (key !== undefined) {
+    if (typeof key !== 'string') {
+      return either.makeLeft({
+        kind: 'invalidExpression',
+        message: 'expected a key path composed of sequential atoms',
+      })
+    } else {
+      relativePath.push(key)
+    }
+    queryIndex++
+    key = node[queryIndex]
+  }
+  return either.makeRight(relativePath)
+}

--- a/src/language/semantics/keyword.ts
+++ b/src/language/semantics/keyword.ts
@@ -2,6 +2,7 @@ export const isKeyword = (input: string) =>
   input === '@apply' ||
   input === '@check' ||
   input === '@function' ||
+  input === '@index' ||
   input === '@lookup' ||
   input === '@runtime' ||
   input === '@todo'


### PR DESCRIPTION
This makes it possible to access properties of objects directly (without using a `@lookup`).

I may eventually drop `@lookup`'s support for deep queries and instead desugar `:a.b` to something like `{@index {@lookup a} b}`, but for now that kind of thing is still handled within `@lookup` itself.