### PR TITLE
Add `sugar-free-plz` output format

### DIFF
--- a/src/language/cli/output.ts
+++ b/src/language/cli/output.ts
@@ -1,7 +1,13 @@
 import either, { type Either } from '@matt.kantor/either'
 import { parseArgs } from 'util'
 import { type SyntaxTree } from '../parsing/syntax-tree.js'
-import { prettyJson, prettyPlz, unparse, type Notation } from '../unparsing.js'
+import {
+  prettyJson,
+  prettyPlz,
+  sugarFreePrettyPlz,
+  unparse,
+  type Notation,
+} from '../unparsing.js'
 
 export const handleOutput = async (
   process: NodeJS.Process,
@@ -23,6 +29,8 @@ export const handleOutput = async (
       notation = prettyJson
     } else if (outputFormat === 'plz') {
       notation = prettyPlz
+    } else if (outputFormat === 'sugar-free-plz') {
+      notation = sugarFreePrettyPlz
     } else {
       throw new Error(`Unsupported output format: "${outputFormat}"`)
     }

--- a/src/language/unparsing.ts
+++ b/src/language/unparsing.ts
@@ -6,6 +6,7 @@ import type { Notation } from './unparsing/unparsing-utilities.js'
 export { inlinePlz } from './unparsing/inline-plz.js'
 export { prettyJson } from './unparsing/pretty-json.js'
 export { prettyPlz } from './unparsing/pretty-plz.js'
+export { sugarFreePrettyPlz } from './unparsing/sugar-free-pretty-plz.js'
 export type { Notation } from './unparsing/unparsing-utilities.js'
 
 export const unparse = (

--- a/src/language/unparsing/sugar-free-pretty-plz.ts
+++ b/src/language/unparsing/sugar-free-pretty-plz.ts
@@ -1,0 +1,35 @@
+import either from '@matt.kantor/either'
+import type { Atom, Molecule } from '../parsing.js'
+import {
+  closeBrace,
+  moleculeAsKeyValuePairStrings,
+  openBrace,
+  unparseAtom,
+} from './plz-utilities.js'
+import { indent, type Notation } from './unparsing-utilities.js'
+
+const unparseMolecule = (value: Molecule) => {
+  if (Object.keys(value).length === 0) {
+    return either.makeRight(openBrace + closeBrace)
+  } else {
+    return either.map(
+      moleculeAsKeyValuePairStrings(value, unparseAtomOrMolecule, {
+        ordinalKeys: 'preserve',
+      }),
+      keyValuePairsAsStrings =>
+        openBrace
+          .concat('\n')
+          .concat(indent(2, keyValuePairsAsStrings.join('\n')))
+          .concat('\n')
+          .concat(closeBrace),
+    )
+  }
+}
+
+const unparseAtomOrMolecule = (value: Atom | Molecule) =>
+  typeof value === 'string' ? unparseAtom(value) : unparseMolecule(value)
+
+export const sugarFreePrettyPlz: Notation = {
+  atom: unparseAtom,
+  molecule: unparseMolecule,
+}


### PR DESCRIPTION
This is the notation I've been using for plo and plt in [the layering section of the README](https://github.com/mkantor/please-lang-prototype/blob/bab859d9ad985aa25c4330a9ac483ab57ffff47f/README.md#layering). As the name implies it uses the desugared forms of all keyword expressions, and also never omits property keys.