### PR TITLE
Implement static analysis of `@apply` expressions

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -473,4 +473,13 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `:boolean.not("not a boolean")`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -482,4 +482,27 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `:boolean.not(@runtime { _ => "not a boolean" })`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `@runtime { _ => :integer.greater_than(1)(2) } ~ :boolean.type`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `@runtime { _ => 1 |> :identity } ~ 1`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -1,48 +1,103 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  containedTypeParameters,
   containsAnyUnelaboratedNodes,
+  isAssignable,
   isFunctionNode,
   readApplyExpression,
+  stringifySemanticGraphForEndUser,
   type Expression,
   type ExpressionContext,
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
+import { showType } from '../../../semantics/type-system/show-type.js'
+import type { Type } from '../../../semantics/type-system/type-formats.js'
+import { inferType, resolveParameterTypes } from './check-handler.js'
+
+const staticallyCheckArgument = (
+  argument: SemanticGraph,
+  parameterType: Type,
+  context: ExpressionContext,
+): Either<ElaborationError, undefined> =>
+  (
+    // Type inference does not yet instantiate type parameters from argument
+    // types, so skip the static check for generic parameter types.
+    // TODO: Implement type parameter instantiation.
+    containedTypeParameters(parameterType).size > 0
+  ) ?
+    either.makeRight(undefined)
+  : either.flatMap(
+      inferType(argument, resolveParameterTypes(context), new Set(), context),
+      argumentType =>
+        (
+          // For now, reject only when the argument's inferred type and the
+          // parameter type are completely disjoint. The sound thing to do here
+          // would be to only proceed when `argumentType` is assignable to
+          // `parameterType` (and not the other way around), but progress is
+          // needed elsewhere to allow extant programs to typecheck like that.
+          // TODO: Revisit this once function parameter type annotations are
+          // expressible in plz.
+          isAssignable({ source: argumentType, target: parameterType }) ||
+          isAssignable({ source: parameterType, target: argumentType })
+        ) ?
+          either.makeRight(undefined)
+        : either.makeLeft({
+            kind: 'typeMismatch',
+            message: `the value \`${stringifySemanticGraphForEndUser(
+              argument,
+            )}\` is not assignable to the type \`${showType(parameterType)}\``,
+          }),
+    )
 
 export const applyKeywordHandler: KeywordHandler = (
   expression: Expression,
-  _context: ExpressionContext,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   either.flatMap(
     readApplyExpression(expression),
     (applyExpression): Either<ElaborationError, SemanticGraph> => {
-      if (containsAnyUnelaboratedNodes(applyExpression[1].argument)) {
-        // The argument isn't ready, so keep the @apply unelaborated.
-        return either.makeRight(applyExpression)
-      } else {
-        const functionToApply = applyExpression[1].function
-        if (isFunctionNode(functionToApply)) {
-          const result = functionToApply(applyExpression[1].argument)
-          if (either.isLeft(result)) {
-            if (result.value.kind === 'dependencyUnavailable') {
-              // Keep the @apply unelaborated.
-              return either.makeRight(applyExpression)
+      const functionToApply = applyExpression[1].function
+      const argument = applyExpression[1].argument
+
+      const staticCheck: Either<ElaborationError, undefined> =
+        isFunctionNode(functionToApply) ?
+          staticallyCheckArgument(
+            argument,
+            functionToApply.signature.parameter,
+            context,
+          )
+        : either.makeRight(undefined)
+
+      return either.flatMap(
+        staticCheck,
+        (): Either<ElaborationError, SemanticGraph> => {
+          if (containsAnyUnelaboratedNodes(argument)) {
+            // The argument isn't ready, so keep the @apply unelaborated.
+            return either.makeRight(applyExpression)
+          } else if (isFunctionNode(functionToApply)) {
+            const result = functionToApply(argument)
+            if (either.isLeft(result)) {
+              if (result.value.kind === 'dependencyUnavailable') {
+                // Keep the @apply unelaborated.
+                return either.makeRight(applyExpression)
+              } else {
+                return either.makeLeft(result.value)
+              }
             } else {
-              return either.makeLeft(result.value)
+              return result
             }
+          } else if (containsAnyUnelaboratedNodes(functionToApply)) {
+            // The function isn't ready, so keep the @apply unelaborated.
+            return either.makeRight(applyExpression)
           } else {
-            return result
+            return either.makeLeft({
+              kind: 'invalidExpression',
+              message: 'only functions can be applied',
+            })
           }
-        } else if (containsAnyUnelaboratedNodes(functionToApply)) {
-          // The function isn't ready, so keep the @apply unelaborated.
-          return either.makeRight(applyExpression)
-        } else {
-          return either.makeLeft({
-            kind: 'invalidExpression',
-            message: 'only functions can be applied',
-          })
-        }
-      }
+        },
+      )
     },
   )

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -227,6 +227,14 @@ const inferType = (
     if (either.isRight(inferredFunctionType)) {
       if (inferredFunctionType.value.kind === 'function') {
         return either.makeRight(inferredFunctionType.value.signature.return)
+      } else if (inferredFunctionType.value.kind === 'parameter') {
+        // Let's just assume this type parameter will be instantiated with a
+        // function type. Ideally this would actually be checked elsewhere.
+        // TODO: If there's not an appropriate place to do such a check, could
+        // check here that the constraint is a function type.
+        return either.makeRight(
+          inferredFunctionType.value.constraint.assignableTo,
+        )
       } else {
         return either.makeLeft({
           kind: 'invalidExpression',

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -57,7 +57,7 @@ const isEnclosedInRuntimeExpression = (
   }
 }
 
-const resolveParameterTypes = (
+export const resolveParameterTypes = (
   context: ExpressionContext,
 ): ReadonlyMap<Atom, Type> => {
   const parameterTypes = new Map<Atom, Type>()
@@ -108,7 +108,7 @@ const resolveParameterTypes = (
   return parameterTypes
 }
 
-const inferType = (
+export const inferType = (
   node: SemanticGraph,
   parameterTypes: ReadonlyMap<Atom, Type>,
   lookingUpKeys: ReadonlySet<Atom>,

--- a/src/language/semantics/function-node.ts
+++ b/src/language/semantics/function-node.ts
@@ -14,12 +14,15 @@ import { nodeTag } from './semantic-graph-node-tag.js'
 import { serialize, type Output, type SemanticGraph } from './semantic-graph.js'
 import { type FunctionType } from './type-system/type-formats.js'
 
+export type FunctionNodeCallError =
+  | DependencyUnavailable
+  | TypeMismatchError
+  | Panic
+  | Bug
+
 export type FunctionNodeCallSignature = (
   value: SemanticGraph,
-) => Either<
-  DependencyUnavailable | TypeMismatchError | Panic | Bug,
-  SemanticGraph
->
+) => Either<FunctionNodeCallError, SemanticGraph>
 
 export type FunctionNode = FunctionNodeCallSignature & {
   readonly [nodeTag]: 'function'
@@ -39,19 +42,11 @@ export const makeFunctionNode = <Signature extends FunctionType['signature']>(
   signature: Signature,
   serialize: FunctionNode['serialize'],
   parameterName: Option<Atom>,
-  f: (
-    value: SemanticGraph,
-  ) => Either<
-    DependencyUnavailable | TypeMismatchError | Panic | Bug,
-    SemanticGraph
-  >,
+  f: (value: SemanticGraph) => Either<FunctionNodeCallError, SemanticGraph>,
 ): FunctionNodeWithSignature<Signature> => {
   const node: ((
     value: SemanticGraph,
-  ) => Either<
-    DependencyUnavailable | TypeMismatchError | Panic | Bug,
-    SemanticGraph
-  >) &
+  ) => Either<FunctionNodeCallError, SemanticGraph>) &
     Writable<FunctionNodeWithSignature<Signature>> = value => f(value)
   node[nodeTag] = 'function'
   node.parameterName = parameterName

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -18,14 +18,14 @@ export const atom = {
     atomToAppend => {
       if (typeof atomToAppend !== 'string') {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`append` expected an atom',
         })
       } else {
         return either.makeRight(atomToAppendTo => {
           if (typeof atomToAppendTo !== 'string') {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`append` expected an atom',
             })
           } else {
@@ -52,14 +52,14 @@ export const atom = {
     atom2 => {
       if (typeof atom2 !== 'string') {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`equal` expected an atom',
         })
       } else {
         return either.makeRight(atom1 => {
           if (typeof atom1 !== 'string') {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`equal` expected an atom',
             })
           } else {
@@ -82,14 +82,14 @@ export const atom = {
     atomToPrepend => {
       if (typeof atomToPrepend !== 'string') {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`prepend` expected an atom',
         })
       } else {
         return either.makeRight(atomToPrependTo => {
           if (typeof atomToPrependTo !== 'string') {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`prepend` expected an atom',
             })
           } else {

--- a/src/language/semantics/stdlib/boolean.ts
+++ b/src/language/semantics/stdlib/boolean.ts
@@ -35,7 +35,7 @@ export const boolean = {
     argument => {
       if (!nodeIsBoolean(argument)) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`not` expected a boolean',
         })
       } else {
@@ -56,14 +56,14 @@ export const boolean = {
     argument2 => {
       if (!nodeIsBoolean(argument2)) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`and` expected a boolean',
         })
       } else {
         return either.makeRight(argument1 => {
           if (!nodeIsBoolean(argument1)) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`and` expected a boolean',
             })
           } else {
@@ -91,14 +91,14 @@ export const boolean = {
     argument2 => {
       if (!nodeIsBoolean(argument2)) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`or` expected a boolean',
         })
       } else {
         return either.makeRight(argument1 => {
           if (!nodeIsBoolean(argument1)) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`or` expected a boolean',
             })
           } else {

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -62,7 +62,7 @@ export const globalFunctions = {
       either.makeRight(functionToApply => {
         if (!isFunctionNode(functionToApply)) {
           return either.makeLeft({
-            kind: 'panic',
+            kind: 'typeMismatch',
             message: '`apply` expected a function',
           })
         } else {
@@ -128,14 +128,14 @@ export const globalFunctions = {
     secondFunction => {
       if (!isFunctionNode(secondFunction)) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`flow` expected a function',
         })
       } else {
         return either.makeRight(firstFunction => {
           if (!isFunctionNode(firstFunction)) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`flow` expected a function',
             })
           } else {
@@ -164,14 +164,14 @@ export const globalFunctions = {
     cases => {
       if (!isObjectNode(cases)) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`match` cases must be an object',
         })
       } else {
         return either.makeRight(argument => {
           if (!nodeIsTagged(argument)) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`match` argument was not tagged',
             })
           } else {

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -24,7 +24,7 @@ export const integer = {
         !types.integer.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`add` expected an integer',
         })
       } else {
@@ -34,7 +34,7 @@ export const integer = {
             !types.integer.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`add` expected an integer',
             })
           } else {
@@ -67,7 +67,7 @@ export const integer = {
         !types.integer.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`equals` expected an integer',
         })
       } else {
@@ -77,7 +77,7 @@ export const integer = {
             !types.integer.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`equals` expected an integer',
             })
           } else {
@@ -125,7 +125,7 @@ export const integer = {
         !types.integer.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`greater_than` expected an integer',
         })
       } else {
@@ -135,7 +135,7 @@ export const integer = {
             !types.integer.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`greater_than` expected an integer',
             })
           } else {
@@ -162,7 +162,7 @@ export const integer = {
         !types.integer.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`less_than` expected an integer',
         })
       } else {
@@ -172,7 +172,7 @@ export const integer = {
             !types.integer.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`less_than` expected an integer',
             })
           } else {
@@ -199,7 +199,7 @@ export const integer = {
         !types.integer.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`multiply` expected an integer',
         })
       } else {
@@ -209,7 +209,7 @@ export const integer = {
             !types.integer.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`multiply` expected an integer',
             })
           } else {
@@ -236,7 +236,7 @@ export const integer = {
         !types.integer.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`subtract` expected an integer',
         })
       } else {
@@ -246,7 +246,7 @@ export const integer = {
             !types.integer.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`subtract` expected an integer',
             })
           } else {

--- a/src/language/semantics/stdlib/natural-number.ts
+++ b/src/language/semantics/stdlib/natural-number.ts
@@ -45,7 +45,7 @@ export const natural_number = {
         !types.naturalNumber.isAssignableFrom(makeUnionType('', [number2]))
       ) {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`modulo` expected a natural number',
         })
       } else {
@@ -55,7 +55,7 @@ export const natural_number = {
             !types.naturalNumber.isAssignableFrom(makeUnionType('', [number1]))
           ) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`modulo` expected a natural number',
             })
           } else {

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -20,14 +20,14 @@ export const object = {
     key => {
       if (typeof key !== 'string') {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`lookup` key was not an atom',
         })
       } else {
         return either.makeRight(argument => {
           if (!isObjectNode(argument)) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`lookup` expected an object',
             })
           } else {
@@ -56,7 +56,7 @@ export const object = {
     key => {
       if (typeof key !== 'string') {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`from_property` key was not an atom',
         })
       } else {
@@ -80,14 +80,14 @@ export const object = {
     object2 => {
       if (typeof object2 !== 'object') {
         return either.makeLeft({
-          kind: 'panic',
+          kind: 'typeMismatch',
           message: '`overlay` expected an object',
         })
       } else {
         return either.makeRight(object1 => {
           if (!isObjectNode(object1)) {
             return either.makeLeft({
-              kind: 'panic',
+              kind: 'typeMismatch',
               message: '`overlay` expected an object',
             })
           } else {

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -1,12 +1,12 @@
 import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
-import type { DependencyUnavailable, Panic } from '../../errors.js'
 import {
   keyPathToLookupExpression,
   makeApplyExpression,
 } from '../../semantics.js'
 import {
   makeFunctionNode,
+  type FunctionNodeCallError,
   type FunctionNodeCallSignature,
 } from '../function-node.js'
 import { type NonEmptyKeyPath } from '../key-path.js'
@@ -72,7 +72,7 @@ export const preludeFunctionArity2 = (
   },
   f: (
     argument1: SemanticGraph,
-  ) => Either<DependencyUnavailable | Panic, FunctionNodeCallSignature>,
+  ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
 ) =>
   preludeFunctionArity1(keyPath, signature, argument1 =>
     either.map(f(argument1), f1 =>
@@ -99,10 +99,10 @@ export const preludeFunctionArity3 = (
   f: (
     argument1: SemanticGraph,
   ) => Either<
-    DependencyUnavailable | Panic,
+    FunctionNodeCallError,
     (
       argument2: SemanticGraph,
-    ) => Either<DependencyUnavailable | Panic, FunctionNodeCallSignature>
+    ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>
   >,
 ) =>
   preludeFunctionArity1(keyPath, signature, argument1 =>


### PR DESCRIPTION
Arguments passed to functions must conform to the function's parameter type.

The analysis is currently not entirely sound and there are some limitations (which I've attempted to document in comments). I'll try to plug these holes in future changesets.