### PR TITLE
Generalize type parameter instantiation when inferring the type of `@apply`s

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -512,4 +512,11 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    '{ f: :identity >> :identity, :f(1) ~ 1 }',
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -519,4 +519,13 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    ':flow(@runtime { _ => "not a function" })',
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -3,6 +3,7 @@ import type { ElaborationError } from '../../../errors.js'
 import {
   containedTypeParameters,
   containsAnyUnelaboratedNodes,
+  getTypesForTypeParameters,
   inferType,
   isAssignable,
   isFunctionNode,
@@ -10,6 +11,7 @@ import {
   resolveParameterTypes,
   showType,
   stringifySemanticGraphForEndUser,
+  supplyTypeArguments,
   type Expression,
   type ExpressionContext,
   type KeywordHandler,
@@ -22,19 +24,18 @@ const staticallyCheckArgument = (
   parameterType: Type,
   context: ExpressionContext,
 ): Either<ElaborationError, undefined> =>
-  (
-    // Type inference does not yet robustly instantiate type parameters from
-    // argument types, so skip the static check for generic parameter types.
-    // TODO: Implement enough type parameter instantiation logic to eliminate
-    // this hack.
-    containedTypeParameters(parameterType).size > 0
-  ) ?
-    either.makeRight(undefined)
-  : either.flatMap(
-      inferType(argument, resolveParameterTypes(context), new Set(), context),
-      argumentType =>
+  either.flatMap(
+    inferType(argument, resolveParameterTypes(context), new Set(), context),
+    argumentType => {
+      // Instantiate type parameters contained in `parameterType` before the
+      // assignability check.
+      const instantiatedParameterType = supplyTypeArguments(
+        parameterType,
+        getTypesForTypeParameters({ parameterType, argumentType }),
+      )
+      return (
         (
-          // Also skip when the argument's inferred type contains type
+          // Skip checking when the argument's inferred type contains type
           // parameters (e.g. a lookup of an unannotated function parameter,
           // which `resolveParameterTypes` infers as a type parameter).
           // TODO: Implement enough type parameter instantiation logic to
@@ -42,15 +43,22 @@ const staticallyCheckArgument = (
           containedTypeParameters(argumentType).size > 0
         ) ?
           either.makeRight(undefined)
-        : isAssignable({ source: argumentType, target: parameterType }) ?
+        : (
+          isAssignable({
+            source: argumentType,
+            target: instantiatedParameterType,
+          })
+        ) ?
           either.makeRight(undefined)
         : either.makeLeft({
             kind: 'typeMismatch',
             message: `the value \`${stringifySemanticGraphForEndUser(
               argument,
             )}\` is not assignable to the type \`${showType(parameterType)}\``,
-          }),
-    )
+          })
+      )
+    },
+  )
 
 export const applyKeywordHandler: KeywordHandler = (
   expression: Expression,

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -84,6 +84,7 @@ export {
 } from './semantics/semantic-graph.js'
 export {
   containedTypeParameters,
+  getTypesForTypeParameters,
   inferType,
   isAssignable,
   literalTypeFromSemanticGraph,
@@ -91,6 +92,7 @@ export {
   resolveParameterTypes,
   showType,
   supplyTypeArgument,
+  supplyTypeArguments,
   types,
   type Type,
 } from './semantics/type-system.js'

--- a/src/language/semantics/type-system.test.ts
+++ b/src/language/semantics/type-system.test.ts
@@ -21,7 +21,10 @@ import {
   type Type,
   type UnionType,
 } from './type-system/type-formats.js'
-import { applyKeyPathToType } from './type-system/type-utilities.js'
+import {
+  applyKeyPathToType,
+  getTypesForTypeParameters,
+} from './type-system/type-utilities.js'
 
 const typeAssignabilitySuite = testCases(
   ([source, target]: [source: Type, target: Type]) =>
@@ -1294,4 +1297,79 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
     ],
     showType(integer),
   ],
+])
+
+const getTypesForTypeParametersSuite = testCases(
+  ([parameterType, argumentType]: readonly [
+    parameterType: Type,
+    argumentType: Type,
+  ]) => getTypesForTypeParameters({ parameterType, argumentType }),
+  ([parameterType, argumentType]) =>
+    `getting types for type parameters in \`${showType(parameterType)}\` from \`${showType(argumentType)}\``,
+)
+
+getTypesForTypeParametersSuite('getTypesForTypeParameters', [
+  [[A, atom], new Map([[A, atom]])],
+
+  [[extendsAnyAtom, atom], new Map([[extendsAnyAtom, atom]])],
+
+  [[something, atom], new Map()],
+
+  [[makeObjectType('', { a: A }), atom], new Map()],
+
+  [
+    [
+      makeObjectType('', { a: A, b: B }),
+      makeObjectType('', { a: atom, b: integer }),
+    ],
+    new Map([
+      [A, atom],
+      [B, integer],
+    ]),
+  ],
+
+  [
+    [
+      makeFunctionType('', { parameter: A, return: B }),
+      makeFunctionType('', { parameter: atom, return: integer }),
+    ],
+    new Map([
+      [A, atom],
+      [B, integer],
+    ]),
+  ],
+
+  [
+    [
+      makeFunctionType('', { parameter: A, return: A }),
+      makeFunctionType('', { parameter: atom, return: integer }),
+    ],
+    // The first occurrence should be used in situations like this. In real code
+    // this will likely result in a type error later.
+    new Map([[A, atom]]),
+  ],
+
+  [
+    [
+      makeObjectType('', { a: A, b: A }),
+      makeObjectType('', { a: atom, b: integer }),
+    ],
+    // The first occurrence should be used in situations like this. In real code
+    // this will likely result in a type error later.
+    new Map([[A, atom]]),
+  ],
+
+  // `getTypesForTypeParameters` doesn't currently consider constraints.
+  // TODO: This should probably return an empty `Map`?
+  [[extendsAnyAtom, object], new Map([[extendsAnyAtom, object]])],
+
+  // TODO: Handle type parameters within unions:
+  //
+  // [[makeUnionType('', [A, atom]), object], new Map([[A, object]])],
+  //
+  // [[makeUnionType('', [A, atom]), something], new Map([[A, something]])],
+  //
+  // TODO: Which of these is preferable? I believe both are sound.
+  // [[makeUnionType('', [A, atom]), atom], new Map()],
+  // [[makeUnionType('', [A, atom]), atom], new Map([[A, atom]])],
 ])

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -9,7 +9,9 @@ export {
 export {
   applyKeyPathToType,
   containedTypeParameters,
+  getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
   replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArgument,
+  supplyTypeArguments,
 } from './type-system/type-utilities.js'

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -32,8 +32,9 @@ import {
 } from './type-formats.js'
 import {
   applyKeyPathToType,
+  getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
-  supplyTypeArgument,
+  supplyTypeArguments,
 } from './type-utilities.js'
 
 /**
@@ -213,26 +214,24 @@ export const inferType = (
       if (inferredFunctionType.value.kind === 'function') {
         const { parameter: parameterType, return: returnType } =
           inferredFunctionType.value.signature
-        // If the function parameter is typed as a bare type parameter,
-        // instantiate it from the argument's type.
-        // TODO: Generalize this to handle type parameters nested within
-        // structures (e.g. `{ a, b } ~> { b, a }`).
-        if (parameterType.kind === 'parameter') {
-          const argumentTypeResult = inferType(
-            applyExpressionResult.value[1].argument,
-            parameterTypes,
-            lookingUpKeys,
-            context,
-          )
-          if (either.isRight(argumentTypeResult)) {
-            return either.makeRight(
-              supplyTypeArgument(
-                returnType,
+        const argumentTypeResult = inferType(
+          applyExpressionResult.value[1].argument,
+          parameterTypes,
+          lookingUpKeys,
+          context,
+        )
+        if (either.isRight(argumentTypeResult)) {
+          // Supply type arguments to the return type based on the inferred
+          // argument type.
+          return either.makeRight(
+            supplyTypeArguments(
+              returnType,
+              getTypesForTypeParameters({
                 parameterType,
-                argumentTypeResult.value,
-              ),
-            )
-          }
+                argumentType: argumentTypeResult.value,
+              }),
+            ),
+          )
         }
         return either.makeRight(returnType)
       } else if (inferredFunctionType.value.kind === 'parameter') {

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -289,6 +289,69 @@ export const replaceAllTypeParametersWithTheirConstraints = (
     )
 
 /**
+ * Finds concrete types for the `TypeParameter`s in `parameter` by locating the
+ * corresponding position for each in `argument`.
+ *
+ * The types are not checked for consistency with each other, nor for
+ * assignability to `argument`. Callers should use `supplyTypeArguments` to
+ * create a concrete type and then perform any needed checks.
+ */
+// TODO: This should probably be checking type parameter constraints. It'll
+// definitely need to do so for the not-yet-implemented union case.
+export const getTypesForTypeParameters = ({
+  parameterType,
+  argumentType,
+}: {
+  readonly parameterType: Type
+  readonly argumentType: Type
+}): ReadonlyMap<TypeParameter, Type> => {
+  // Avoid infinite recursion when we hit the top type.
+  if (parameterType === types.something) {
+    return new Map()
+  } else {
+    return matchTypeFormat(parameterType, {
+      function: parameterType =>
+        argumentType.kind === 'function' ?
+          new Map([
+            ...getTypesForTypeParameters({
+              parameterType: parameterType.signature.return,
+              argumentType: argumentType.signature.return,
+            }),
+            ...getTypesForTypeParameters({
+              parameterType: parameterType.signature.parameter,
+              argumentType: argumentType.signature.parameter,
+            }),
+          ])
+        : new Map(),
+      object: parameterType =>
+        argumentType.kind === 'object' ?
+          Object.entries(parameterType.children)
+            .map(([key, childParameter]) => {
+              const childArgument = argumentType.children[key]
+              return childArgument === undefined ?
+                  new Map<TypeParameter, Type>()
+                : getTypesForTypeParameters({
+                    parameterType: childParameter,
+                    argumentType: childArgument,
+                  })
+            })
+            .reduce(
+              (types, typesFromChild) => new Map([...typesFromChild, ...types]),
+              new Map<TypeParameter, Type>(),
+            )
+        : new Map(),
+      opaque: _ => new Map(),
+      parameter: parameterType => new Map([[parameterType, argumentType]]),
+      // TODO: Handle type parameters in unions. This case will have to check
+      // type parameter constraints (e.g. if `parameterType` is `(A <: object) |
+      // atom`, if `argumentType` is an object type then `A` should be
+      // substituted with that type, but not if `argumentType` is an atom type).
+      union: _ => new Map(),
+    })
+  }
+}
+
+/**
  * Substitute the given `typeParameter` with the given `typeArgument` within
  * `type`, recursively visiting object properties, union members, etc.
  *
@@ -353,6 +416,19 @@ export const supplyTypeArgument = (
     })
   }
 }
+
+/** @see `supplyTypeArgument` */
+// TODO: If this becomes a performance bottleneck it could be specialized to
+// only match the format of `type` once.
+export const supplyTypeArguments = (
+  type: Type,
+  typeArguments: ReadonlyMap<TypeParameter, Type>,
+): Type =>
+  [...typeArguments].reduce(
+    (partiallyAppliedType, [typeParameter, typeArgument]) =>
+      supplyTypeArgument(partiallyAppliedType, typeParameter, typeArgument),
+    type,
+  )
 
 /**
  * If the given `KeyPath` is not valid for the given `Type`, the given `Type` is


### PR DESCRIPTION
#131 only supported functions whose parameter type was a lone type parameter (e.g. `a ~> a`). This changeset generalizes type parameter instantiation to support function parameters whose types contain one or more type parameters at arbitrary locations (e.g. `{ a, b } ~> { b, a }`). It also removes a hacky workaround for the lack of this functionality; making type-checking more correct & comprehensive.