### PR TITLE
Add modules for `nothing` & `something` to the prelude

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -723,6 +723,25 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [`:object.from_property(key)(value)`, either.makeRight({ key: 'value' })],
   [`(1 + 1) ~ :integer.type`, either.makeRight('2')],
   [
+    `{
+      1 ~ :something.type
+      blah ~ :something.type
+      {} ~ :something.type
+      (a => :a) ~ :something.type
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+  [
+    `"arbitrary value" ~ :nothing.type`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+  [
     // `true | (false || true) | false`
     'true | false || true | false',
     either.makeRight({

--- a/src/language/semantics/prelude.ts
+++ b/src/language/semantics/prelude.ts
@@ -8,10 +8,10 @@ import { object } from './stdlib/object.js'
 
 export const prelude = makeObjectNode({
   ...globalFunctions,
-  boolean: makeObjectNode(boolean),
-  natural_number: makeObjectNode(natural_number),
-  integer: makeObjectNode(integer),
   atom: makeObjectNode(atom),
+  boolean: makeObjectNode(boolean),
+  integer: makeObjectNode(integer),
+  natural_number: makeObjectNode(natural_number),
   object: makeObjectNode(object),
 
   // Aliases:

--- a/src/language/semantics/prelude.ts
+++ b/src/language/semantics/prelude.ts
@@ -4,7 +4,9 @@ import { boolean } from './stdlib/boolean.js'
 import { globalFunctions } from './stdlib/global-functions.js'
 import { integer } from './stdlib/integer.js'
 import { natural_number } from './stdlib/natural-number.js'
+import { nothing } from './stdlib/nothing.js'
 import { object } from './stdlib/object.js'
+import { something } from './stdlib/something.js'
 
 export const prelude = makeObjectNode({
   ...globalFunctions,
@@ -12,7 +14,9 @@ export const prelude = makeObjectNode({
   boolean: makeObjectNode(boolean),
   integer: makeObjectNode(integer),
   natural_number: makeObjectNode(natural_number),
+  nothing: makeObjectNode(nothing),
   object: makeObjectNode(object),
+  something: makeObjectNode(something),
 
   // Aliases:
   '>>': globalFunctions.flow,

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -28,12 +28,14 @@ import {
   atomTypeSymbol,
   integerTypeSymbol,
   naturalNumberTypeSymbol,
+  somethingTypeSymbol,
 } from './type-system/prelude-types.js'
 
 export type TypeSymbol =
   | typeof atomTypeSymbol
   | typeof integerTypeSymbol
   | typeof naturalNumberTypeSymbol
+  | typeof somethingTypeSymbol
 
 export type SemanticGraph = Atom | TypeSymbol | FunctionNode | ObjectNode
 
@@ -192,6 +194,8 @@ export const serialize = (
                     return makeLookupExpression('integer')
                   case naturalNumberTypeSymbol:
                     return makeLookupExpression('natural_number')
+                  case somethingTypeSymbol:
+                    return makeLookupExpression('something')
                 }
               })(),
             }),

--- a/src/language/semantics/stdlib/nothing.ts
+++ b/src/language/semantics/stdlib/nothing.ts
@@ -1,0 +1,16 @@
+import either from '@matt.kantor/either'
+import { types } from '../type-system.js'
+import { preludeFunctionArity1 } from './stdlib-utilities.js'
+
+export const nothing = {
+  // TODO: Add `type`.
+
+  is: preludeFunctionArity1(
+    ['nothing', 'is'],
+    {
+      parameter: types.something,
+      return: types.boolean,
+    },
+    _ => either.makeRight('false'),
+  ),
+} as const

--- a/src/language/semantics/stdlib/nothing.ts
+++ b/src/language/semantics/stdlib/nothing.ts
@@ -1,9 +1,10 @@
 import either from '@matt.kantor/either'
+import { makeObjectNode } from '../object-node.js'
 import { types } from '../type-system.js'
 import { preludeFunctionArity1 } from './stdlib-utilities.js'
 
 export const nothing = {
-  // TODO: Add `type`.
+  type: makeObjectNode({ 0: '@union', 1: {} }),
 
   is: preludeFunctionArity1(
     ['nothing', 'is'],

--- a/src/language/semantics/stdlib/something.ts
+++ b/src/language/semantics/stdlib/something.ts
@@ -1,0 +1,16 @@
+import either from '@matt.kantor/either'
+import { types } from '../type-system.js'
+import { preludeFunctionArity1 } from './stdlib-utilities.js'
+
+export const something = {
+  // TODO: Add `type`.
+
+  is: preludeFunctionArity1(
+    ['something', 'is'],
+    {
+      parameter: types.something,
+      return: types.boolean,
+    },
+    _ => either.makeRight('true'),
+  ),
+} as const

--- a/src/language/semantics/stdlib/something.ts
+++ b/src/language/semantics/stdlib/something.ts
@@ -3,7 +3,7 @@ import { types } from '../type-system.js'
 import { preludeFunctionArity1 } from './stdlib-utilities.js'
 
 export const something = {
-  // TODO: Add `type`.
+  type: types.somethingTypeSymbol,
 
   is: preludeFunctionArity1(
     ['something', 'is'],

--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -49,12 +49,6 @@ export const naturalNumber = makeOpaqueType(
   },
 )
 
-export const opaqueTypesBySymbol = {
-  [atom.symbol]: atom,
-  [integer.symbol]: integer,
-  [naturalNumber.symbol]: naturalNumber,
-}
-
 export const object = makeObjectType('object', {})
 
 // `functionType` and `something` reference each other directly, so we need to
@@ -72,6 +66,17 @@ Object.assign(
   something,
   makeUnionType('something', [functionType, atom, object]) satisfies UnionType,
 )
+
+// Despite not being opaque, `something` gets a type symbol to avoid
+// complications in value space stemming from its circular definition.
+export const somethingTypeSymbol = Symbol('something')
+
+export const typesBySymbol = {
+  [atomTypeSymbol]: atom,
+  [integerTypeSymbol]: integer,
+  [naturalNumberTypeSymbol]: naturalNumber,
+  [somethingTypeSymbol]: something,
+}
 
 export const option = (value: Type) =>
   makeUnionType('option', [

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -5,7 +5,7 @@ import type { Atom } from '../../parsing.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
 import { type SemanticGraph } from '../semantic-graph.js'
 import { types } from '../type-system.js'
-import { opaqueTypesBySymbol } from './prelude-types.js'
+import { typesBySymbol } from './prelude-types.js'
 import { simplifyUnionType } from './subtyping.js'
 import {
   makeFunctionType,
@@ -480,11 +480,8 @@ export const literalTypeFromSemanticGraph = (
       members: new Set([node]),
     })
   } else if (typeof node === 'symbol') {
-    if (
-      node in opaqueTypesBySymbol &&
-      opaqueTypesBySymbol[node] !== undefined
-    ) {
-      return either.makeRight(opaqueTypesBySymbol[node])
+    if (node in typesBySymbol && typesBySymbol[node] !== undefined) {
+      return either.makeRight(typesBySymbol[node])
     } else {
       return either.makeLeft({
         kind: 'bug',


### PR DESCRIPTION
The motivation for this was to provide a way to refer to the `nothing` and `something` types (the bottom and top type, respectively) from userland.