### PR TITLE
Un-stub signatures in `@function` handler

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
@@ -25,6 +25,15 @@ elaborationSuite('@function', [
           1: { parameter: 'x', body: { 0: '@lookup', 1: { key: 'x' } } },
         }),
       )
+      assert.deepEqual(
+        elaboratedFunction.value.signature.parameter.kind,
+        'parameter',
+      )
+      assert.deepEqual(elaboratedFunction.value.signature.parameter.name, 'x')
+      assert.deepEqual(
+        elaboratedFunction.value.signature.return,
+        elaboratedFunction.value.signature.parameter,
+      )
     },
   ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -3,11 +3,12 @@ import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
   elaborateWithContext,
+  inferType,
   makeFunctionNode,
   makeObjectNode,
   readFunctionExpression,
+  resolveParameterTypes,
   serialize,
-  types,
   updateValueAtKeyPathInSemanticGraph,
   type Expression,
   type ExpressionContext,
@@ -21,21 +22,39 @@ export const functionKeywordHandler: KeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, FunctionNode> =>
-  either.map(readFunctionExpression(expression), functionExpression =>
-    makeFunctionNode(
-      {
-        // TODO
-        parameter: types.something,
-        return: types.something,
+  either.flatMap(readFunctionExpression(expression), functionExpression =>
+    either.flatMap(
+      inferType(expression, resolveParameterTypes(context), new Set(), context),
+      inferredType => {
+        if (inferredType.kind !== 'function') {
+          return either.makeLeft({
+            kind: 'bug',
+            message:
+              'inferred type of function expression was not a function type',
+          })
+        } else {
+          return either.makeRight(
+            makeFunctionNode(
+              inferredType.signature,
+              () => either.makeRight(functionExpression),
+              option.makeSome(functionExpression[1].parameter),
+              argument =>
+                apply(
+                  functionExpression,
+                  inferredType.signature,
+                  argument,
+                  context,
+                ),
+            ),
+          )
+        }
       },
-      () => either.makeRight(functionExpression),
-      option.makeSome(functionExpression[1].parameter),
-      argument => apply(functionExpression, argument, context),
     ),
   )
 
 const apply = (
   expression: FunctionExpression,
+  signature: FunctionNode['signature'],
   argument: SemanticGraph,
   context: ExpressionContext,
 ): ReturnType<FunctionNode> => {
@@ -65,14 +84,10 @@ const apply = (
           makeObjectNode({
             // Include the function itself to allow recursion.
             [ownKey]: makeFunctionNode(
-              {
-                // TODO
-                parameter: types.something,
-                return: types.something,
-              },
+              signature,
               () => either.makeRight(expression),
               option.makeSome(parameter),
-              argument => apply(expression, argument, context),
+              argument => apply(expression, signature, argument, context),
             ),
             // Put the argument in scope.
             [parameter]: argument,

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -100,11 +100,16 @@ export const inferType = (
   lookingUpKeys: ReadonlySet<Atom>,
   context: ExpressionContext,
 ): Either<ElaborationError, Type> => {
+  if (
+    typeof node === 'string' ||
+    typeof node === 'symbol' ||
+    typeof node === 'function'
+  ) {
+    return literalTypeFromSemanticGraph(node)
+  }
+
   // @function: infer return type from the body.
-  const functionExpressionResult =
-    isFunctionNode(node) ?
-      either.flatMap(node.serialize(), readFunctionExpression)
-    : readFunctionExpression(node)
+  const functionExpressionResult = readFunctionExpression(node)
   if (either.isRight(functionExpressionResult)) {
     const { parameter, body } = functionExpressionResult.value[1]
 
@@ -124,16 +129,6 @@ export const inferType = (
       returnType =>
         makeFunctionType('', { parameter: parameterType, return: returnType }),
     )
-  }
-
-  // TODO: Once the @function handler uses real type signatures, move this
-  // before the @function case above.
-  if (
-    typeof node === 'string' ||
-    typeof node === 'symbol' ||
-    typeof node === 'function'
-  ) {
-    return literalTypeFromSemanticGraph(node)
   }
 
   // @lookup: check if it directly refers to a function parameter. If so, use


### PR DESCRIPTION
There's now enough type system machinery in place to devise/preserve function signatures when converting between raw `@function` expressions and `FunctionNode`s.