### PR TITLE
Add static analysis in `@index` handler 

### DIFF
--- a/examples/.snapshot
+++ b/examples/.snapshot
@@ -149,7 +149,10 @@ exports[`examples > fizzbuzz.plz > --input=\"not a number\" > stdout 1`] = `
 exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
 {
   fizzbuzz: (limit: :natural_number.type) => {
-    fizzbuzz_internal: state => @if {
+    fizzbuzz_internal: (state: {
+      current: :natural_number.type
+      output: :object.type
+    }) => @if {
       (:state.current > :limit)
       then: :state.output
       else: :fizzbuzz_internal({
@@ -166,7 +169,7 @@ exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
             }
           }
         } object.from_property :state.current)
-        current: :state.current + 1
+        current: :state.current + 1 assume :natural_number.type
       })
     }
     internal_return: :fizzbuzz_internal({

--- a/examples/fizzbuzz.plz
+++ b/examples/fizzbuzz.plz
@@ -1,6 +1,6 @@
 {
   fizzbuzz: (limit: :natural_number.type) => {
-    fizzbuzz_internal: state => @if {
+    fizzbuzz_internal: (state: { current: :natural_number.type, output: :object.type }) => @if {
       :state.current > :limit
       then: :state.output
       else: :fizzbuzz_internal({
@@ -17,7 +17,7 @@
             }
           }
         })
-        current: :state.current + 1
+        current: (:state.current + 1) assume :natural_number.type
       })
     }
     internal_return: :fizzbuzz_internal({ current: 1, output: {} })

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -665,7 +665,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     either.makeRight('it works'),
   ],
   [
-    `(inner => @if {
+    `((inner: { a: :boolean.type }) => @if {
       :inner.a
       then: "it works"
       else: { @panic }

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -640,4 +640,67 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `{ a: {}, :a.non_existent_property }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `a => :a.non_existent_property`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ a: {}, @if { @runtime { _ => true }, :a.non_existent_property, oops } }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ a: { b: {} }, :a.b.non_existent_property }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ a: "not an object", :a.non_existent_property }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ a: { b: 1 }, :a.non_existent_property.another_non_existent_property }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ a: :identity, :a.non_existent_property }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.test.ts
@@ -118,7 +118,7 @@ elaborationSuite('@apply', [
         function: {
           0: '@function',
           1: {
-            0: 'x',
+            0: { x: { a: 'it works' } },
             1: {
               0: '@index',
               1: {

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -3,42 +3,69 @@ import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
   applyKeyPathToSemanticGraph,
+  applyKeyPathToType,
   containsAnyUnelaboratedNodes,
+  inferType,
   keyPathFromObjectNodeOrMolecule,
   readIndexExpression,
+  resolveParameterTypes,
+  showType,
   stringifyKeyPathForEndUser,
   type Expression,
   type ExpressionContext,
+  type KeyPath,
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 
+const checkKeyPathExistsInType = (
+  object: SemanticGraph,
+  keyPath: KeyPath,
+  context: ExpressionContext,
+): Either<ElaborationError, undefined> =>
+  either.flatMap(
+    inferType(object, resolveParameterTypes(context), new Set(), context),
+    objectType => {
+      const typeAtKeyPath = applyKeyPathToType(objectType, keyPath)
+      return (
+          typeAtKeyPath.kind === 'union' && typeAtKeyPath.members.size === 0
+        ) ?
+          either.makeLeft({
+            kind: 'typeMismatch',
+            message: `property \`${stringifyKeyPathForEndUser(
+              keyPath,
+            )}\` does not exist on type \`${showType(objectType)}\``,
+          })
+        : either.makeRight(undefined)
+    },
+  )
+
 export const indexKeywordHandler: KeywordHandler = (
   expression: Expression,
-  _context: ExpressionContext,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   either.flatMap(readIndexExpression(expression), indexExpression =>
     either.flatMap(
       keyPathFromObjectNodeOrMolecule(indexExpression[1].query),
       keyPath => {
-        if (containsAnyUnelaboratedNodes(indexExpression[1].object)) {
-          // The object isn't ready, so keep the @index unelaborated.
-          return either.makeRight(indexExpression)
-        } else {
-          return option.match(
-            applyKeyPathToSemanticGraph(indexExpression[1].object, keyPath),
-            {
-              none: () =>
-                either.makeLeft({
-                  kind: 'invalidExpression',
-                  message: `property \`${stringifyKeyPathForEndUser(
-                    keyPath,
-                  )}\` not found`,
-                }),
-              some: either.makeRight,
-            },
-          )
-        }
+        const object = indexExpression[1].object
+        return either.flatMap(
+          checkKeyPathExistsInType(object, keyPath, context),
+          _ =>
+            containsAnyUnelaboratedNodes(object) ?
+              // The object isn't ready, so keep the @index unelaborated.
+              either.makeRight(indexExpression)
+            : option.match(applyKeyPathToSemanticGraph(object, keyPath), {
+                none: () =>
+                  either.makeLeft({
+                    kind: 'typeMismatch',
+                    message: `property \`${stringifyKeyPathForEndUser(
+                      keyPath,
+                    )}\` not found`,
+                  }),
+                some: either.makeRight,
+              }),
+        )
       },
     ),
   )

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -89,6 +89,7 @@ export {
   type SemanticGraph,
 } from './semantics/semantic-graph.js'
 export {
+  applyKeyPathToType,
   containedTypeParameters,
   getTypesForTypeParameters,
   inferType,

--- a/src/language/semantics/expressions/index-expression.ts
+++ b/src/language/semantics/expressions/index-expression.ts
@@ -13,7 +13,7 @@ import { readArgumentsFromExpression } from './expression-utilities.js'
 export type IndexExpression = ObjectNode & {
   readonly 0: '@index'
   readonly 1: {
-    readonly object: ObjectNode
+    readonly object: SemanticGraph
     readonly query: ObjectNode
   }
 }
@@ -25,12 +25,7 @@ export const readIndexExpression = (
     either.flatMap(
       readArgumentsFromExpression(node, ['object', 'query']),
       ([object, query]) => {
-        if (!isObjectNode(object)) {
-          return either.makeLeft({
-            kind: 'invalidExpression',
-            message: 'object must be an object',
-          })
-        } else if (!isObjectNode(query)) {
+        if (!isObjectNode(query)) {
           return either.makeLeft({
             kind: 'invalidExpression',
             message: 'query must be an object',
@@ -53,7 +48,7 @@ export const makeIndexExpression = ({
   object,
 }: {
   readonly query: ObjectNode
-  readonly object: ObjectNode
+  readonly object: SemanticGraph
 }): IndexExpression =>
   makeObjectNode({
     0: '@index',


### PR DESCRIPTION
Forbid indexing with keys that aren't statically-known to be present in the type, e.g. `a => :a.b` is now a type error