### PR TITLE
Improve type inference & static analysis for `@apply` expressions

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -528,14 +528,6 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [`:|>(:>>(:atom.append(c))(:atom.append(b)))(a)`, either.makeRight('abc')],
   [
     `{
-      |>: f => a => :f(:a)
-      ab: a |> :atom.append(b)
-      abc: :ab |> :atom.append(c)
-    }.abc`,
-    either.makeRight('abc'),
-  ],
-  [
-    `{
       append_bc: :atom.append(b) >> :atom.append(c)
       abc: a |> :append_bc
     }.abc`,
@@ -792,5 +784,17 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       // TODO: Consider normalizing away the duplicate `false`s.
       '1': { '0': 'false', '1': 'true', '2': 'false' },
     }),
+  ],
+  [
+    `{
+      |>: :identity
+      // TODO: Define \`|>\` as below once it's possible to annotate \`f\` as a
+      // function type.
+      // |>: f => a => :f(:a)
+
+      ab: a |> :atom.append(b)
+      abc: :ab |> :atom.append(c)
+    }.abc`,
+    either.makeRight('abc'),
   ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -528,4 +528,15 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    // `:f` isn't necessarily a function, e.g. `:oops("not a function")` is a
+    // legal call.
+    '{ oops: f => :f(42) }',
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'invalidExpression')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -19,7 +19,7 @@ import {
   type Type,
 } from '../../../semantics.js'
 
-const staticallyCheckArgument = (
+const checkArgumentType = (
   argument: SemanticGraph,
   parameterType: Type,
   context: ExpressionContext,
@@ -70,17 +70,28 @@ export const applyKeywordHandler: KeywordHandler = (
       const functionToApply = applyExpression[1].function
       const argument = applyExpression[1].argument
 
-      const staticCheck: Either<ElaborationError, undefined> =
-        isFunctionNode(functionToApply) ?
-          staticallyCheckArgument(
-            argument,
-            functionToApply.signature.parameter,
-            context,
-          )
-        : either.makeRight(undefined)
+      const argumentTypeCheck = either.flatMap(
+        inferType(
+          functionToApply,
+          resolveParameterTypes(context),
+          new Set(),
+          context,
+        ),
+        functionType =>
+          functionType.kind === 'function' ?
+            checkArgumentType(
+              argument,
+              functionType.signature.parameter,
+              context,
+            )
+          : either.makeLeft({
+              kind: 'invalidExpression',
+              message: `only functions can be applied, but got a \`${showType(functionType)}\``,
+            }),
+      )
 
       return either.flatMap(
-        staticCheck,
+        argumentTypeCheck,
         (): Either<ElaborationError, SemanticGraph> => {
           if (containsAnyUnelaboratedNodes(argument)) {
             // The argument isn't ready, so keep the @apply unelaborated.

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -211,42 +211,49 @@ export const inferType = (
       context,
     )
     if (either.isRight(inferredFunctionType)) {
-      if (inferredFunctionType.value.kind === 'function') {
-        const { parameter: parameterType, return: returnType } =
-          inferredFunctionType.value.signature
-        const argumentTypeResult = inferType(
-          applyExpressionResult.value[1].argument,
-          parameterTypes,
-          lookingUpKeys,
-          context,
-        )
-        if (either.isRight(argumentTypeResult)) {
-          // Supply type arguments to the return type based on the inferred
-          // argument type.
-          return either.makeRight(
-            supplyTypeArguments(
-              returnType,
-              getTypesForTypeParameters({
-                parameterType,
-                argumentType: argumentTypeResult.value,
-              }),
-            ),
+      const inferredFunctionTypeAsFunctionType =
+        inferredFunctionType.value.kind === 'function' ?
+          option.makeSome(inferredFunctionType.value)
+        : (
+          inferredFunctionType.value.kind === 'parameter' &&
+          inferredFunctionType.value.constraint.assignableTo.kind === 'function'
+        ) ?
+          option.makeSome(inferredFunctionType.value.constraint.assignableTo)
+        : option.none
+
+      return option.match(inferredFunctionTypeAsFunctionType, {
+        some: ({
+          signature: { parameter: parameterType, return: returnType },
+        }) => {
+          const argumentTypeResult = inferType(
+            applyExpressionResult.value[1].argument,
+            parameterTypes,
+            lookingUpKeys,
+            context,
           )
-        }
-        return either.makeRight(returnType)
-      } else if (inferredFunctionType.value.kind === 'parameter') {
-        // Let's just assume here that this type parameter will be instantiated
-        // with a function type. If it's not, an error should be raised
-        // elsewhere.
-        return either.makeRight(
-          inferredFunctionType.value.constraint.assignableTo,
-        )
-      } else {
-        return either.makeLeft({
-          kind: 'invalidExpression',
-          message: 'cannot infer type: only functions can be applied',
-        })
-      }
+          if (either.isRight(argumentTypeResult)) {
+            // Supply type arguments to the return type based on the inferred
+            // argument type.
+            return either.makeRight(
+              supplyTypeArguments(
+                returnType,
+                getTypesForTypeParameters({
+                  parameterType,
+                  argumentType: argumentTypeResult.value,
+                }),
+              ),
+            )
+          }
+          return either.makeRight(returnType)
+        },
+        none: _ => either.makeRight(types.something),
+        // TODO: Error instead once inference is comprehensive enough to do so
+        // without failing tests:
+        // none: _ => either.makeLeft({
+        //   kind: 'invalidExpression',
+        //   message: `cannot infer return type: only functions can be applied, but got a \`${showType(inferredFunctionType.value)}\``,
+        // }),
+      })
     }
   }
 


### PR DESCRIPTION
This plugs a few intentional holes that were opened to allow existing tests to pass.

I think I'll need to introduce syntax for function parameter type annotations before much longer; it's blocking me from plugging some of the remaining holes (existing programs in tests/examples contain functions with unspecified parameter types, yet do specific things with the parameter).