### PR TITLE
Implement optional function parameter type annotations

### DIFF
--- a/examples/.snapshot
+++ b/examples/.snapshot
@@ -54,7 +54,7 @@ exports[`examples > fibonacci.plz > --input=\"not a number\" > stdout 1`] = `
 
 exports[`examples > fibonacci.plz > roundtripped syntax tree 1`] = `
 {
-  fibonacci: n => @if {
+  fibonacci: (n: :integer.type) => @if {
     (:n < 2)
     then: :n
     else: :fibonacci(:n - 1) + :fibonacci(:n - 2)
@@ -152,7 +152,7 @@ exports[`examples > fizzbuzz.plz > --input=\"not a number\" > stdout 1`] = `
 
 exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
 {
-  fizzbuzz: limit => {
+  fizzbuzz: (limit: :natural_number.type) => {
     fizzbuzz_internal: state => @if {
       (:state.current > :limit)
       then: :state.output

--- a/examples/fibonacci.plz
+++ b/examples/fibonacci.plz
@@ -1,5 +1,5 @@
 {
-  fibonacci: n =>
+  fibonacci: (n: :integer.type) =>
     @if {
       :n < 2
       then: :n

--- a/examples/fizzbuzz.plz
+++ b/examples/fizzbuzz.plz
@@ -1,5 +1,5 @@
 {
-  fizzbuzz: limit => {
+  fizzbuzz: (limit: :natural_number.type) => {
     fizzbuzz_internal: state => @if {
       :state.current > :limit
       then: :state.output

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -69,8 +69,8 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
     either.makeRight('42'),
   ],
   [
-    `(a => {
-      my_function: b => @if {
+    `((a: :natural_number.type) => {
+      my_function: (b: :natural_number.type) => @if {
         :b > :a
         then: @panic "should not go down this branch"
         else: 2 + @if {
@@ -85,19 +85,20 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
   ],
   [
     `{
-      count: limit => {
-        count_internal: state => @if {
-          :state.current > :limit
-          then: :state.output
-          else: :count_internal({
-            output: :state.output atom.append :state.current atom.append @if {
-              :state.current > 1
-              then: " (greater than one) "
-              else: " (not greater than one) "
-            }
-            current: :state.current + 1
-          })
-        }
+      count: (limit: :natural_number.type) => {
+        count_internal: (state: { current: :integer.type, output: :atom.type }) =>
+          @if {
+            :state.current > :limit
+            then: :state.output
+            else: :count_internal({
+              output: :state.output atom.append :state.current atom.append @if {
+                :state.current > 1
+                then: " (greater than one) "
+                else: " (not greater than one) "
+              }
+              current: :state.current + 1
+            })
+          }
         return: :count_internal({ current: 0, output: "" })
       }.return
     }.count(2)`,
@@ -401,7 +402,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      fibonacci: n =>
+      fibonacci: (n: :integer.type) =>
         @if {
           :integer.is_less_than(2)(:n)
           then: :n
@@ -413,7 +414,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      +: a => b => :integer.add(:a)(:b)
+      +: (a: :integer.type) => (b: :integer.type) => :integer.add(:a)(:b)
       result: 1 + 1
      }.result`,
     either.makeRight('2'),
@@ -428,7 +429,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [`0 > 0`, either.makeRight('false')],
   [`1 < 0`, either.makeRight('false')],
   [`0 > 1`, either.makeRight('false')],
-  [`(a => (1 + :a))(1)`, either.makeRight('2')],
+  [`((a: :integer.type) => (1 + :a))(1)`, either.makeRight('2')],
   [`2 |> (a => :a)`, either.makeRight('2')],
   [`a atom.append b atom.append c`, either.makeRight('abc')],
   [`b atom.append c atom.prepend a`, either.makeRight('abc')],
@@ -646,10 +647,13 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     }`,
     either.makeRight('a'),
   ],
-  [`(a => b => :a + :b)(1)(1)`, either.makeRight('2')],
+  [
+    `((a: :integer.type) => (b: :integer.type) => :a + :b)(1)(1)`,
+    either.makeRight('2'),
+  ],
   [
     `{
-      f: state => @if {
+      f: (state: { current: :integer.type, limit: :integer.type }) => @if {
         :state.current > :state.limit
         then: "it works"
         else: :f({
@@ -669,8 +673,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     either.makeRight('it works'),
   ],
   [
-    `(outer =>
-      (inner =>
+    `((outer: :boolean.type) =>
+      ((inner: { value: :boolean.type }) =>
         @if {
           condition: :boolean.or(:outer)(:inner.value)
           then: { @panic }
@@ -681,8 +685,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     either.makeRight('true'),
   ],
   [
-    `(outer =>
-      (inner =>
+    `((outer: :boolean.type) =>
+      ((inner: { value: :boolean.type }) =>
         @if {
           condition: :boolean.or(:outer)(:inner.value)
           then: "it works"
@@ -787,11 +791,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
-      |>: :identity
-      // TODO: Define \`|>\` as below once it's possible to annotate \`f\` as a
-      // function type.
-      // |>: f => a => :f(:a)
-
+      // TODO: Once syntax exists for type parameters, make this generic:
+      |>: (f: :atom.type ~> :atom.type) => (a: :atom.type) => :f(:a)
       ab: a |> :atom.append(b)
       abc: :ab |> :atom.append(c)
     }.abc`,

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -797,4 +797,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     }.abc`,
     either.makeRight('abc'),
   ],
+  [
+    `{
+      increment: @function {
+        parameter: { a: :integer.type }
+        body: :a + 1
+      }
+      two: :increment(1)
+    }.two`,
+    either.makeRight('2'),
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -578,4 +578,19 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `{
+      integer_identity: @function {
+        parameter: { a: :integer.type }
+        body: :a
+      }
+      :integer_identity("not an integer")
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/parsing.test.ts
+++ b/src/language/compiling/parsing.test.ts
@@ -67,6 +67,78 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ],
 
   [
+    '(a: b) => c',
+    either.makeRight(
+      syntaxTree({
+        '0': '@function',
+        '1': {
+          parameter: { a: 'b' },
+          body: 'c',
+        },
+      }),
+    ),
+  ],
+
+  [
+    '(a: :integer.type) => :a',
+    either.makeRight(
+      syntaxTree({
+        '0': '@function',
+        '1': {
+          parameter: {
+            a: {
+              '0': '@index',
+              '1': {
+                object: { '0': '@lookup', '1': { key: 'integer' } },
+                query: { '0': 'type' },
+              },
+            },
+          },
+          body: { '0': '@lookup', '1': { key: 'a' } },
+        },
+      }),
+    ),
+  ],
+
+  [
+    '(a: b) => (c: d) => e',
+    either.makeRight(
+      syntaxTree({
+        '0': '@function',
+        '1': {
+          parameter: { a: 'b' },
+          body: {
+            '0': '@function',
+            '1': {
+              parameter: { c: 'd' },
+              body: 'e',
+            },
+          },
+        },
+      }),
+    ),
+  ],
+
+  [
+    'a => (b: c) => d',
+    either.makeRight(
+      syntaxTree({
+        '0': '@function',
+        '1': {
+          parameter: 'a',
+          body: {
+            '0': '@function',
+            '1': {
+              parameter: { b: 'c' },
+              body: 'd',
+            },
+          },
+        },
+      }),
+    ),
+  ],
+
+  [
     'a ~> b',
     either.makeRight(
       syntaxTree({

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
@@ -82,7 +82,15 @@ elaborationSuite('@apply', [
         function: {
           0: '@function',
           1: {
-            0: 'x',
+            0: {
+              x: {
+                0: '@index',
+                1: {
+                  0: { 0: '@lookup', 1: { 0: 'boolean' } },
+                  1: { 0: 'type' },
+                },
+              },
+            },
             1: {
               0: '@apply',
               1: {

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
@@ -36,4 +36,22 @@ elaborationSuite('@function', [
       )
     },
   ],
+  [
+    {
+      0: '@function',
+      1: {
+        0: { x: 'an arbitrary type' },
+        1: { 0: '@lookup', 1: { 0: 'x' } },
+      },
+    },
+    elaboratedFunction => {
+      assert(!either.isLeft(elaboratedFunction))
+      assert(isFunctionNode(elaboratedFunction.value))
+      assert.deepEqual(
+        elaboratedFunction.value.parameterName,
+        option.makeSome('x'),
+      )
+      // TODO: Test parameter type once it is wired through.
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
@@ -51,7 +51,28 @@ elaborationSuite('@function', [
         elaboratedFunction.value.parameterName,
         option.makeSome('x'),
       )
-      // TODO: Test parameter type once it is wired through.
+      assert.deepEqual(
+        elaboratedFunction.value.serialize(),
+        either.makeRight({
+          0: '@function',
+          1: {
+            parameter: { x: 'an arbitrary type' },
+            body: { 0: '@lookup', 1: { key: 'x' } },
+          },
+        }),
+      )
+      const parameterType = elaboratedFunction.value.signature.parameter
+      if (parameterType.kind !== 'union') {
+        assert.fail(
+          `expected a union type, but got a ${parameterType.kind} type`,
+        )
+      } else {
+        assert.deepEqual(parameterType.members, new Set(['an arbitrary type']))
+        assert.deepEqual(
+          elaboratedFunction.value.signature.return,
+          parameterType,
+        )
+      }
     },
   ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -3,6 +3,7 @@ import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
   elaborateWithContext,
+  getParameterName,
   inferType,
   makeFunctionNode,
   makeObjectNode,
@@ -37,7 +38,7 @@ export const functionKeywordHandler: KeywordHandler = (
             makeFunctionNode(
               inferredType.signature,
               () => either.makeRight(functionExpression),
-              option.makeSome(functionExpression[1].parameter),
+              option.makeSome(getParameterName(functionExpression)),
               argument =>
                 apply(
                   functionExpression,
@@ -58,7 +59,7 @@ const apply = (
   argument: SemanticGraph,
   context: ExpressionContext,
 ): ReturnType<FunctionNode> => {
-  const parameter = expression[1].parameter
+  const parameterName = getParameterName(expression)
   const body = expression[1].body
 
   const ownKey = context.location[context.location.length - 1]
@@ -71,7 +72,7 @@ const apply = (
 
   // TODO: Make this foolproof.
   const returnKey =
-    parameter === 'return' || ownKey === 'return' ?
+    parameterName === 'return' || ownKey === 'return' ?
       'return with a different key to avoid collision with a stupidly-named parameter'
     : 'return'
 
@@ -86,11 +87,11 @@ const apply = (
             [ownKey]: makeFunctionNode(
               signature,
               () => either.makeRight(expression),
-              option.makeSome(parameter),
+              option.makeSome(parameterName),
               argument => apply(expression, signature, argument, context),
             ),
             // Put the argument in scope.
-            [parameter]: argument,
+            [parameterName]: argument,
             [returnKey]: body,
           }),
       ),

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -191,6 +191,26 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
 
     [
       {
+        0: '@function',
+        1: {
+          parameter: { a: 'a' },
+          body: { 0: '@lookup', 1: { 0: 'a' } },
+        },
+      },
+      {
+        inlinePlz: '(a: a) => :a',
+        inlineSugarFreePrettyPlz:
+          '{ 0: "@function", 1: { parameter: { a: a }, body: { 0: "@lookup", 1: { 0: a } } } }',
+        prettyPlz: '(a: a) => :a\n',
+        sugarFreePrettyPlz:
+          '{\n  0: "@function"\n  1: {\n    parameter: {\n      a: a\n    }\n    body: {\n      0: "@lookup"\n      1: {\n        0: a\n      }\n    }\n  }\n}\n',
+        prettyJson:
+          '{\n  "0": "@function",\n  "1": {\n    "parameter": {\n      "a": "a"\n    },\n    "body": {\n      "0": "@lookup",\n      "1": {\n        "0": "a"\n      }\n    }\n  }\n}\n',
+      },
+    ],
+
+    [
+      {
         0: '@apply',
         1: {
           function: {

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -453,20 +453,41 @@ const trailingInfixTokens = oneOrMore(
   ),
 )
 
+// (a: :integer.type) => :a + 1
+const typedFunctionParameter: Parser<Molecule> = surroundedByParentheses(
+  map(
+    sequence([
+      atom,
+      optionalTrivia,
+      colon,
+      optionalTrivia,
+      lazy(() => expression),
+    ]),
+    ([name, _trivia1, _colon, _trivia2, type]) => ({ [name]: type }),
+  ),
+)
+
+const functionParameter: Parser<Atom | Molecule> = oneOf([
+  typedFunctionParameter,
+  atom,
+])
+
 // a => :b
 // a => {}
 // a => (b => c => :d)
 // a => b => c => d
 // a => 1 + 1
+// (a: :integer.type) => :a + 1
+// (a: :integer.type) => (b: :integer.type) => :a + :b
 const precededByAtomThenFunctionArrow = map(
   sequence([
-    atom,
+    functionParameter,
     trivia,
     functionArrow,
     trivia,
     zeroOrMore(
       map(
-        sequence([atom, trivia, functionArrow, trivia]),
+        sequence([functionParameter, trivia, functionArrow, trivia]),
         ([parameter, _trivia1, _arrow, _trivia2]) => parameter,
       ),
     ),

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -24,6 +24,7 @@ export {
 } from './semantics/expressions/expression-utilities.js'
 export {
   getParameterName,
+  getParameterTypeAnnotation,
   makeFunctionExpression,
   readFunctionExpression,
   type FunctionExpression,

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -23,6 +23,7 @@ export {
   stringifyKeyForEndUser,
 } from './semantics/expressions/expression-utilities.js'
 export {
+  getParameterName,
   makeFunctionExpression,
   readFunctionExpression,
   type FunctionExpression,

--- a/src/language/semantics/expressions/function-expression.ts
+++ b/src/language/semantics/expressions/function-expression.ts
@@ -2,7 +2,11 @@ import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
-import { makeObjectNode, type ObjectNode } from '../object-node.js'
+import {
+  isObjectNode,
+  makeObjectNode,
+  type ObjectNode,
+} from '../object-node.js'
 import { serialize, type SemanticGraph } from '../semantic-graph.js'
 import {
   asSemanticGraph,
@@ -12,7 +16,7 @@ import {
 export type FunctionExpression = ObjectNode & {
   readonly 0: '@function'
   readonly 1: {
-    readonly parameter: Atom
+    readonly parameter: Atom | ObjectNode
     readonly body: SemanticGraph
   }
 }
@@ -24,10 +28,15 @@ export const readFunctionExpression = (
     either.flatMap(
       readArgumentsFromExpression(node, ['parameter', 'body']),
       ([parameter, body]): Either<ElaborationError, FunctionExpression> =>
-        typeof parameter !== 'string' ?
+        typeof parameter !== 'string' && !isObjectNode(parameter) ?
           either.makeLeft({
             kind: 'invalidExpression',
-            message: 'parameter name must be an atom',
+            message: 'parameter must be an atom or an object',
+          })
+        : isObjectNode(parameter) && Object.keys(parameter).length !== 1 ?
+          either.makeLeft({
+            kind: 'invalidExpression',
+            message: 'typed parameter object must contain exactly one property',
           })
         : either.map(serialize(body), body =>
             makeFunctionExpression(parameter, asSemanticGraph(body)),
@@ -39,7 +48,7 @@ export const readFunctionExpression = (
     })
 
 export const makeFunctionExpression = (
-  parameter: Atom,
+  parameter: Atom | ObjectNode,
   body: SemanticGraph,
 ): FunctionExpression =>
   makeObjectNode({
@@ -49,3 +58,17 @@ export const makeFunctionExpression = (
       body,
     }),
   })
+
+export const getParameterName = (expression: FunctionExpression): Atom => {
+  if (typeof expression[1].parameter === 'string') {
+    return expression[1].parameter
+  } else {
+    const parameterName = Object.keys(expression[1].parameter)[0]
+    if (parameterName === undefined) {
+      throw new Error(
+        '@function parameter object did not contain any properties. This is a bug!',
+      )
+    }
+    return parameterName
+  }
+}

--- a/src/language/semantics/expressions/function-expression.ts
+++ b/src/language/semantics/expressions/function-expression.ts
@@ -1,4 +1,5 @@
 import either, { type Either } from '@matt.kantor/either'
+import option, { type Option } from '@matt.kantor/option'
 import type { ElaborationError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
@@ -70,5 +71,22 @@ export const getParameterName = (expression: FunctionExpression): Atom => {
       )
     }
     return parameterName
+  }
+}
+
+export const getParameterTypeAnnotation = (
+  expression: FunctionExpression,
+): Option<SemanticGraph> => {
+  const parameter = expression[1].parameter
+  if (typeof parameter === 'string') {
+    return option.none
+  } else {
+    const typeAnnotation = parameter[getParameterName(expression)]
+    if (typeAnnotation === undefined) {
+      throw new Error(
+        '@function parameter object did not contain expected key. This is a bug!',
+      )
+    }
+    return option.makeSome(typeAnnotation)
   }
 }

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -20,7 +20,10 @@ import {
   readArgumentsFromExpression,
   stringifyKeyForEndUser,
 } from './expression-utilities.js'
-import { readFunctionExpression } from './function-expression.js'
+import {
+  getParameterName,
+  readFunctionExpression,
+} from './function-expression.js'
 import { makeIndexExpression } from './index-expression.js'
 
 export type LookupExpression = ObjectNode & {
@@ -137,7 +140,7 @@ export const lookup = ({
           // parameter.
           if (
             either.isRight(parentFunctionResult) &&
-            parentFunctionResult.value[1].parameter === key
+            getParameterName(parentFunctionResult.value) === key
           ) {
             // Keep an unelaborated `@lookup` around for resolution when the
             // `@function` is called.

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -182,24 +182,22 @@ export const serialize = (
       function: node => serializeFunctionNode(node),
       object: node => serializeObjectNode(node),
       typeSymbol: node =>
-        either.makeRight(
-          serialize(
-            makeIndexExpression({
-              query: makeObjectNode({ 0: 'type' }),
-              object: (() => {
-                switch (node) {
-                  case atomTypeSymbol:
-                    return makeLookupExpression('atom')
-                  case integerTypeSymbol:
-                    return makeLookupExpression('integer')
-                  case naturalNumberTypeSymbol:
-                    return makeLookupExpression('natural_number')
-                  case somethingTypeSymbol:
-                    return makeLookupExpression('something')
-                }
-              })(),
-            }),
-          ),
+        serialize(
+          makeIndexExpression({
+            query: makeObjectNode({ 0: 'type' }),
+            object: (() => {
+              switch (node) {
+                case atomTypeSymbol:
+                  return makeLookupExpression('atom')
+                case integerTypeSymbol:
+                  return makeLookupExpression('integer')
+                case naturalNumberTypeSymbol:
+                  return makeLookupExpression('natural_number')
+                case somethingTypeSymbol:
+                  return makeLookupExpression('something')
+              }
+            })(),
+          }),
         ),
     }),
     withPhantomData<Serialized & Canonicalized>(),

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -23,7 +23,10 @@ import {
   type SemanticGraph,
 } from '../../semantics.js'
 import { isKeywordExpressionWithArgument } from '../../semantics/expression.js'
-import { type FunctionExpression } from '../expressions/function-expression.js'
+import {
+  getParameterTypeAnnotation,
+  type FunctionExpression,
+} from '../expressions/function-expression.js'
 import * as types from './prelude-types.js'
 import {
   makeFunctionType,
@@ -322,38 +325,31 @@ export const inferType = (
 const getFunctionParameterType = (
   expression: FunctionExpression,
   context: ExpressionContext,
-): Either<Bug, Type> => {
-  if (typeof expression[1].parameter === 'string') {
-    if (
-      isEnclosedInRuntimeExpression(
-        context.program,
-        context.location.slice(0, -2),
-      )
-    ) {
-      return either.makeRight(types.runtimeContext)
-    } else {
-      // Conjure up a fresh type parameter when there is no type annotation. This
-      // gives inference a chance to derive a nice signature, e.g. `a => :a` can
-      // be inferred as a true generic identity function.
-      // TODO: Generalize contextual type inference of un-annotated parameters
-      // (this currently only happens for `@runtime` functions).
-      return either.makeRight(
-        makeTypeParameter(getParameterName(expression), {
-          assignableTo: types.something,
-        }),
-      )
-    }
-  } else {
-    const parameterType = Object.values(expression[1].parameter)[0]
-    return parameterType === undefined ?
-        either.makeLeft({
-          kind: 'bug',
-          message:
-            '@function parameter object did not contain any properties. This is a bug!',
-        })
-      : literalTypeFromSemanticGraph(parameterType)
-  }
-}
+): Either<Bug, Type> =>
+  option.match(getParameterTypeAnnotation(expression), {
+    some: literalTypeFromSemanticGraph,
+    none: _ => {
+      if (
+        isEnclosedInRuntimeExpression(
+          context.program,
+          context.location.slice(0, -2),
+        )
+      ) {
+        return either.makeRight(types.runtimeContext)
+      } else {
+        // Conjure up a fresh type parameter when there is no type annotation. This
+        // gives inference a chance to derive a nice signature, e.g. `a => :a` can
+        // be inferred as a true generic identity function.
+        // TODO: Generalize contextual type inference of un-annotated parameters
+        // (this currently only happens for `@runtime` functions).
+        return either.makeRight(
+          makeTypeParameter(getParameterName(expression), {
+            assignableTo: types.something,
+          }),
+        )
+      }
+    },
+  })
 
 const isEnclosedInRuntimeExpression = (
   program: SemanticGraph,

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -1,6 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
-import type { ElaborationError } from '../../errors.js'
+import type { Bug, ElaborationError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import {
   applyKeyPathToSemanticGraph,
@@ -23,6 +23,7 @@ import {
   type SemanticGraph,
 } from '../../semantics.js'
 import { isKeywordExpressionWithArgument } from '../../semantics/expression.js'
+import { type FunctionExpression } from '../expressions/function-expression.js'
 import * as types from './prelude-types.js'
 import {
   makeFunctionType,
@@ -69,22 +70,19 @@ export const resolveParameterTypes = (
         if (either.isRight(functionResult)) {
           const parameterName = getParameterName(functionResult.value)
           if (!parameterTypes.has(parameterName)) {
-            const parameterType =
-              (
-                isEnclosedInRuntimeExpression(
-                  context.program,
-                  pathToParentScope,
-                )
-              ) ?
-                types.runtimeContext
-                // TODO: Implement syntax for explicit parameter type annotations, as well
-                // as eventually supporting contextual inference of un-annotated parameters.
-              : makeTypeParameter(parameterName, {
-                  assignableTo: types.something,
-                })
-
-            // Side-effect: add the parameter.
-            parameterTypes.set(parameterName, parameterType)
+            const parameterTypeResult = getFunctionParameterType(
+              functionResult.value,
+              {
+                keywordHandlers: context.keywordHandlers,
+                program: context.program,
+                location: currentLocation,
+              },
+            )
+            // Ignore errors here (they should be surfaced elsewhere).
+            if (either.isRight(parameterTypeResult)) {
+              // Side-effect: add the parameter.
+              parameterTypes.set(parameterName, parameterTypeResult.value)
+            }
           }
         }
       }
@@ -114,23 +112,25 @@ export const inferType = (
   // @function: infer return type from the body.
   const functionExpressionResult = readFunctionExpression(node)
   if (either.isRight(functionExpressionResult)) {
-    const parameterName = getParameterName(functionExpressionResult.value)
-
-    // TODO: Implement syntax for explicit parameter type annotations, as well
-    // as eventually supporting contextual inference of un-annotated parameters.
-    const parameterType = makeTypeParameter(parameterName, {
-      assignableTo: types.something,
-    })
-
-    return either.map(
-      inferType(
-        functionExpressionResult.value[1].body,
-        new Map([...parameterTypes, [parameterName, parameterType]]),
-        lookingUpKeys,
-        context,
-      ),
-      returnType =>
-        makeFunctionType('', { parameter: parameterType, return: returnType }),
+    return either.flatMap(
+      getFunctionParameterType(functionExpressionResult.value, context),
+      parameterType =>
+        either.map(
+          inferType(
+            functionExpressionResult.value[1].body,
+            new Map([
+              ...parameterTypes,
+              [getParameterName(functionExpressionResult.value), parameterType],
+            ]),
+            lookingUpKeys,
+            context,
+          ),
+          returnType =>
+            makeFunctionType('', {
+              parameter: parameterType,
+              return: returnType,
+            }),
+        ),
     )
   }
 
@@ -316,6 +316,42 @@ export const inferType = (
     return either.makeRight(makeObjectType('', children))
   } else {
     return literalTypeFromSemanticGraph(node)
+  }
+}
+
+const getFunctionParameterType = (
+  expression: FunctionExpression,
+  context: ExpressionContext,
+): Either<Bug, Type> => {
+  if (typeof expression[1].parameter === 'string') {
+    if (
+      isEnclosedInRuntimeExpression(
+        context.program,
+        context.location.slice(0, -2),
+      )
+    ) {
+      return either.makeRight(types.runtimeContext)
+    } else {
+      // Conjure up a fresh type parameter when there is no type annotation. This
+      // gives inference a chance to derive a nice signature, e.g. `a => :a` can
+      // be inferred as a true generic identity function.
+      // TODO: Generalize contextual type inference of un-annotated parameters
+      // (this currently only happens for `@runtime` functions).
+      return either.makeRight(
+        makeTypeParameter(getParameterName(expression), {
+          assignableTo: types.something,
+        }),
+      )
+    }
+  } else {
+    const parameterType = Object.values(expression[1].parameter)[0]
+    return parameterType === undefined ?
+        either.makeLeft({
+          kind: 'bug',
+          message:
+            '@function parameter object did not contain any properties. This is a bug!',
+        })
+      : literalTypeFromSemanticGraph(parameterType)
   }
 }
 

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -76,6 +76,8 @@ export const resolveParameterTypes = (
                 )
               ) ?
                 types.runtimeContext
+                // TODO: Implement syntax for explicit parameter type annotations, as well
+                // as eventually supporting contextual inference of un-annotated parameters.
               : makeTypeParameter(parameterName, {
                   assignableTo: types.something,
                 })

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -5,6 +5,7 @@ import type { Atom } from '../../parsing.js'
 import {
   applyKeyPathToSemanticGraph,
   containsAnyUnelaboratedNodes,
+  getParameterName,
   isAssignable,
   isExpression,
   isFunctionNode,
@@ -66,7 +67,7 @@ export const resolveParameterTypes = (
       if (lastKey === '1') {
         const functionResult = readFunctionExpression(parentNodeOption.value)
         if (either.isRight(functionResult)) {
-          const parameterName = functionResult.value[1].parameter
+          const parameterName = getParameterName(functionResult.value)
           if (!parameterTypes.has(parameterName)) {
             const parameterType =
               (
@@ -113,18 +114,18 @@ export const inferType = (
   // @function: infer return type from the body.
   const functionExpressionResult = readFunctionExpression(node)
   if (either.isRight(functionExpressionResult)) {
-    const { parameter, body } = functionExpressionResult.value[1]
+    const parameterName = getParameterName(functionExpressionResult.value)
 
     // TODO: Implement syntax for explicit parameter type annotations, as well
     // as eventually supporting contextual inference of un-annotated parameters.
-    const parameterType = makeTypeParameter(parameter, {
+    const parameterType = makeTypeParameter(parameterName, {
       assignableTo: types.something,
     })
 
     return either.map(
       inferType(
-        body,
-        new Map([...parameterTypes, [parameter, parameterType]]),
+        functionExpressionResult.value[1].body,
+        new Map([...parameterTypes, [parameterName, parameterType]]),
         lookingUpKeys,
         context,
       ),
@@ -191,7 +192,10 @@ export const inferType = (
         functionExpressionResult.value[1].body,
         new Map([
           ...parameterTypes,
-          [functionExpressionResult.value[1].parameter, types.runtimeContext],
+          [
+            getParameterName(functionExpressionResult.value),
+            types.runtimeContext,
+          ],
         ]),
         lookingUpKeys,
         context,

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -8,6 +8,7 @@ import { unquotedAtomParser } from '../parsing/atom.js'
 import {
   asSemanticGraph,
   getParameterName,
+  getParameterTypeAnnotation,
   isExpression,
   isSemanticGraph,
   readApplyExpression,
@@ -307,17 +308,55 @@ const unparseSugaredApply = (
 
 const unparseSugaredFunction = (
   expression: FunctionExpression,
-  { unparseAtomOrMolecule }: Context,
+  context: Context,
 ) =>
-  either.flatMap(serializeIfNeeded(expression[1].body), serializedBody =>
-    either.map(unparseAtomOrMolecule('default')(serializedBody), bodyAsString =>
-      [
-        styleText(keyColor, getParameterName(expression)),
-        punctuation(styleText).functionArrow,
-        bodyAsString,
-      ].join(' '),
-    ),
+  either.flatMap(
+    unparseSugaredFunctionParameter(expression, context),
+    parameterAsString =>
+      either.flatMap(serializeIfNeeded(expression[1].body), serializedBody =>
+        either.map(
+          context.unparseAtomOrMolecule('default')(serializedBody),
+          bodyAsString =>
+            [
+              parameterAsString,
+              punctuation(styleText).functionArrow,
+              bodyAsString,
+            ].join(' '),
+        ),
+      ),
   )
+
+const unparseSugaredFunctionParameter = (
+  expression: FunctionExpression,
+  { unparseAtomOrMolecule }: Context,
+): Either<UnserializableValueError, string> => {
+  const parameterName = styleText(keyColor, getParameterName(expression))
+  return option.match(getParameterTypeAnnotation(expression), {
+    none: () => either.makeRight(parameterName),
+    some: typeAnnotation =>
+      either.flatMap(
+        serializeIfNeeded(typeAnnotation),
+        serializedTypeAnnotation =>
+          either.map(
+            unparseAtomOrMolecule('default')(serializedTypeAnnotation),
+            typeAnnotationAsString => {
+              const {
+                openGroupingParenthesis,
+                closeGroupingParenthesis,
+                typeAnnotationColon,
+              } = punctuation(styleText)
+              return openGroupingParenthesis.concat(
+                parameterName,
+                typeAnnotationColon,
+                ' ',
+                typeAnnotationAsString,
+                closeGroupingParenthesis,
+              )
+            },
+          ),
+      ),
+  })
+}
 
 const unparseSugaredIndex = (
   expression: IndexExpression,

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -7,6 +7,7 @@ import type { Atom, Molecule } from '../parsing.js'
 import { unquotedAtomParser } from '../parsing/atom.js'
 import {
   asSemanticGraph,
+  getParameterName,
   isExpression,
   isSemanticGraph,
   readApplyExpression,
@@ -311,7 +312,7 @@ const unparseSugaredFunction = (
   either.flatMap(serializeIfNeeded(expression[1].body), serializedBody =>
     either.map(unparseAtomOrMolecule('default')(serializedBody), bodyAsString =>
       [
-        styleText(keyColor, expression[1].parameter),
+        styleText(keyColor, getParameterName(expression)),
         punctuation(styleText).functionArrow,
         bodyAsString,
       ].join(' '),

--- a/src/language/unparsing/unparsing-utilities.ts
+++ b/src/language/unparsing/unparsing-utilities.ts
@@ -45,4 +45,5 @@ export const punctuation = (styleText: typeof util.styleText) => ({
   signatureArrow: styleText(functionColor, '~>'),
 
   tilde: styleText(checkColor, '~'),
+  typeAnnotationColon: styleText(['dim', checkColor], ':'),
 })


### PR DESCRIPTION
The syntax is `(parameter_name: parameter_type) => …`. Re-using `:` here makes me a bit uneasy[^1], but I fear I've already blown my [language strangeness budget](https://steveklabnik.com/writing/the-language-strangeness-budget/), so I opted for something traditional.

[^1]: Especially if I think ahead to possible parameter destructuring syntax.