### PR TITLE
Remove another hacky workaround in `@apply` type checking

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -593,4 +593,17 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    // `:a` is a lookup of an unannotated parameter, so its inferred type is an
+    // unconstrained type parameter, which is not assignable to `:integer.type`.
+    // If the language eventually gains Hindley–Milner-style inference this
+    // program may become valid (and this test case will need updating).
+    `(a => :integer.add(1)(:a))(1)`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -1,7 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
-  containedTypeParameters,
   containsAnyUnelaboratedNodes,
   getTypesForTypeParameters,
   inferType,
@@ -34,16 +33,6 @@ const checkArgumentType = (
         getTypesForTypeParameters({ parameterType, argumentType }),
       )
       return (
-        (
-          // Skip checking when the argument's inferred type contains type
-          // parameters (e.g. a lookup of an unannotated function parameter,
-          // which `resolveParameterTypes` infers as a type parameter).
-          // TODO: Implement enough type parameter instantiation logic to
-          // eliminate this hack.
-          containedTypeParameters(argumentType).size > 0
-        ) ?
-          either.makeRight(undefined)
-        : (
           isAssignable({
             source: argumentType,
             target: instantiatedParameterType,
@@ -56,7 +45,6 @@ const checkArgumentType = (
               argument,
             )}\` is not assignable to the type \`${showType(parameterType)}\``,
           })
-      )
     },
   )
 


### PR DESCRIPTION
Now that it's possible to type-annotate function parameters, this analysis can be made more correct.