### PR TITLE
Infer untyped function parameters as type parameters in one more place

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -539,4 +539,43 @@ testCases(
       assert.deepEqual(result.value.kind, 'invalidExpression')
     },
   ],
+
+  [
+    '{ f: a => :a, :f(1) ~ 1 }',
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `@runtime { context => (a => :a)(:context.program.start_time) } ~ :atom.type`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `@runtime { context => (a => :a)(:context.program.start_time) } ~ :integer.type`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `@runtime { context => (a => :context.log(:a))(1) } ~ 1`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `@runtime { context => (a => :context.log(:a))(1) } ~ 2`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -41,7 +41,7 @@ const check = ({
             kind: 'typeMismatch',
             message: `the value \`${stringifySemanticGraphForEndUser(
               value,
-            )}\` is not assignable to the type \`${showType(typeAsType)}\``,
+            )}\` (inferred to have type \`${showType(valueAsType)}\`) is not assignable to the type \`${showType(typeAsType)}\``,
           })
         }
       }),

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -110,7 +110,9 @@ export const inferType = (
 
     // TODO: Implement syntax for explicit parameter type annotations, as well
     // as eventually supporting contextual inference of un-annotated parameters.
-    const parameterType = types.something
+    const parameterType = makeTypeParameter(parameter, {
+      assignableTo: types.something,
+    })
 
     return either.map(
       inferType(


### PR DESCRIPTION
This should've happened in 106453ed1707c8c63422781311f25599990f15eb, but was overlooked.