### PR TITLE
Syntax change: require commas or newlines to delimit properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git clone git@github.com:mkantor/please-lang-prototype.git
 cd please-lang-prototype
 npm install
 npm run build
-echo '{@runtime context => :context.program.start_time}' | ./please --output-format=json
+echo '{@runtime, context => :context.program.start_time}' | ./please --output-format=json
 ```
 
 There are more example programs in [`./examples`](./examples).
@@ -72,22 +72,21 @@ Objects are maps of key/value pairs ("properties"), where keys must be atoms:
 { greeting: "Hello, World!" }
 ```
 
-Properties are delimited by whitespace and/or commas:
+Properties are delimited by newlines or commas:
 
 ```
-// These all mean the same thing:
+// These mean the same thing:
 {
   a: 1
   b: 2
 }
 { a: 1, b: 2 }
-{ a: 1 b: 2 }
 ```
 
 Properties without explicitly-written keys are automatically enumerated:
 
 ```
-{ a b } // is the same as { 0: a, 1: b }
+{ a, b } // is the same as { 0: a, 1: b }
 ```
 
 #### Lookups
@@ -157,10 +156,10 @@ expressions_. Most of the interesting stuff that Please does involves evaluating
 keyword expressions.
 
 Under the hood, keyword expressions are modeled as objects. For example, `:foo`
-desugars to `{@lookup key: foo}`. All such expressions have a key `0` referring
-to a value that is an `@`-prefixed atom (the keyword). Keywords include
-`@apply`, `@check`, `@function`, `@if`, `@index`, `@lookup`, `@panic`, and
-`@runtime`.
+desugars to `{ @lookup, key: foo }`. All such expressions have a key `0`
+referring to a value that is an `@`-prefixed atom (the keyword). Keywords
+include `@apply`, `@check`, `@function`, `@if`, `@index`, `@lookup`, `@panic`,
+and `@runtime`.
 
 Currently only `@function`, `@lookup`, `@index`, and `@apply` have syntax
 sugars.
@@ -188,7 +187,7 @@ function from other programming languages, except there can be any number of
 `@runtime` expressions in a given program. Here's an example:
 
 ```
-{@runtime context => :context.program.start_time}
+{@runtime, context => :context.program.start_time}
 ```
 
 Unsurprisingly, this program outputs the current time when run.
@@ -227,7 +226,7 @@ Take this example `plz` program:
 {
   language: Please
   message: :atom.prepend("Welcome to ")(:language)
-  now: {@runtime context => :context.program.start_time}
+  now: {@runtime, context => :context.program.start_time}
 }
 ```
 

--- a/examples/fibonacci.plz
+++ b/examples/fibonacci.plz
@@ -1,6 +1,6 @@
 {
   fibonacci: n => {
-    @if :integer.less_than(2)(:n)
+    @if, :integer.less_than(2)(:n)
     then: :n
     else: :integer.add(
       :fibonacci(:integer.subtract(2)(:n))
@@ -9,13 +9,13 @@
     )
   }
 
-  input: { @runtime context => :context.arguments.lookup(input) }
+  input: { @runtime, context => :context.arguments.lookup(input) }
 
   output: :apply(:input)(
     :match({
       none: _ => "missing input argument"
       some: input => {
-        @if :natural_number.is(:input)
+        @if, :natural_number.is(:input)
         then: :fibonacci(:input)
         else: "input must be a natural number"
       }

--- a/examples/kitchen-sink.plz
+++ b/examples/kitchen-sink.plz
@@ -3,11 +3,11 @@
   foo: bar
   bar: :foo
   sky_is_blue: :boolean.not(false)
-  colors: { red green blue }
+  colors: { red, green, blue }
   two: :integer.add(1)(1)
   add_one: :integer.add(1)
   three: :add_one(:two)
   function: x => { value: :x }
-  conditional_value: :function({ @if :sky_is_blue :two :three })
-  side_effect: { @runtime context => :context.log("this goes to stderr") }
+  conditional_value: :function({ @if, :sky_is_blue, :two, :three })
+  side_effect: { @runtime, context => :context.log("this goes to stderr") }
 }

--- a/examples/lookup-environment-variable.plz
+++ b/examples/lookup-environment-variable.plz
@@ -1,4 +1,4 @@
-{@runtime context =>
+{@runtime, context =>
   :flow({
     :context.arguments.lookup
     :match({

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -22,11 +22,12 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ['{{{}}}', either.makeRight({ 0: { 0: {} } })],
   ['"hello world"', either.makeRight('hello world')],
   ['{foo:bar}', either.makeRight({ foo: 'bar' })],
+  ['{hi}', either.makeRight({ 0: 'hi' })],
   ['{a,b,c}', either.makeRight({ 0: 'a', 1: 'b', 2: 'c' })],
   ['{,a,b,c,}', either.makeRight({ 0: 'a', 1: 'b', 2: 'c' })],
   ['{a,1:overwritten,c}', either.makeRight({ 0: 'a', 1: 'c' })],
   ['{overwritten,0:a,c}', either.makeRight({ 0: 'a', 1: 'c' })],
-  ['{@check type:true value:true}', either.makeRight('true')],
+  ['{@check, type:true, value:true}', either.makeRight('true')],
   [
     '{@panic}',
     result => {
@@ -36,17 +37,17 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     },
   ],
   [
-    '{@runtime _ => {@panic}}',
+    '{@runtime, _ => {@panic}}',
     result => {
       assert(either.isLeft(result))
       assert('kind' in result.value)
       assert.deepEqual(result.value.kind, 'panic')
     },
   ],
-  ['{a:A b:{@lookup a}}', either.makeRight({ a: 'A', b: 'A' })],
-  ['{a:A b: :a}', either.makeRight({ a: 'A', b: 'A' })],
-  ['{a:A {@lookup a}}', either.makeRight({ a: 'A', 0: 'A' })],
-  ['{a:A :a}', either.makeRight({ a: 'A', 0: 'A' })],
+  ['{a:A, b:{@lookup, a}}', either.makeRight({ a: 'A', b: 'A' })],
+  ['{a:A, b: :a}', either.makeRight({ a: 'A', b: 'A' })],
+  ['{a:A, {@lookup, a}}', either.makeRight({ a: 'A', 0: 'A' })],
+  ['{a:A, :a}', either.makeRight({ a: 'A', 0: 'A' })],
   ['{ a: (a => :a)(A) }', either.makeRight({ a: 'A' })],
   ['{ a: ( a => :a )( A ) }', either.makeRight({ a: 'A' })],
   ['(a => :a)(A)', either.makeRight('A')],
@@ -101,7 +102,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
           c: z => {
             d: y => x => {
               e: {
-                f: w => { g: { :z :y :x :w } }
+                f: w => { g: { :z, :y, :x, :w, } }
               }
             }
           }
@@ -116,13 +117,12 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ['{ ("a"): A }', either.makeRight({ a: 'A' })],
   ['{ a: :(b), b: B }', either.makeRight({ a: 'B', b: 'B' })],
   ['{ a: :("b"), b: B }', either.makeRight({ a: 'B', b: 'B' })],
-  ['{ (a: A) (b: B) }', either.makeRight({ a: 'A', b: 'B' })],
-  ['( { ((a): :(b)) ( ( b ): B ) } )', either.makeRight({ a: 'B', b: 'B' })],
+  ['{ (a: A), (b: B) }', either.makeRight({ a: 'A', b: 'B' })],
+  ['( { ((a): :(b)), ( ( b ): B ) } )', either.makeRight({ a: 'B', b: 'B' })],
   ['{ (a: :(")")), (")": (B)) }', either.makeRight({ a: 'B', ')': 'B' })],
   [`/**/a/**/`, either.makeRight('a')],
   ['hello//world', either.makeRight('hello')],
   [`"hello//world"`, either.makeRight('hello//world')],
-  [`{a/* this works as a delimiter */b}`, either.makeRight({ 0: 'a', 1: 'b' })],
   [
     `/**/{/**/a:/**/b/**/,/**/c:/**/d/**/}/**/`,
     either.makeRight({ a: 'b', c: 'd' }),
@@ -133,7 +133,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [':match({ a: A })({ tag: a, value: {} })', either.makeRight('A')],
   [':atom.prepend(a)(b)', either.makeRight('ab')],
-  [':flow({ :atom.append(a) :atom.append(b) })(z)', either.makeRight('zab')],
+  [':flow({ :atom.append(a), :atom.append(b) })(z)', either.makeRight('zab')],
   [
     `{
       // foo: bar
@@ -142,7 +142,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         0:@runtime
         function:{
           0:@apply
-          function:{0:@index object:{0:@lookup key:object} query:{0:lookup}}
+          function:{0:@index, object:{0:@lookup, key:object}, query:{0:lookup}}
           argument:"key which does not exist in runtime context"
         }
       }
@@ -159,15 +159,15 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     either.makeRight({ tag: 'none', value: {} }),
   ],
   [
-    `{@runtime {@apply :flow {
-      {@apply :object.lookup environment}
-      {@apply :match {
+    `{@runtime, {@apply, :flow, {
+      {@apply, :object.lookup, environment}
+      {@apply, :match, {
         none: "environment does not exist"
-        some: {@apply :flow {
-          {@apply :object.lookup lookup}
-          {@apply :match {
+        some: {@apply, :flow, {
+          {@apply, :object.lookup, lookup}
+          {@apply, :match, {
             none: "environment.lookup does not exist"
-            some: {@apply :apply PATH}
+            some: {@apply, :apply, PATH}
           }}
         }}
       }}
@@ -182,7 +182,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     },
   ],
   [
-    `{@runtime :flow({
+    `{@runtime, :flow({
       :object.lookup(environment)
       :match({
         none: "environment does not exist"
@@ -205,7 +205,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     },
   ],
   [
-    `{@runtime context =>
+    `{@runtime, context =>
       :identity(:context).program.start_time
     }`,
     output => {
@@ -216,7 +216,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     },
   ],
   [
-    `{@runtime context =>
+    `{@runtime, context =>
       :context.environment.lookup(PATH)
     }`,
     output => {
@@ -265,8 +265,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     either.makeRight({ true: 'true', false: 'false' }),
   ],
   [
-    `{@runtime context =>
-      {@if :boolean.not(:boolean.is(:context))
+    `{@runtime, context =>
+      {@if, :boolean.not(:boolean.is(:context))
         "it works!"
         {@panic}
       }
@@ -275,7 +275,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      fibonacci: n => {@if :integer.less_than(2)(:n)
+      fibonacci: n => {
+        @if, :integer.less_than(2)(:n)
         then: :n
         else: :integer.add(
           :fibonacci(:integer.subtract(2)(:n))

--- a/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
@@ -68,7 +68,7 @@ const lookup = ({
           left: _ =>
             // Lookups should not resolve to expression properties.
             // For example the value of the lookup expression in `a => :parameter` (which desugars
-            // to `{@function parameter: a, body: {@lookup key: parameter}}`) should not be `a`.
+            // to `{@function, parameter: a, body: {@lookup, key: parameter}}`) should not be `a`.
             isExpression(scope)
               ? option.none
               : applyKeyPathToSemanticGraph(scope, [key]),

--- a/src/language/parsing/molecule.ts
+++ b/src/language/parsing/molecule.ts
@@ -21,11 +21,12 @@ import {
   colon,
   comma,
   dot,
+  newline,
   openingBrace,
   openingParenthesis,
 } from './literals.js'
 import { optionallySurroundedByParentheses } from './parentheses.js'
-import { optionalTrivia, trivia } from './trivia.js'
+import { optionalTrivia, trivia, triviaExceptNewlines } from './trivia.js'
 
 export type Molecule = { readonly [key: Atom]: Molecule | Atom }
 
@@ -66,7 +67,7 @@ const property = (index: Indexer) =>
 
 const propertyDelimiter = oneOf([
   sequence([optionalTrivia, comma, optionalTrivia]),
-  trivia,
+  sequence([optional(triviaExceptNewlines), newline, optionalTrivia]),
 ])
 
 const argument = map(
@@ -97,6 +98,7 @@ const moleculeAsEntries = (
   map(
     sequence([
       openingBrace,
+      optional(trivia),
       // Allow initial property not preceded by a delimiter (e.g. `{a b}`).
       optional(property(index)),
       zeroOrMore(
@@ -106,13 +108,16 @@ const moleculeAsEntries = (
         ),
       ),
       optional(propertyDelimiter),
+      optional(trivia),
       closingBrace,
     ]),
     ([
       _openingBrace,
+      _optionalLeadingTrivia,
       optionalInitialProperty,
       remainingProperties,
-      _delimiter,
+      _optionalDelimiter,
+      _optionalTrailingTrivia,
       _closingBrace,
     ]) =>
       optionalInitialProperty === undefined

--- a/src/language/parsing/trivia.ts
+++ b/src/language/parsing/trivia.ts
@@ -41,3 +41,9 @@ export const trivia = oneOrMore(
 )
 
 export const optionalTrivia = oneOf([trivia, nothing])
+
+export const whitespaceExceptNewlines = regularExpression(/[^\S\n]+/)
+
+export const triviaExceptNewlines = oneOrMore(
+  oneOf([whitespaceExceptNewlines, singleLineComment, blockComment]),
+)


### PR DESCRIPTION
Previously `{ a:1 b:2 }` would be parsed as an object containing two properties. Now, it's a syntax error. A comma or newline is required between each property.

The motivation for this change is to carve out syntax space for infix expressions. Without this, it's unclear whether `{ 1 + 1 }` means `{ 0: (1 + 1) }` or `{ 0: 1, 1: +, 2: 1 }`.