### PR TITLE
Specify minimum supported version of Node.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "@types/node": "^22.5.5",
         "strip-ansi": "^7.1.0",
         "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@matt.kantor/either": {

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "@matt.kantor/option": "^1.0.0",
     "@matt.kantor/parsing": "^1.1.0",
     "kleur": "^4.1.5"
+  },
+  "engines": {
+    "node": ">=22"
   }
 }


### PR DESCRIPTION
Currently everything does work with earlier Node.js versions (I just tested v20), but since CI only tests with v22 that may change at any time.