### PR TITLE
Upgrade dependencies and runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
         "please": "please"
       },
       "devDependencies": {
-        "@types/node": "^22.15.3",
+        "@types/node": "^22.17.0",
         "strip-ansi": "^7.1.0",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "node": ">=22"
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-      "integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+      "version": "22.17.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
+      "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "test-update-snapshots": "npm run build:tests && node --test --test-update-snapshots --experimental-test-snapshots"
   },
   "devDependencies": {
-    "@types/node": "^22.15.3",
+    "@types/node": "^22.17.0",
     "strip-ansi": "^7.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "@matt.kantor/either": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build": "tsc --build tsconfig.app.json --force",
     "build:tests": "tsc --project tsconfig.app.json --outDir dist-test --declarationDir dist && tsc --build tsconfig.test.json",
     "clean": "rm -rf dist* *.tsbuildinfo",
-    "test": "npm run build:tests && node --test --experimental-test-snapshots",
-    "test-update-snapshots": "npm run build:tests && node --test --test-update-snapshots --experimental-test-snapshots"
+    "test": "npm run build:tests && node --test --no-experimental-strip-types",
+    "test-update-snapshots": "npm run build:tests && node --test --test-update-snapshots"
   },
   "devDependencies": {
     "@types/node": "^22.17.0",
@@ -27,6 +27,6 @@
     "kleur": "^4.1.5"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.18"
   }
 }


### PR DESCRIPTION
While testing Node.js 22.18 I noticed that the way I'm running `node --test` wasn't playing nicely with the fact that [type stripping is now enabled by default](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#type-stripping-is-enabled-by-default). `node --test` was trying to execute the `*.test.ts` files (in addition to the compiled `*.test.js` files), but [`examples.test.ts`](https://github.com/mkantor/please-lang-prototype/blob/70a08a69ea3366c6545c8f481651e91bd56cbff5/src/examples.test.ts) failed due to [an incorrect path to the `please` CLI](https://github.com/mkantor/please-lang-prototype/blob/70a08a69ea3366c6545c8f481651e91bd56cbff5/src/examples.test.ts#L26-L31).