### PR TITLE
Add test coverage for various aspects of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,15 @@ Objects are maps of key/value pairs ("properties"), where keys must be atoms:
 { greeting: "Hello, World!" }
 ```
 
-Properties are delimited by newlines or commas:
+Properties are delimited by newlines or commas; these mean the same thing:
 
 ```plz
-// These mean the same thing:
 {
   a: 1
   b: 2
 }
+```
+```plz
 { a: 1, b: 2 }
 ```
 

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -155,10 +155,12 @@ export type UnionType = {
   >
 }
 
-type SpecificUnionType<Member extends Atom | Exclude<Type, UnionType>> =
-  UnionType & {
-    readonly members: ReadonlySet<Member>
-  }
+type SpecificUnionType<Member extends Atom | Exclude<Type, UnionType>> = Omit<
+  UnionType,
+  'members'
+> & {
+  readonly members: ReadonlySet<Member>
+}
 
 export const makeUnionType = <Member extends Atom | Exclude<Type, UnionType>>(
   name: string,

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -1,0 +1,132 @@
+import either from '@matt.kantor/either'
+import assert from 'node:assert'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import test, { suite } from 'node:test'
+import { parse } from './language/parsing/parser.js'
+
+const repositoryRootDirectory = path.join(import.meta.dirname, '..')
+const readmePath = path.resolve(repositoryRootDirectory, 'README.md')
+
+type CodeBlock = {
+  readonly content: string
+  readonly startingLineNumber: number
+}
+
+type RelativeLink = {
+  readonly target: string
+  readonly lineNumber: number
+}
+
+const lineNumberAtOffset = (source: string, offset: number): number =>
+  source.slice(0, offset).split('\n').length
+
+const fencedCodeBlocks = (
+  source: string,
+  codeBlockLanguage: string,
+): readonly CodeBlock[] => {
+  const fencedCodeBlockPattern = new RegExp(
+    `\`\`\`${RegExp.escape(codeBlockLanguage)}\\n([\\s\\S]*?)\\n\\s*\`\`\``,
+    'g',
+  )
+  return [...source.matchAll(fencedCodeBlockPattern)].map(match => ({
+    content: match[1] ?? '',
+    // The line after the opening fence is where code begins:
+    startingLineNumber: lineNumberAtOffset(source, match.index) + 1,
+  }))
+}
+
+const relativeLinks = (source: string): readonly RelativeLink[] => {
+  return [...source.matchAll(relativeLinkPattern)].map(match => ({
+    target: match[1] ?? '',
+    lineNumber: lineNumberAtOffset(source, match.index),
+  }))
+}
+// This pattern matches links of the form `[text](./path)` or `[text](../path)`:
+const relativeLinkPattern = /\[[^\]]*\]\((\.\.?\/[^)\s]+)\)/g
+
+suite('README.md', async () => {
+  const readmeSource = await fs.readFile(readmePath, { encoding: 'utf-8' })
+
+  await suite('plz code blocks', _ =>
+    fencedCodeBlocks(readmeSource, 'plz').forEach(
+      ({ content, startingLineNumber }) =>
+        test(`parsing code in block at line ${startingLineNumber}`, () =>
+          either.match(parse(content), {
+            right: _ => undefined,
+            left: error =>
+              assert.fail(
+                `block beginning at line ${startingLineNumber} couldn't be parsed: ${error.message}`,
+              ),
+          })),
+    ),
+  )
+
+  await suite('relative links', _ =>
+    relativeLinks(readmeSource).forEach(({ target, lineNumber }) =>
+      test(`resolving ${target} (line ${lineNumber})`, async () => {
+        const [pathPart] = target.split('#')
+        const absolutePath = path.resolve(
+          repositoryRootDirectory,
+          pathPart ?? '',
+        )
+        return assert.doesNotReject(
+          fs.stat(absolutePath),
+          `link target \`${pathPart}\` does not exist`,
+        )
+      }),
+    ),
+  )
+
+  await test('resolving target line range from reserved character sequences link', async () => {
+    const linkPattern =
+      /\[.*reserved.*\]\(\.\/(src\/language\/parsing\/atom\.ts)#L(\d+)-L(\d+)\)/
+    const match = readmeSource.match(linkPattern)
+    assert(match !== null, 'expected the link to exist')
+    const [_, relativePath, linkedStart, linkedEnd] = match
+    const linkedStartingLine = BigInt(linkedStart ?? 'start not found')
+    const linkedEndingLine = BigInt(linkedEnd ?? 'end not found')
+
+    // If I wanted to be robust here I'd actually parse the TypeScript source,
+    // but for now this is good enough.
+
+    const targetFileSourceLines = (
+      await fs.readFile(
+        path.resolve(repositoryRootDirectory, relativePath ?? ''),
+        { encoding: 'utf-8' },
+      )
+    ).split('\n')
+
+    const declarationStartingLineIndex = targetFileSourceLines.findIndex(line =>
+      /^\s*const atomComponentsRequiringQuotation = \[/.test(line),
+    )
+    assert.notDeepEqual(
+      declarationStartingLineIndex,
+      -1,
+      'could not find `atomComponentsRequiringQuotation` declaration in atom.ts',
+    )
+    const declarationStartingLine = BigInt(declarationStartingLineIndex + 1)
+
+    const declarationEndingLineIndex = targetFileSourceLines.findIndex(
+      (line, index) =>
+        index > declarationStartingLineIndex && /^\s*\][^,]*$/.test(line),
+    )
+    assert.notDeepEqual(
+      declarationEndingLineIndex,
+      -1,
+      'could not find the closing `]` for `atomComponentsRequiringQuotation`',
+    )
+    const declarationEndingLine = BigInt(declarationEndingLineIndex + 1)
+
+    assert.deepEqual(
+      linkedStartingLine,
+      declarationStartingLine,
+      `README link starts at L${linkedStartingLine} but the \`atomComponentsRequiringQuotation\` declaration starts at L${declarationStartingLine}`,
+    )
+    assert.deepEqual(
+      linkedEndingLine,
+      declarationEndingLine,
+      `README link ends at L${linkedEndingLine} but the \`atomComponentsRequiringQuotation\` declaration ends at L${declarationEndingLine}`,
+    )
+  })
+})

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "composite": true,
     "exactOptionalPropertyTypes": true,
-    "lib": ["es2023"],
+    "lib": ["es2025"],
     "module": "node16",
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,
     "rootDir": "./src",
     "skipLibCheck": true,
-    "target": "es2023",
+    "target": "es2025",
     "types": ["node"],
     "verbatimModuleSyntax": true
   }


### PR DESCRIPTION
I got tired of manually validating this stuff, especially the link to [reserved character sequences](https://github.com/mkantor/please-lang-prototype/blob/412f60c043c4836227c62a595ef3573217f34c48/src/language/parsing/atom.ts#L38-L63) which is easy to accidentally disrupt when making parser changes.