### PR TITLE
Instantiate bare type parameters when inferring the type of `@apply`s

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -505,4 +505,11 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    '{ f: :identity, :f(1) ~ 1 }',
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -23,9 +23,10 @@ const staticallyCheckArgument = (
   context: ExpressionContext,
 ): Either<ElaborationError, undefined> =>
   (
-    // Type inference does not yet instantiate type parameters from argument
-    // types, so skip the static check for generic parameter types.
-    // TODO: Implement type parameter instantiation.
+    // Type inference does not yet robustly instantiate type parameters from
+    // argument types, so skip the static check for generic parameter types.
+    // TODO: Implement enough type parameter instantiation logic to eliminate
+    // this hack.
     containedTypeParameters(parameterType).size > 0
   ) ?
     either.makeRight(undefined)
@@ -33,11 +34,21 @@ const staticallyCheckArgument = (
       inferType(argument, resolveParameterTypes(context), new Set(), context),
       argumentType =>
         (
+          // Also skip when the argument's inferred type contains type
+          // parameters (e.g. a lookup of an unannotated function parameter,
+          // which `resolveParameterTypes` infers as a type parameter).
+          // TODO: Implement enough type parameter instantiation logic to
+          // eliminate this hack.
+          containedTypeParameters(argumentType).size > 0
+        ) ?
+          either.makeRight(undefined)
+        : (
           // For now, reject only when the argument's inferred type and the
-          // parameter type are completely disjoint. The sound thing to do here
-          // would be to only proceed when `argumentType` is assignable to
-          // `parameterType` (and not the other way around), but progress is
-          // needed elsewhere to allow extant programs to typecheck like that.
+          // parameter type are completely disjoint. The sound thing to do
+          // here would be to only proceed when `argumentType` is assignable
+          // to `parameterType` (and not the other way around), but progress
+          // is needed elsewhere to allow extant programs to typecheck like
+          // that.
           // TODO: Revisit this once function parameter type annotations are
           // expressible in plz.
           isAssignable({ source: argumentType, target: parameterType }) ||

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -42,18 +42,7 @@ const staticallyCheckArgument = (
           containedTypeParameters(argumentType).size > 0
         ) ?
           either.makeRight(undefined)
-        : (
-          // For now, reject only when the argument's inferred type and the
-          // parameter type are completely disjoint. The sound thing to do
-          // here would be to only proceed when `argumentType` is assignable
-          // to `parameterType` (and not the other way around), but progress
-          // is needed elsewhere to allow extant programs to typecheck like
-          // that.
-          // TODO: Revisit this once function parameter type annotations are
-          // expressible in plz.
-          isAssignable({ source: argumentType, target: parameterType }) ||
-          isAssignable({ source: parameterType, target: argumentType })
-        ) ?
+        : isAssignable({ source: argumentType, target: parameterType }) ?
           either.makeRight(undefined)
         : either.makeLeft({
             kind: 'typeMismatch',

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -26,6 +26,7 @@ import * as types from './prelude-types.js'
 import {
   makeFunctionType,
   makeObjectType,
+  makeTypeParameter,
   makeUnionType,
   type Type,
 } from './type-formats.js'
@@ -73,7 +74,9 @@ export const resolveParameterTypes = (
                 )
               ) ?
                 types.runtimeContext
-              : types.something
+              : makeTypeParameter(parameterName, {
+                  assignableTo: types.something,
+                })
 
             // Side-effect: add the parameter.
             parameterTypes.set(parameterName, parameterType)

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -33,6 +33,7 @@ import {
 import {
   applyKeyPathToType,
   literalTypeFromSemanticGraph,
+  supplyTypeArgument,
 } from './type-utilities.js'
 
 /**
@@ -210,7 +211,30 @@ export const inferType = (
     )
     if (either.isRight(inferredFunctionType)) {
       if (inferredFunctionType.value.kind === 'function') {
-        return either.makeRight(inferredFunctionType.value.signature.return)
+        const { parameter: parameterType, return: returnType } =
+          inferredFunctionType.value.signature
+        // If the function parameter is typed as a bare type parameter,
+        // instantiate it from the argument's type.
+        // TODO: Generalize this to handle type parameters nested within
+        // structures (e.g. `{ a, b } ~> { b, a }`).
+        if (parameterType.kind === 'parameter') {
+          const argumentTypeResult = inferType(
+            applyExpressionResult.value[1].argument,
+            parameterTypes,
+            lookingUpKeys,
+            context,
+          )
+          if (either.isRight(argumentTypeResult)) {
+            return either.makeRight(
+              supplyTypeArgument(
+                returnType,
+                parameterType,
+                argumentTypeResult.value,
+              ),
+            )
+          }
+        }
+        return either.makeRight(returnType)
       } else if (inferredFunctionType.value.kind === 'parameter') {
         // Let's just assume here that this type parameter will be instantiated
         // with a function type. If it's not, an error should be raised


### PR DESCRIPTION
This currently only handles functions whose parameter is directly-typed as a lone type parameter, not function parameter types with type parameters occuring within structures (e.g. `identity` i.e. `a ~> a` is handled, but `swap` i.e. `{ a, b } ~> { b, a }` isn't[^1]).

When such a function is applied, its return type is now computed after supplying the argument type for the type parameter.

This changeset allows the `@apply` check to be made sounder: now arguments must be subtypes of their parameters' types (rather than subtypes or supertypes).

[^1]: I need to come up with unambiguous notation for type parameters; it's probably obvious, but the letters in types in this parenthetical refer to type parameters, not atoms.