### PR TITLE
Syntax sugar for `@index` expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ data representation implied by the fact that a value is an atom (e.g. the atom
 `2` may be an integer in memory).
 
 Bare words not containing any
-[reserved character sequences](./src/language/parsing/atom.ts#L32-L54) are
+[reserved character sequences](./src/language/parsing/atom.ts#L24-L46) are
 atoms:
 
 ```

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -53,6 +53,47 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       body: { 0: '@lookup', query: { 0: 'a' } },
     }),
   ],
+  ['{ success }.0', either.makeRight('success')],
+  ['{ f: :identity }.f(success)', either.makeRight('success')],
+  ['{ f: :identity }.f({ a: success }).a', either.makeRight('success')],
+  [
+    '{ f: :identity }.f({ g: :identity }).g({ a: success }).a',
+    either.makeRight('success'),
+  ],
+  ['{ a: { b: success } }.a.b', either.makeRight('success')],
+  [
+    '{ a: { "b.c(d) e \\" {}": success } }.a."b.c(d) e \\" {}"',
+    either.makeRight('success'),
+  ],
+  ['(a => { b: :a }.b)(success)', either.makeRight('success')],
+  ['(a => { b: :a })(success).b', either.makeRight('success')],
+  ['{ success }/**/./**/0', either.makeRight('success')],
+  [
+    `
+      { a: { b: success } } // blah
+        // blah
+        .a // blah
+        // blah
+        .b // blah
+    `,
+    either.makeRight('success'),
+  ],
+  [
+    `{
+      a: {
+        b: {
+          c: z => {
+            d: y => x => {
+              e: {
+                f: w => { g: { :z :y :x :w } }
+              }
+            }
+          }
+        }
+      }
+    }.a.b.c(a).d(b)(c).e.f(d).g`,
+    either.makeRight({ 0: 'a', 1: 'b', 2: 'c', 3: 'd' }),
+  ],
   ['{ a: ({ A }) }', either.makeRight({ a: { 0: 'A' } })],
   ['{ a: ( A ) }', either.makeRight({ a: 'A' })],
   ['{ a: ("A A A") }', either.makeRight({ a: 'A A A' })],


### PR DESCRIPTION
You can now write expressions like `{ a: 1 }.a` in plz.