### PR TITLE
Add & use inline sugar-free plz notation

### DIFF
--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -6,6 +6,7 @@ import { type Atom, type Molecule } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import {
   inlinePlz,
+  inlineSugarFreePrettyPlz,
   prettyJson,
   prettyPlz,
   sugarFreePrettyPlz,
@@ -22,6 +23,9 @@ const unparsers = (value: Atom | Molecule) => {
     )
 
   const unparsedInlinePlz = unparseAndStripAnsi(inlinePlz)
+  const unparsedInlineSugarFreePrettyPlz = unparseAndStripAnsi(
+    inlineSugarFreePrettyPlz,
+  )
   const unparsedSugarFreePrettyPlz = unparseAndStripAnsi(sugarFreePrettyPlz)
   const unparsedPrettyPlz = unparseAndStripAnsi(prettyPlz)
   const unparsedPrettyJson = unparseAndStripAnsi(prettyJson)
@@ -32,6 +36,13 @@ const unparsers = (value: Atom | Molecule) => {
       (roundtrippedValue: {}) => {
         assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
         return unparsedInlinePlz
+      },
+    ).value,
+    inlineSugarFreePrettyPlz: either.flatMap(
+      either.flatMap(unparsedInlineSugarFreePrettyPlz, parse),
+      (roundtrippedValue: {}) => {
+        assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
+        return unparsedInlineSugarFreePrettyPlz
       },
     ).value,
     prettyPlz: either.flatMap(
@@ -62,6 +73,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       {},
       {
         inlinePlz: '{}',
+        inlineSugarFreePrettyPlz: '{}',
         prettyPlz: '{}\n',
         sugarFreePrettyPlz: '{}\n',
         prettyJson: '{}\n',
@@ -72,6 +84,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       'a',
       {
         inlinePlz: 'a',
+        inlineSugarFreePrettyPlz: 'a',
         prettyPlz: 'a\n',
         sugarFreePrettyPlz: 'a\n',
         prettyJson: '"a"\n',
@@ -82,6 +95,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       'Hello, world!',
       {
         inlinePlz: '"Hello, world!"',
+        inlineSugarFreePrettyPlz: '"Hello, world!"',
         prettyPlz: '"Hello, world!"\n',
         sugarFreePrettyPlz: '"Hello, world!"\n',
         prettyJson: '"Hello, world!"\n',
@@ -92,6 +106,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       '@test',
       {
         inlinePlz: '"@test"',
+        inlineSugarFreePrettyPlz: '"@test"',
         prettyPlz: '"@test"\n',
         sugarFreePrettyPlz: '"@test"\n',
         prettyJson: '"@test"\n',
@@ -102,6 +117,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       { 0: 'a' },
       {
         inlinePlz: '{ a }',
+        inlineSugarFreePrettyPlz: '{ 0: a }',
         prettyPlz: '{\n  a\n}\n',
         sugarFreePrettyPlz: '{\n  0: a\n}\n',
         prettyJson: '{\n  "0": "a"\n}\n',
@@ -112,6 +128,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       { 1: 'a' },
       {
         inlinePlz: '{ 1: a }',
+        inlineSugarFreePrettyPlz: '{ 1: a }',
         prettyPlz: '{\n  1: a\n}\n',
         sugarFreePrettyPlz: '{\n  1: a\n}\n',
         prettyJson: '{\n  "1": "a"\n}\n',
@@ -122,6 +139,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       { 0: 'a', 1: 'b', 3: 'c', somethingElse: 'd' },
       {
         inlinePlz: '{ a, b, 3: c, somethingElse: d }',
+        inlineSugarFreePrettyPlz: '{ 0: a, 1: b, 3: c, somethingElse: d }',
         prettyPlz: '{\n  a\n  b\n  3: c\n  somethingElse: d\n}\n',
         sugarFreePrettyPlz:
           '{\n  0: a\n  1: b\n  3: c\n  somethingElse: d\n}\n',
@@ -134,6 +152,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       { a: { b: { c: 'd' } } },
       {
         inlinePlz: '{ a: { b: { c: d } } }',
+        inlineSugarFreePrettyPlz: '{ a: { b: { c: d } } }',
         prettyPlz: '{\n  a: {\n    b: {\n      c: d\n    }\n  }\n}\n',
         sugarFreePrettyPlz: '{\n  a: {\n    b: {\n      c: d\n    }\n  }\n}\n',
         prettyJson: '{\n  "a": {\n    "b": {\n      "c": "d"\n    }\n  }\n}\n',
@@ -159,6 +178,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       },
       {
         inlinePlz: '{ identity: a => :a, test: :identity("it works!") }',
+        inlineSugarFreePrettyPlz:
+          '{ identity: { 0: "@function", 1: { parameter: a, body: { 0: "@lookup", 1: { 0: a } } } }, test: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { 0: identity } }, argument: "it works!" } } }',
         prettyPlz:
           '{\n  identity: a => :a\n  test: :identity("it works!")\n}\n',
         sugarFreePrettyPlz:
@@ -184,6 +205,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       },
       {
         inlinePlz: '(a => :a)("it works!")',
+        inlineSugarFreePrettyPlz:
+          '{ 0: "@apply", 1: { function: { 0: "@function", 1: { parameter: a, body: { 0: "@lookup", 1: { 0: a } } } }, argument: "it works!" } }',
         prettyPlz: '(a => :a)("it works!")\n',
         sugarFreePrettyPlz:
           '{\n  0: "@apply"\n  1: {\n    function: {\n      0: "@function"\n      1: {\n        parameter: a\n        body: {\n          0: "@lookup"\n          1: {\n            0: a\n          }\n        }\n      }\n    }\n    argument: "it works!"\n  }\n}\n',
@@ -213,6 +236,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       },
       {
         inlinePlz: '@runtime { context => :context.program.start_time }',
+        inlineSugarFreePrettyPlz:
+          '{ 0: "@runtime", 1: { 0: { 0: "@function", 1: { parameter: context, body: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: context } }, query: { 0: program, 1: start_time } } } } } } }',
         prettyPlz: '@runtime {\n  context => :context.program.start_time\n}\n',
         sugarFreePrettyPlz:
           '{\n  0: "@runtime"\n  1: {\n    0: {\n      0: "@function"\n      1: {\n        parameter: context\n        body: {\n          0: "@index"\n          1: {\n            object: {\n              0: "@lookup"\n              1: {\n                key: context\n              }\n            }\n            query: {\n              0: program\n              1: start_time\n            }\n          }\n        }\n      }\n    }\n  }\n}\n',
@@ -239,6 +264,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       {
         inlinePlz:
           '{ a.b: { "c \\"d\\"": { e.f: g } }, test: :"a.b"."c \\"d\\""."e.f" }',
+        inlineSugarFreePrettyPlz:
+          '{ a.b: { "c \\"d\\"": { e.f: g } }, test: { 0: "@index", 1: { object: { 0: "@lookup", 1: { 0: a.b } }, query: { 0: "c \\"d\\"", 1: e.f } } } }',
         prettyPlz:
           '{\n  a.b: {\n    "c \\"d\\"": {\n      e.f: g\n    }\n  }\n  test: :"a.b"."c \\"d\\""."e.f"\n}\n',
         sugarFreePrettyPlz:
@@ -269,6 +296,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       },
       {
         inlinePlz: '1 + 2',
+        inlineSugarFreePrettyPlz:
+          '{ 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: + } }, argument: 2 } }, argument: 1 } }',
         prettyPlz: '1 + 2\n',
         sugarFreePrettyPlz:
           '{\n  0: "@apply"\n  1: {\n    function: {\n      0: "@apply"\n      1: {\n        function: {\n          0: "@lookup"\n          1: {\n            key: +\n          }\n        }\n        argument: 2\n      }\n    }\n    argument: 1\n  }\n}\n',
@@ -306,6 +335,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       },
       {
         inlinePlz: 'a atom.append b',
+        inlineSugarFreePrettyPlz:
+          '{ 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: atom } }, query: { 0: append } } }, argument: b } }, argument: a } }',
         prettyPlz: 'a atom.append b\n',
         sugarFreePrettyPlz:
           '{\n  0: "@apply"\n  1: {\n    function: {\n      0: "@apply"\n      1: {\n        function: {\n          0: "@index"\n          1: {\n            object: {\n              0: "@lookup"\n              1: {\n                key: atom\n              }\n            }\n            query: {\n              0: append\n            }\n          }\n        }\n        argument: b\n      }\n    }\n    argument: a\n  }\n}\n',
@@ -431,6 +462,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       {
         inlinePlz:
           '{ five: 5, answer: 1 + 2 - (3 + 4) < :five && :boolean.not(true) }',
+        inlineSugarFreePrettyPlz:
+          '{ five: 5, answer: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: && } }, argument: { 0: "@apply", 1: { function: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: boolean } }, query: { 0: not } } }, argument: true } } } }, argument: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: < } }, argument: { 0: "@lookup", 1: { key: five } } } }, argument: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: - } }, argument: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: + } }, argument: 4 } }, argument: 3 } } } }, argument: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: + } }, argument: 2 } }, argument: 1 } } } } } } } } }',
         prettyPlz:
           '{\n  five: 5\n  answer: 1 + 2 - (3 + 4) < :five && :boolean.not(true)\n}\n',
         sugarFreePrettyPlz:
@@ -523,6 +556,8 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
       },
       {
         inlinePlz: '((a => :a + 1) >> (a => :a - 1))(1)',
+        inlineSugarFreePrettyPlz:
+          '{ 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: >> } }, argument: { 0: "@function", 1: { parameter: a, body: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: - } }, argument: 1 } }, argument: { 0: "@lookup", 1: { key: a } } } } } } } }, argument: { 0: "@function", 1: { parameter: a, body: { 0: "@apply", 1: { function: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: + } }, argument: 1 } }, argument: { 0: "@lookup", 1: { key: a } } } } } } } }, argument: 1 } }',
         prettyPlz: '((a => :a + 1) >> (a => :a - 1))(1)\n',
         sugarFreePrettyPlz:
           '{\n  0: "@apply"\n  1: {\n    function: {\n      0: "@apply"\n      1: {\n        function: {\n          0: "@apply"\n          1: {\n            function: {\n              0: "@lookup"\n              1: {\n                key: >>\n              }\n            }\n            argument: {\n              0: "@function"\n              1: {\n                parameter: a\n                body: {\n                  0: "@apply"\n                  1: {\n                    function: {\n                      0: "@apply"\n                      1: {\n                        function: {\n                          0: "@lookup"\n                          1: {\n                            key: -\n                          }\n                        }\n                        argument: 1\n                      }\n                    }\n                    argument: {\n                      0: "@lookup"\n                      1: {\n                        key: a\n                      }\n                    }\n                  }\n                }\n              }\n            }\n          }\n        }\n        argument: {\n          0: "@function"\n          1: {\n            parameter: a\n            body: {\n              0: "@apply"\n              1: {\n                function: {\n                  0: "@apply"\n                  1: {\n                    function: {\n                      0: "@lookup"\n                      1: {\n                        key: +\n                      }\n                    }\n                    argument: 1\n                  }\n                }\n                argument: {\n                  0: "@lookup"\n                  1: {\n                    key: a\n                  }\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n    argument: 1\n  }\n}\n',

--- a/src/language/semantics/expressions/expression-utilities.ts
+++ b/src/language/semantics/expressions/expression-utilities.ts
@@ -2,6 +2,7 @@ import either, { type Either } from '@matt.kantor/either'
 import option, { type Option } from '@matt.kantor/option'
 import type { ElaborationError } from '../../errors.js'
 import type { Atom, Molecule } from '../../parsing.js'
+import { inlineSugarFreePrettyPlz } from '../../unparsing.js'
 import type { ExpressionContext } from '../expression-elaboration.js'
 import type { Expression } from '../expression.js'
 import { isFunctionNode } from '../function-node.js'
@@ -14,6 +15,7 @@ import {
 } from '../object-node.js'
 import {
   applyKeyPathToSemanticGraph,
+  stringifySemanticGraphForEndUser,
   type SemanticGraph,
 } from '../semantic-graph.js'
 
@@ -70,7 +72,10 @@ export const readArgumentsFromExpression = <
         const requiredKeySummary = `\`${keyword}\` or \`${position}\``
         return either.makeLeft({
           kind: 'invalidExpression',
-          message: `missing required property ${requiredKeySummary} within ${expression['0']} expression`,
+          message: `missing required property ${requiredKeySummary} within ${expression['0']} expression: \`${stringifySemanticGraphForEndUser(
+            expression,
+            inlineSugarFreePrettyPlz,
+          )}\``,
         })
       } else {
         expressionArguments.push(argument.value)

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -12,7 +12,7 @@ import {
   makeIndexExpression,
   makeLookupExpression,
 } from '../semantics.js'
-import { inlinePlz, unparse } from '../unparsing.js'
+import { inlinePlz, unparse, type Notation } from '../unparsing.js'
 import { isExpression } from './expression.js'
 import { serializeFunctionNode, type FunctionNode } from './function-node.js'
 import { isSemanticGraph } from './is-semantic-graph.js'
@@ -203,9 +203,10 @@ export const serialize = (
 
 export const stringifySemanticGraphForEndUser = (
   graph: SemanticGraph,
+  notation: Notation = inlinePlz,
 ): string =>
   either.match(
-    either.flatMap(serialize(graph), output => unparse(output, inlinePlz)),
+    either.flatMap(serialize(graph), output => unparse(output, notation)),
     {
       right: stringifiedOutput => stringifiedOutput,
       left: error => `(unserializable value: ${error.message})`,

--- a/src/language/unparsing.ts
+++ b/src/language/unparsing.ts
@@ -5,6 +5,7 @@ import type { Atom, Molecule } from './parsing.js'
 import type { Notation } from './unparsing/unparsing-utilities.js'
 
 export { inlinePlz } from './unparsing/inline-plz.js'
+export { inlineSugarFreePrettyPlz } from './unparsing/inline-sugar-free-pretty-plz.js'
 export { prettyJson } from './unparsing/pretty-json.js'
 export { prettyPlz } from './unparsing/pretty-plz.js'
 export { sugarFreePrettyPlz } from './unparsing/sugar-free-pretty-plz.js'

--- a/src/language/unparsing/inline-sugar-free-pretty-plz.ts
+++ b/src/language/unparsing/inline-sugar-free-pretty-plz.ts
@@ -1,0 +1,47 @@
+import either from '@matt.kantor/either'
+import { styleText } from 'node:util'
+import type { Molecule } from '../parsing.js'
+import {
+  moleculeAsKeyValuePairStrings,
+  unparseAtom,
+  type SemanticContext,
+  type UnparseAtomOrMolecule,
+} from './plz-utilities.js'
+import { punctuation, type Notation } from './unparsing-utilities.js'
+
+const unparseMolecule =
+  (semanticContext: SemanticContext) => (value: Molecule) => {
+    const { closeBrace, openBrace, comma } = punctuation(styleText)
+    if (Object.keys(value).length === 0) {
+      return either.makeRight(openBrace + closeBrace)
+    } else {
+      return either.map(
+        moleculeAsKeyValuePairStrings(
+          value,
+          { unparseAtomOrMolecule, semanticContext },
+          {
+            ordinalKeys: 'preserve',
+          },
+        ),
+        keyValuePairsAsStrings =>
+          openBrace.concat(
+            ' ',
+            keyValuePairsAsStrings.join(comma.concat(' ')),
+            ' ',
+            closeBrace,
+          ),
+      )
+    }
+  }
+
+const unparseAtomOrMolecule: UnparseAtomOrMolecule =
+  semanticContext => value =>
+    typeof value === 'string' ?
+      unparseAtom(value)
+    : unparseMolecule(semanticContext)(value)
+
+export const inlineSugarFreePrettyPlz: Notation = {
+  atom: unparseAtom,
+  molecule: unparseMolecule('default'),
+  suffix: '',
+}


### PR DESCRIPTION
The new notation is currently only used in [a single error message](https://github.com/mkantor/please-lang-prototype/compare/inline-sugar-free-plz?expand=1#diff-04d2b4191044afd8a85fdfa813903623a03e744d36531c099a1f594b36df6596R75-R78) (where sugarful plz would result in circularity).