### PR TITLE
Handle type parameters in union-typed function parameters 

### DIFF
--- a/src/language/semantics/type-system.test.ts
+++ b/src/language/semantics/type-system.test.ts
@@ -9,6 +9,7 @@ import {
   nothing,
   nullType,
   object,
+  option,
   something,
 } from './type-system/prelude-types.js'
 import { showType } from './type-system/show-type.js'
@@ -19,6 +20,7 @@ import {
   makeTypeParameter,
   makeUnionType,
   type Type,
+  type TypeParameter,
   type UnionType,
 } from './type-system/type-formats.js'
 import {
@@ -1372,5 +1374,31 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
     new Map([[A, makeUnionType('', ['specific atom'])]]),
   ],
 
+  [
+    [
+      makeUnionType('', [extendsAnyAtom, object]),
+      makeUnionType('', ['specific atom', object]),
+    ],
+    new Map([
+      [extendsAnyAtom, makeUnionType('specific atom', ['specific atom'])],
+    ]),
+  ],
+
   [[makeUnionType('', [extendsAnyAtom, object]), object], new Map()],
+
+  [[option(A), option(naturalNumber)], new Map([[A, naturalNumber]])],
+
+  [
+    [
+      makeFunctionType('', { parameter: A, return: option(B) }),
+      makeFunctionType('', {
+        parameter: atom,
+        return: option(naturalNumber),
+      }),
+    ],
+    new Map<TypeParameter, Type>([
+      [A, atom],
+      [B, naturalNumber],
+    ]),
+  ],
 ])

--- a/src/language/semantics/type-system.test.ts
+++ b/src/language/semantics/type-system.test.ts
@@ -1361,13 +1361,16 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [[extendsAnyAtom, object], new Map()],
 
-  // TODO: Handle type parameters within unions:
-  //
-  // [[makeUnionType('', [A, atom]), object], new Map([[A, object]])],
-  //
-  // [[makeUnionType('', [A, atom]), something], new Map([[A, something]])],
-  //
-  // TODO: Which of these is preferable? I believe both are sound.
-  // [[makeUnionType('', [A, atom]), atom], new Map()],
-  // [[makeUnionType('', [A, atom]), atom], new Map([[A, atom]])],
+  [[makeUnionType('', [A, atom]), object], new Map([[A, object]])],
+
+  [[makeUnionType('', [A, atom]), something], new Map([[A, something]])],
+
+  [[makeUnionType('', [A, atom]), atom], new Map([[A, atom]])],
+
+  [
+    [makeUnionType('', [A, object]), makeUnionType('', ['specific atom'])],
+    new Map([[A, makeUnionType('', ['specific atom'])]]),
+  ],
+
+  [[makeUnionType('', [extendsAnyAtom, object]), object], new Map()],
 ])

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -321,6 +321,7 @@ export const getTypesForTypeParameters = ({
             }),
           ])
         : new Map(),
+
       object: parameterType =>
         argumentType.kind === 'object' ?
           Object.entries(parameterType.children)
@@ -338,7 +339,9 @@ export const getTypesForTypeParameters = ({
               new Map<TypeParameter, Type>(),
             )
         : new Map(),
+
       opaque: _ => new Map(),
+
       parameter: parameterType =>
         (
           isAssignable({
@@ -348,30 +351,51 @@ export const getTypesForTypeParameters = ({
         ) ?
           new Map([[parameterType, argumentType]])
         : new Map(),
-      union: parameterType =>
-        // For each member which could accept `argumentType` (with its type
-        // parameters replaced by constraints), recurse to collect bindings
-        // implied by that member.
-        [...parameterType.members]
-          .map(
-            (member): ReadonlyMap<TypeParameter, Type> =>
-              (
-                typeof member !== 'string' &&
-                isAssignable({
-                  source: argumentType,
-                  target: replaceAllTypeParametersWithTheirConstraints(member),
-                })
-              ) ?
-                getTypesForTypeParameters({
-                  parameterType: member,
-                  argumentType,
-                })
-              : new Map(),
+
+      union: parameterType => {
+        const argumentCandidates = [
+          argumentType,
+          ...(argumentType.kind === 'union' ?
+            // These additional candidates enable alignment between parameter
+            // unions and argument unions. For example, given a `parameterType`
+            // of `(A <: atom) | object` and an `argumentType` of `atom |
+            // object`, `A` should be inferred as `atom`.
+            [...argumentType.members].flatMap((member): readonly Type[] =>
+              typeof member === 'string' ?
+                [makeUnionType(member, [member])]
+              : [member],
+            )
+          : []),
+        ] as const
+        return [...parameterType.members]
+          .flatMap(parameterMember =>
+            typeof parameterMember === 'string' ?
+              []
+            : argumentCandidates
+                .filter(candidate =>
+                  isAssignable({
+                    source: candidate,
+                    target:
+                      replaceAllTypeParametersWithTheirConstraints(
+                        parameterMember,
+                      ),
+                  }),
+                )
+                .flatMap(candidate => [
+                  ...getTypesForTypeParameters({
+                    parameterType: parameterMember,
+                    argumentType: candidate,
+                  }),
+                ]),
           )
           .reduce(
-            (types, typesFromMember) => new Map([...typesFromMember, ...types]),
+            (types, [parameter, type]) =>
+              types.has(parameter) ? types : (
+                new Map([...types, [parameter, type]])
+              ),
             new Map<TypeParameter, Type>(),
-          ),
+          )
+      },
     })
   }
 }

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -348,11 +348,30 @@ export const getTypesForTypeParameters = ({
         ) ?
           new Map([[parameterType, argumentType]])
         : new Map(),
-      // TODO: Handle type parameters in unions. This case will have to check
-      // type parameter constraints (e.g. if `parameterType` is `(A <: object) |
-      // atom`, if `argumentType` is an object type then `A` should be
-      // substituted with that type, but not if `argumentType` is an atom type).
-      union: _ => new Map(),
+      union: parameterType =>
+        // For each member which could accept `argumentType` (with its type
+        // parameters replaced by constraints), recurse to collect bindings
+        // implied by that member.
+        [...parameterType.members]
+          .map(
+            (member): ReadonlyMap<TypeParameter, Type> =>
+              (
+                typeof member !== 'string' &&
+                isAssignable({
+                  source: argumentType,
+                  target: replaceAllTypeParametersWithTheirConstraints(member),
+                })
+              ) ?
+                getTypesForTypeParameters({
+                  parameterType: member,
+                  argumentType,
+                })
+              : new Map(),
+          )
+          .reduce(
+            (types, typesFromMember) => new Map([...typesFromMember, ...types]),
+            new Map<TypeParameter, Type>(),
+          ),
     })
   }
 }


### PR DESCRIPTION
This is relevant for both inference and `@apply` checks.