### PR TITLE
Make all `@function`s implicitly generic

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -724,4 +724,16 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [`((a: :integer.type) => :a)(42) ~ 42`, success('42')],
+
+  [
+    `{
+      swap: (parameters: { :something.type, :something.type }) =>
+        { :parameters.1, :parameters.0 }
+    }.swap({ a, b }) ~ { b, a }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
@@ -62,12 +62,18 @@ elaborationSuite('@function', [
         }),
       )
       const parameterType = elaboratedFunction.value.signature.parameter
-      if (parameterType.kind !== 'union') {
+      if (parameterType.kind !== 'parameter') {
         assert.fail(
-          `expected a union type, but got a ${parameterType.kind} type`,
+          `expected a type parameter, but got a ${parameterType.kind} type`,
         )
       } else {
-        assert.deepEqual(parameterType.members, new Set(['an arbitrary type']))
+        assert.deepEqual(parameterType.name, 'x')
+        const constraint = parameterType.constraint.assignableTo
+        assert.deepEqual(constraint.kind, 'union')
+        assert.deepEqual(
+          constraint.kind === 'union' ? constraint.members : undefined,
+          new Set(['an arbitrary type']),
+        )
         assert.deepEqual(
           elaboratedFunction.value.signature.return,
           parameterType,

--- a/src/language/semantics/type-system.test.ts
+++ b/src/language/semantics/type-system.test.ts
@@ -25,6 +25,7 @@ import {
 } from './type-system/type-formats.js'
 import {
   applyKeyPathToType,
+  genericizeFunctionParameterAnnotation,
   getTypesForTypeParameters,
 } from './type-system/type-utilities.js'
 
@@ -1401,4 +1402,61 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
       [B, naturalNumber],
     ]),
   ],
+])
+
+const genericizeParameterAnnotationSuite = testCases(
+  ([parameterName, annotation]: readonly [
+    parameterName: string,
+    annotation: Type,
+  ]) =>
+    // I'd prefer to check the actual `Type` rather than its string
+    // representation, but since synthesized type parameters contain fresh
+    // symbols they can't be structurally compared to `Type`s instantiated here.
+    // TODO: Consider traversing the returned type to substitute symbols.
+    showType(genericizeFunctionParameterAnnotation(parameterName, annotation)),
+  ([parameterName, annotation]) =>
+    `genericizing \`${parameterName}: ${showType(annotation)}\``,
+)
+
+genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
+  [['a', atom], '(a <: atom)'],
+
+  [['a', integer], '(a <: integer)'],
+
+  [['a', makeUnionType('', ['foo', 'bar'])], '(a <: ("foo" | "bar"))'],
+
+  [['a', something], 'a'],
+
+  [
+    [
+      'x',
+      makeObjectType('', {
+        a: integer,
+        b: atom,
+      }),
+    ],
+    '{ a: (x.a <: integer), b: (x.b <: atom) }',
+  ],
+
+  [
+    [
+      'x',
+      makeObjectType('', {
+        a: makeObjectType('', { b: atom }),
+      }),
+    ],
+    '{ a: { b: (x.a.b <: atom) } }',
+  ],
+
+  [
+    [
+      'x',
+      makeObjectType('', {
+        callback: makeFunctionType('', { parameter: atom, return: integer }),
+      }),
+    ],
+    '{ callback: (x.callback.#parameter <: atom) ~> (x.callback.#return <: integer) }',
+  ],
+
+  [['empty', makeObjectType('', {})], '{}'],
 ])

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -32,12 +32,12 @@ import * as types from './prelude-types.js'
 import {
   makeFunctionType,
   makeObjectType,
-  makeTypeParameter,
   makeUnionType,
   type Type,
 } from './type-formats.js'
 import {
   applyKeyPathToType,
+  genericizeFunctionParameterAnnotation,
   getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
   supplyTypeArguments,
@@ -329,13 +329,30 @@ export const inferType = (
   }
 }
 
+/**
+ * Functions are implicitly generic.
+ *
+ * With no explicit parameter annotation, a new type parameter (constrained to
+ * the top type) is created for the function parameter. If there is an
+ * annotation, it's used to create one or more type parameters with constraints
+ * derived from the annotation (see `genericizeFunctionParameterAnnotation` for
+ * specifics).
+ */
 const getFunctionParameterType = (
   expression: FunctionExpression,
   context: ExpressionContext,
 ): Either<Bug, Type> =>
   option.match(getParameterTypeAnnotation(expression), {
-    some: literalTypeFromSemanticGraph,
+    some: annotation =>
+      either.map(literalTypeFromSemanticGraph(annotation), annotationType =>
+        genericizeFunctionParameterAnnotation(
+          getParameterName(expression),
+          annotationType,
+        ),
+      ),
     none: _ => {
+      // TODO: Generalize contextual type inference of un-annotated parameters
+      // (it currently only happens for `@runtime` functions).
       if (
         isEnclosedInRuntimeExpression(
           context.program,
@@ -344,15 +361,11 @@ const getFunctionParameterType = (
       ) {
         return either.makeRight(types.runtimeContext)
       } else {
-        // Conjure up a fresh type parameter when there is no type annotation. This
-        // gives inference a chance to derive a nice signature, e.g. `a => :a` can
-        // be inferred as a true generic identity function.
-        // TODO: Generalize contextual type inference of un-annotated parameters
-        // (this currently only happens for `@runtime` functions).
         return either.makeRight(
-          makeTypeParameter(getParameterName(expression), {
-            assignableTo: types.something,
-          }),
+          genericizeFunctionParameterAnnotation(
+            getParameterName(expression),
+            types.something,
+          ),
         )
       }
     },

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -141,6 +141,95 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
   }
 }
 
+/**
+ * Traverse a function parameter type annotation, replacing each leaf (opaque
+ * type, union type, or existing type parameter) with a fresh `TypeParameter`
+ * constrained to the leaf. This is used to make functions implicitly generic,
+ * even when annotated. For example:
+ *
+ * ```plz
+ * ((x: { a: :integer.type }) => :x.a)({ a: 42 }) ~ 42
+ * ```
+ */
+export const genericizeFunctionParameterAnnotation = (
+  parameterName: Atom,
+  annotationType: Type,
+): Type =>
+  genericizeFunctionParameterAnnotationAtKeyPath(
+    parameterName,
+    annotationType,
+    [],
+  )
+
+const genericizeFunctionParameterAnnotationAtKeyPath = (
+  parameterName: Atom,
+  type: Type,
+  keyPath: TypeKeyPath,
+): Type =>
+  matchTypeFormat(type, {
+    function: (type): Type =>
+      makeFunctionType(type.name, {
+        parameter: genericizeFunctionParameterAnnotationAtKeyPath(
+          parameterName,
+          type.signature.parameter,
+          [...keyPath, functionParameter],
+        ),
+        return: genericizeFunctionParameterAnnotationAtKeyPath(
+          parameterName,
+          type.signature.return,
+          [...keyPath, functionReturn],
+        ),
+      }),
+    object: type =>
+      makeObjectType(
+        type.name,
+        Object.fromEntries(
+          Object.entries(type.children).map(
+            ([key, child]) =>
+              [
+                key,
+                genericizeFunctionParameterAnnotationAtKeyPath(
+                  parameterName,
+                  child,
+                  [...keyPath, key],
+                ),
+              ] as const,
+          ),
+        ),
+      ),
+    opaque: leafType =>
+      makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
+        assignableTo: leafType,
+      }),
+    parameter: leafType =>
+      makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
+        assignableTo: leafType,
+      }),
+    union: leafType =>
+      makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
+        assignableTo: leafType,
+      }),
+  })
+
+const synthesizeTypeParameterName = (
+  parameterName: Atom,
+  keyPath: TypeKeyPath,
+): string =>
+  keyPath.reduce<string>((name, key) => {
+    // TODO: Consider surfacing this in plz syntax (allowing programmatic access
+    // of un-elaborated function parameters/returns and type parameter
+    // constraints).
+    if (key === functionParameter) {
+      return `${name}.#parameter`
+    } else if (key === functionReturn) {
+      return `${name}.#return`
+    } else if (key === typeParameterAssignableToConstraint) {
+      return `${name}.#constraint`
+    } else {
+      return `${name}.${key}`
+    }
+  }, parameterName)
+
 export const containedTypeParameters = (type: Type): TypeParametersByKeyPath =>
   containedTypeParametersImplementation(type, [])
 


### PR DESCRIPTION
Previously, `@function`s without parameter type annotations were inferred to be generic (e.g. `a => :a` would be a true identity function), but when an annotation was present it was used directly as the parameter type (e.g. `((a: :atom.type) => :a)(foo)` would be inferred as `:atom.type` rather than the literal type `foo`).

Now, function parameter type annotations are used to determine the constraints of synthesized type parameters, making all functions generic (e.g. `((a: :atom.type) => :a)(foo)` is now inferred to be typed as `foo`).

This feature is analogous to the following TypeScript suggestion: <https://github.com/microsoft/TypeScript/issues/17428>.