### PR TITLE
Use `option` in the standard library

### DIFF
--- a/examples/.snapshot
+++ b/examples/.snapshot
@@ -3,7 +3,7 @@ exports[`examples > fibonacci.plz > --input=-1 > stderr 1`] = `
 `;
 
 exports[`examples > fibonacci.plz > --input=-1 > stdout 1`] = `
-"--input must be a natural number"
+"missing or invalid --input argument (must be a natural number)"
 
 `;
 
@@ -48,13 +48,13 @@ exports[`examples > fibonacci.plz > --input=\"not a number\" > stderr 1`] = `
 `;
 
 exports[`examples > fibonacci.plz > --input=\"not a number\" > stdout 1`] = `
-"--input must be a natural number"
+"missing or invalid --input argument (must be a natural number)"
 
 `;
 
 exports[`examples > fibonacci.plz > roundtripped syntax tree 1`] = `
 {
-  fibonacci: (n: :integer.type) => @if {
+  fibonacci: (n: :natural_number.type) => @if {
     (:n < 2)
     then: :n
     else: :fibonacci(:n - 1) + :fibonacci(:n - 2)
@@ -62,13 +62,9 @@ exports[`examples > fibonacci.plz > roundtripped syntax tree 1`] = `
   input: @runtime {
     context => :context.arguments.lookup(input)
   }
-  output: :input match {
-    none: _ => "missing --input argument"
-    some: input => @if {
-      :natural_number.is(:input)
-      then: :fibonacci(:input)
-      else: "--input must be a natural number"
-    }
+  output: :input option.flat_map :natural_number.from match {
+    none: _ => "missing or invalid --input argument (must be a natural number)"
+    some: :fibonacci
   }
 }.output
 
@@ -79,7 +75,7 @@ exports[`examples > fibonacci.plz > stderr 1`] = `
 `;
 
 exports[`examples > fibonacci.plz > stdout 1`] = `
-"missing --input argument"
+"missing or invalid --input argument (must be a natural number)"
 
 `;
 
@@ -88,7 +84,7 @@ exports[`examples > fizzbuzz.plz > --input=-1 > stderr 1`] = `
 `;
 
 exports[`examples > fizzbuzz.plz > --input=-1 > stdout 1`] = `
-"--input must be a natural number"
+"missing or invalid --input argument (must be a natural number)"
 
 `;
 
@@ -146,7 +142,7 @@ exports[`examples > fizzbuzz.plz > --input=\"not a number\" > stderr 1`] = `
 `;
 
 exports[`examples > fizzbuzz.plz > --input=\"not a number\" > stdout 1`] = `
-"--input must be a natural number"
+"missing or invalid --input argument (must be a natural number)"
 
 `;
 
@@ -181,13 +177,9 @@ exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
   input: @runtime {
     context => :context.arguments.lookup(input)
   }
-  output: :input match {
-    none: _ => "missing --input argument"
-    some: input => @if {
-      :natural_number.is(:input)
-      then: :fizzbuzz(:input)
-      else: "--input must be a natural number"
-    }
+  output: :input option.flat_map :natural_number.from match {
+    none: _ => "missing or invalid --input argument (must be a natural number)"
+    some: :fizzbuzz
   }
 }.output
 
@@ -198,7 +190,7 @@ exports[`examples > fizzbuzz.plz > stderr 1`] = `
 `;
 
 exports[`examples > fizzbuzz.plz > stdout 1`] = `
-"missing --input argument"
+"missing or invalid --input argument (must be a natural number)"
 
 `;
 

--- a/examples/fibonacci.plz
+++ b/examples/fibonacci.plz
@@ -1,5 +1,5 @@
 {
-  fibonacci: (n: :integer.type) =>
+  fibonacci: (n: :natural_number.type) =>
     @if {
       :n < 2
       then: :n
@@ -11,12 +11,10 @@
     :context.arguments.lookup(input)
   }
 
-  output: :input match {
-    none: _ => "missing --input argument"
-    some: input => @if {
-      :natural_number.is(:input)
-      then: :fibonacci(:input)
-      else: "--input must be a natural number"
+  output: :input
+    option.flat_map :natural_number.from
+    match {
+      none: _ => "missing or invalid --input argument (must be a natural number)"
+      some: :fibonacci
     }
-  }
 }.output

--- a/examples/fizzbuzz.plz
+++ b/examples/fizzbuzz.plz
@@ -28,12 +28,10 @@
     :context.arguments.lookup(input)
   }
 
-  output: :input match {
-    none: _ => "missing --input argument"
-    some: input => @if {
-      :natural_number.is(:input)
-      then: :fizzbuzz(:input)
-      else: "--input must be a natural number"
+  output: :input
+    option.flat_map :natural_number.from
+    match {
+      none: _ => "missing or invalid --input argument (must be a natural number)"
+      some: :fizzbuzz
     }
-  }
 }.output

--- a/src/language/semantics/prelude.ts
+++ b/src/language/semantics/prelude.ts
@@ -6,11 +6,13 @@ import { integer } from './stdlib/integer.js'
 import { natural_number } from './stdlib/natural-number.js'
 import { nothing } from './stdlib/nothing.js'
 import { object } from './stdlib/object.js'
+import { option } from './stdlib/option.js'
 import { something } from './stdlib/something.js'
 
 export const prelude = makeObjectNode({
   ...globalFunctions,
   atom: makeObjectNode(atom),
+  option: makeObjectNode(option),
   boolean: makeObjectNode(boolean),
   integer: makeObjectNode(integer),
   natural_number: makeObjectNode(natural_number),

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -1,7 +1,11 @@
 import either from '@matt.kantor/either'
+import { makeObjectNode } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType } from '../type-system/type-formats.js'
-import { preludeFunctionArity2 } from './stdlib-utilities.js'
+import {
+  preludeFunctionArity1,
+  preludeFunctionArity2,
+} from './stdlib-utilities.js'
 
 export const atom = {
   type: types.atom.symbol,
@@ -68,6 +72,20 @@ export const atom = {
         })
       }
     },
+  ),
+
+  from: preludeFunctionArity1(
+    ['atom', 'from'],
+    {
+      parameter: types.something,
+      return: types.option(types.atom),
+    },
+    argument =>
+      either.makeRight(
+        typeof argument === 'string' ?
+          makeObjectNode({ tag: 'some', value: argument })
+        : makeObjectNode({ tag: 'none', value: {} }),
+      ),
   ),
 
   prepend: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/boolean.ts
+++ b/src/language/semantics/stdlib/boolean.ts
@@ -26,6 +26,20 @@ export const boolean = {
     argument => either.makeRight(nodeIsBoolean(argument) ? 'true' : 'false'),
   ),
 
+  from: preludeFunctionArity1(
+    ['boolean', 'from'],
+    {
+      parameter: types.something,
+      return: types.option(types.boolean),
+    },
+    argument =>
+      either.makeRight(
+        nodeIsBoolean(argument) ?
+          makeObjectNode({ tag: 'some', value: argument })
+        : makeObjectNode({ tag: 'none', value: {} }),
+      ),
+  ),
+
   not: preludeFunctionArity1(
     ['boolean', 'not'],
     {

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -1,4 +1,5 @@
 import either from '@matt.kantor/either'
+import { makeObjectNode } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType, makeUnionType } from '../type-system/type-formats.js'
 import {
@@ -107,6 +108,27 @@ export const integer = {
         ) ?
           'true'
         : 'false',
+      ),
+  ),
+
+  from: preludeFunctionArity1(
+    ['integer', 'from'],
+    {
+      parameter: types.something,
+      return: types.option(types.integer),
+    },
+    argument =>
+      either.makeRight(
+        (
+          typeof argument === 'string' &&
+            types.integer.isAssignableFrom({
+              name: '',
+              kind: 'union',
+              members: new Set([argument]),
+            })
+        ) ?
+          makeObjectNode({ tag: 'some', value: argument })
+        : makeObjectNode({ tag: 'none', value: {} }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/natural-number.ts
+++ b/src/language/semantics/stdlib/natural-number.ts
@@ -1,4 +1,5 @@
 import either from '@matt.kantor/either'
+import { makeObjectNode } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType, makeUnionType } from '../type-system/type-formats.js'
 import {
@@ -27,6 +28,27 @@ export const natural_number = {
         ) ?
           'true'
         : 'false',
+      ),
+  ),
+
+  from: preludeFunctionArity1(
+    ['natural_number', 'from'],
+    {
+      parameter: types.something,
+      return: types.option(types.naturalNumber),
+    },
+    argument =>
+      either.makeRight(
+        (
+          typeof argument === 'string' &&
+            types.naturalNumber.isAssignableFrom({
+              name: '',
+              kind: 'union',
+              members: new Set([argument]),
+            })
+        ) ?
+          makeObjectNode({ tag: 'some', value: argument })
+        : makeObjectNode({ tag: 'none', value: {} }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -2,7 +2,10 @@ import either from '@matt.kantor/either'
 import { isObjectNode, makeObjectNode } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType } from '../type-system/type-formats.js'
-import { preludeFunctionArity2 } from './stdlib-utilities.js'
+import {
+  preludeFunctionArity1,
+  preludeFunctionArity2,
+} from './stdlib-utilities.js'
 
 export const object = {
   type: makeObjectNode({}),
@@ -41,6 +44,20 @@ export const object = {
         })
       }
     },
+  ),
+
+  from: preludeFunctionArity1(
+    ['object', 'from'],
+    {
+      parameter: types.something,
+      return: types.option(types.object),
+    },
+    argument =>
+      either.makeRight(
+        isObjectNode(argument) ?
+          makeObjectNode({ tag: 'some', value: argument })
+        : makeObjectNode({ tag: 'none', value: {} }),
+      ),
   ),
 
   from_property: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/option.ts
+++ b/src/language/semantics/stdlib/option.ts
@@ -1,0 +1,145 @@
+import either from '@matt.kantor/either'
+import { makeUnionExpression } from '../expressions/union-expression.js'
+import { isFunctionNode } from '../function-node.js'
+import {
+  isObjectNode,
+  makeObjectNode,
+  type ObjectNode,
+} from '../object-node.js'
+import { type SemanticGraph } from '../semantic-graph.js'
+import { types } from '../type-system.js'
+import {
+  makeFunctionType,
+  makeTypeParameter,
+} from '../type-system/type-formats.js'
+import {
+  preludeFunctionArity1,
+  preludeFunctionArity2,
+} from './stdlib-utilities.js'
+
+const A = makeTypeParameter('a', { assignableTo: types.something })
+const B = makeTypeParameter('b', { assignableTo: types.something })
+
+export const option = {
+  type: preludeFunctionArity1(
+    ['option', 'type'],
+    { parameter: A, return: types.option(A) },
+    value =>
+      either.makeRight(
+        makeUnionExpression(
+          makeObjectNode({
+            0: makeObjectNode({
+              tag: 'some',
+              value,
+            }),
+            1: makeObjectNode({
+              tag: 'none',
+              value: {},
+            }),
+          }),
+        ),
+      ),
+  ),
+
+  none: makeObjectNode({ tag: 'none', value: makeObjectNode({}) }),
+
+  make_some: preludeFunctionArity1(
+    ['option', 'make_some'],
+    { parameter: A, return: types.option(A) },
+    value => either.makeRight(makeObjectNode({ tag: 'some', value })),
+  ),
+
+  // (a ~> b) ~> option(a) ~> option(b)
+  map: preludeFunctionArity2(
+    ['option', 'map'],
+    {
+      parameter: makeFunctionType('', { parameter: A, return: B }),
+      return: makeFunctionType('', {
+        parameter: types.option(A),
+        return: types.option(B),
+      }),
+    },
+    transform => {
+      if (!isFunctionNode(transform)) {
+        return either.makeLeft({
+          kind: 'typeMismatch',
+          message: '`map` expected a function',
+        })
+      } else {
+        return either.makeRight(optionValue => {
+          if (!nodeIsOptionLike(optionValue)) {
+            return either.makeLeft({
+              kind: 'typeMismatch',
+              message: '`map` expected an option',
+            })
+          } else if (optionValue.tag === 'none') {
+            return either.makeRight(optionValue)
+          } else {
+            return either.map(transform(optionValue.value), transformedValue =>
+              makeObjectNode({ tag: 'some', value: transformedValue }),
+            )
+          }
+        })
+      }
+    },
+  ),
+
+  // (a ~> option(b)) ~> option(a) ~> option(b)
+  flat_map: preludeFunctionArity2(
+    ['option', 'flat_map'],
+    {
+      parameter: makeFunctionType('', {
+        parameter: A,
+        return: types.option(B),
+      }),
+      return: makeFunctionType('', {
+        parameter: types.option(A),
+        return: types.option(B),
+      }),
+    },
+    transform => {
+      if (!isFunctionNode(transform)) {
+        return either.makeLeft({
+          kind: 'typeMismatch',
+          message: '`flat_map` expected a function',
+        })
+      } else {
+        return either.makeRight(optionValue => {
+          if (!nodeIsOptionLike(optionValue)) {
+            return either.makeLeft({
+              kind: 'typeMismatch',
+              message: '`flat_map` expected an option',
+            })
+          } else if (optionValue.tag === 'none') {
+            return either.makeRight(optionValue)
+          } else {
+            return either.flatMap(
+              transform(optionValue.value),
+              transformedValue => {
+                if (!nodeIsOptionLike(transformedValue)) {
+                  return either.makeLeft({
+                    kind: 'typeMismatch',
+                    message: '`flat_map` function did not return an option',
+                  })
+                } else {
+                  return either.makeRight(transformedValue)
+                }
+              },
+            )
+          }
+        })
+      }
+    },
+  ),
+} as const
+
+type OptionLikeNode = ObjectNode & {
+  readonly tag: 'some' | 'none'
+  readonly value: SemanticGraph
+}
+
+// TODO: Consider using a type system assignability check instead.
+const nodeIsOptionLike = (node: SemanticGraph): node is OptionLikeNode =>
+  isObjectNode(node) &&
+  (node['tag'] === 'some' || node['tag'] === 'none') &&
+  node['value'] !== undefined

--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -1,4 +1,5 @@
 import optionAdt from '@matt.kantor/option'
+import { showType } from './show-type.js'
 import {
   makeFunctionType,
   makeObjectType,
@@ -79,7 +80,7 @@ export const typesBySymbol = {
 }
 
 export const option = (value: Type) =>
-  makeUnionType('option', [
+  makeUnionType(`option(${showType(value)})`, [
     makeObjectType('some', {
       tag: makeUnionType('', ['some']),
       value,


### PR DESCRIPTION
Adds an `option` module to the prelude, `from` constructors for other data types (to safely narrow to them from arbitrary types), and update the fizzbuzz & fibonacci examples to use these shiny new toys.