### PR TITLE
Add `--no-color` command-line option

### DIFF
--- a/src/language/cli/output.ts
+++ b/src/language/cli/output.ts
@@ -20,32 +20,31 @@ export const handleOutput = async (
       'output-format': { type: 'string' },
     },
   })
-  const outputFormat = args.values['output-format']
-  if (outputFormat === undefined) {
-    throw new Error('Missing required option: --output-format')
-  } else {
-    let notation: Notation
-    if (outputFormat === 'json') {
-      notation = prettyJson
-    } else if (outputFormat === 'plz') {
-      notation = prettyPlz
-    } else if (outputFormat === 'sugar-free-plz') {
-      notation = sugarFreePrettyPlz
-    } else {
-      throw new Error(`Unsupported output format: "${outputFormat}"`)
-    }
 
-    const result = await command()
-    return either.match(result, {
-      left: error => {
-        throw new Error(error.message) // TODO: Improve error reporting.
-      },
-      right: output => {
-        writeOutput(process.stdout, notation, output)
-        return undefined
-      },
-    })
+  const outputFormatArg = args.values['output-format']
+  let notation: Notation
+  if (outputFormatArg === undefined) {
+    throw new Error('Missing required option: --output-format')
+  } else if (outputFormatArg === 'json') {
+    notation = prettyJson
+  } else if (outputFormatArg === 'plz') {
+    notation = prettyPlz
+  } else if (outputFormatArg === 'sugar-free-plz') {
+    notation = sugarFreePrettyPlz
+  } else {
+    throw new Error(`Unsupported output format: "${outputFormatArg}"`)
   }
+
+  const result = await command()
+  return either.match(result, {
+    left: error => {
+      throw new Error(error.message) // TODO: Improve error reporting.
+    },
+    right: output => {
+      writeOutput(process.stdout, notation, output)
+      return undefined
+    },
+  })
 }
 
 export const writeOutput = (

--- a/src/language/cli/output.ts
+++ b/src/language/cli/output.ts
@@ -1,4 +1,5 @@
 import either, { type Either } from '@matt.kantor/either'
+import kleur from 'kleur'
 import { parseArgs } from 'node:util'
 import { type SyntaxTree } from '../parsing/syntax-tree.js'
 import {
@@ -17,9 +18,17 @@ export const handleOutput = async (
     args: process.argv.slice(2), // remove `execPath` and `filename`
     strict: false,
     options: {
+      'no-color': { type: 'boolean' },
       'output-format': { type: 'string' },
     },
   })
+
+  const noColorArg = args.values['no-color'] ?? false
+  if (typeof noColorArg !== 'boolean') {
+    throw new Error('Unsupported value for --no-color')
+  } else if (noColorArg === true) {
+    kleur.enabled = false
+  }
 
   const outputFormatArg = args.values['output-format']
   let notation: Notation

--- a/src/language/unparsing/inline-plz.ts
+++ b/src/language/unparsing/inline-plz.ts
@@ -1,16 +1,15 @@
 import either from '@matt.kantor/either'
+import kleur from 'kleur'
 import type { Atom, Molecule } from '../parsing.js'
 import {
-  closeBrace,
-  comma,
   moleculeAsKeyValuePairStrings,
   moleculeUnparser,
-  openBrace,
   unparseAtom,
 } from './plz-utilities.js'
-import type { Notation } from './unparsing-utilities.js'
+import { punctuation, type Notation } from './unparsing-utilities.js'
 
 const unparseSugarFreeMolecule = (value: Molecule) => {
+  const { comma, closeBrace, openBrace } = punctuation(kleur)
   if (Object.keys(value).length === 0) {
     return either.makeRight(openBrace + closeBrace)
   } else {

--- a/src/language/unparsing/pretty-json.ts
+++ b/src/language/unparsing/pretty-json.ts
@@ -2,22 +2,19 @@ import type { Right } from '@matt.kantor/either'
 import either from '@matt.kantor/either'
 import kleur from 'kleur'
 import type { Atom, Molecule } from '../parsing.js'
-import { indent, type Notation } from './unparsing-utilities.js'
-
-const quote = kleur.dim('"')
-const colon = kleur.dim(':')
-const comma = kleur.dim(',')
-const openBrace = kleur.dim('{')
-const closeBrace = kleur.dim('}')
+import { indent, punctuation, type Notation } from './unparsing-utilities.js'
 
 const escapeStringContents = (value: string) =>
   value.replace('\\', '\\\\').replace('"', '\\"')
 
-const key = (value: Atom): string =>
-  quote.concat(kleur.bold(escapeStringContents(value))).concat(quote)
+const key = (value: Atom): string => {
+  const { quote } = punctuation(kleur)
+  return quote.concat(kleur.bold(escapeStringContents(value))).concat(quote)
+}
 
-const unparseAtom = (value: Atom): Right<string> =>
-  either.makeRight(
+const unparseAtom = (value: Atom): Right<string> => {
+  const { quote } = punctuation(kleur)
+  return either.makeRight(
     quote.concat(
       escapeStringContents(
         /^@[^@]/.test(value) ? kleur.bold(kleur.underline(value)) : value,
@@ -25,8 +22,10 @@ const unparseAtom = (value: Atom): Right<string> =>
       quote,
     ),
   )
+}
 
 const unparseMolecule = (value: Molecule): Right<string> => {
+  const { closeBrace, colon, comma, openBrace } = punctuation(kleur)
   const entries = Object.entries(value)
   if (entries.length === 0) {
     return either.makeRight(openBrace.concat(closeBrace))

--- a/src/language/unparsing/pretty-plz.ts
+++ b/src/language/unparsing/pretty-plz.ts
@@ -1,15 +1,15 @@
 import either from '@matt.kantor/either'
+import kleur from 'kleur'
 import type { Atom, Molecule } from '../parsing.js'
 import {
-  closeBrace,
   moleculeAsKeyValuePairStrings,
   moleculeUnparser,
-  openBrace,
   unparseAtom,
 } from './plz-utilities.js'
-import { indent, type Notation } from './unparsing-utilities.js'
+import { indent, punctuation, type Notation } from './unparsing-utilities.js'
 
 const unparseSugarFreeMolecule = (value: Molecule) => {
+  const { closeBrace, openBrace } = punctuation(kleur)
   if (Object.keys(value).length === 0) {
     return either.makeRight(openBrace + closeBrace)
   } else {

--- a/src/language/unparsing/sugar-free-pretty-plz.ts
+++ b/src/language/unparsing/sugar-free-pretty-plz.ts
@@ -1,14 +1,11 @@
 import either from '@matt.kantor/either'
+import kleur from 'kleur'
 import type { Atom, Molecule } from '../parsing.js'
-import {
-  closeBrace,
-  moleculeAsKeyValuePairStrings,
-  openBrace,
-  unparseAtom,
-} from './plz-utilities.js'
-import { indent, type Notation } from './unparsing-utilities.js'
+import { moleculeAsKeyValuePairStrings, unparseAtom } from './plz-utilities.js'
+import { indent, punctuation, type Notation } from './unparsing-utilities.js'
 
 const unparseMolecule = (value: Molecule) => {
+  const { closeBrace, openBrace } = punctuation(kleur)
   if (Object.keys(value).length === 0) {
     return either.makeRight(openBrace + closeBrace)
   } else {

--- a/src/language/unparsing/unparsing-utilities.ts
+++ b/src/language/unparsing/unparsing-utilities.ts
@@ -1,4 +1,5 @@
 import { type Either } from '@matt.kantor/either'
+import type { Kleur } from 'kleur'
 import type { UnserializableValueError } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
 
@@ -16,3 +17,15 @@ export const indent = (spaces: number, textToIndent: string) => {
     .concat(textToIndent)
     .replace(/(\r?\n)/g, `$1${indentation}`)
 }
+
+export const punctuation = (kleur: Kleur) => ({
+  dot: kleur.dim('.'),
+  quote: kleur.dim('"'),
+  colon: kleur.dim(':'),
+  comma: kleur.dim(','),
+  openBrace: kleur.dim('{'),
+  closeBrace: kleur.dim('}'),
+  openParenthesis: kleur.dim('('),
+  closeParenthesis: kleur.dim(')'),
+  arrow: kleur.dim('=>'),
+})


### PR DESCRIPTION
`please --no-color` avoids printing terminal escape sequences (whether or not a TTY is detected).