### PR TITLE
Allow `@index` operations to be deferred until runtime

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -236,6 +236,17 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{@runtime context =>
+      :identity(:context).program.start_time
+    }`,
+    output => {
+      if (either.isLeft(output)) {
+        assert.fail(output.value.message)
+      }
+      assert(typeof output.value === 'string')
+    },
+  ],
+  [
+    `{@runtime context =>
       :context.environment.lookup(PATH)
     }`,
     output => {


### PR DESCRIPTION
This should have been included in #32, but none of my test cases triggered the bug so I overlooked it.