### PR TITLE
Address a few minor TODOs related to the type system

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/runtime-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/runtime-handler.ts
@@ -19,7 +19,9 @@ export const runtimeKeywordHandler: KeywordHandler = (
 ): Either<ElaborationError, SemanticGraph> =>
   either.flatMap(
     readRuntimeExpression(expression),
-    ({ 1: { function: runtimeFunction } }) => {
+    ({
+      1: { function: runtimeFunction },
+    }): Either<ElaborationError, SemanticGraph> => {
       if (isFunctionNode(runtimeFunction)) {
         const runtimeFunctionSignature = runtimeFunction.signature
         return (
@@ -37,8 +39,10 @@ export const runtimeKeywordHandler: KeywordHandler = (
             })
           : either.makeRight(makeRuntimeExpression(runtimeFunction))
       } else {
-        // TODO: Type-check unelaborated nodes.
-        return either.makeRight(makeRuntimeExpression(runtimeFunction))
+        return either.makeLeft({
+          kind: 'invalidExpression',
+          message: '@runtime function was not a function',
+        })
       }
     },
   )

--- a/src/language/semantics/type-system.test.ts
+++ b/src/language/semantics/type-system.test.ts
@@ -1359,9 +1359,7 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
     new Map([[A, atom]]),
   ],
 
-  // `getTypesForTypeParameters` doesn't currently consider constraints.
-  // TODO: This should probably return an empty `Map`?
-  [[extendsAnyAtom, object], new Map([[extendsAnyAtom, object]])],
+  [[extendsAnyAtom, object], new Map()],
 
   // TODO: Handle type parameters within unions:
   //

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -194,8 +194,12 @@ export const inferType = (
         lookingUpKeys,
         context,
       )
+    } else {
+      return either.makeLeft({
+        kind: 'invalidExpression',
+        message: '@runtime function was not a function',
+      })
     }
-    return either.makeRight(types.something)
   }
 
   // @apply: infer the return type from the function being applied.

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -6,7 +6,7 @@ import { isKeywordExpressionWithArgument } from '../expression.js'
 import { type SemanticGraph } from '../semantic-graph.js'
 import { types } from '../type-system.js'
 import { typesBySymbol } from './prelude-types.js'
-import { simplifyUnionType } from './subtyping.js'
+import { isAssignable, simplifyUnionType } from './subtyping.js'
 import {
   makeFunctionType,
   makeObjectType,
@@ -296,8 +296,6 @@ export const replaceAllTypeParametersWithTheirConstraints = (
  * assignability to `argument`. Callers should use `supplyTypeArguments` to
  * create a concrete type and then perform any needed checks.
  */
-// TODO: This should probably be checking type parameter constraints. It'll
-// definitely need to do so for the not-yet-implemented union case.
 export const getTypesForTypeParameters = ({
   parameterType,
   argumentType,
@@ -341,7 +339,15 @@ export const getTypesForTypeParameters = ({
             )
         : new Map(),
       opaque: _ => new Map(),
-      parameter: parameterType => new Map([[parameterType, argumentType]]),
+      parameter: parameterType =>
+        (
+          isAssignable({
+            source: argumentType,
+            target: parameterType.constraint.assignableTo,
+          })
+        ) ?
+          new Map([[parameterType, argumentType]])
+        : new Map(),
       // TODO: Handle type parameters in unions. This case will have to check
       // type parameter constraints (e.g. if `parameterType` is `(A <: object) |
       // atom`, if `argumentType` is an object type then `A` should be


### PR DESCRIPTION
- Remove now-unnecessary allowances for non-function values in `@runtime`
- Consider type parameter constraints in `getTypesForTypeParameters`