### PR TITLE
Refactor various things related to type inference

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -7,7 +7,6 @@ import {
   isAssignable,
   isFunctionNode,
   readApplyExpression,
-  resolveParameterTypes,
   showType,
   stringifySemanticGraphForEndUser,
   supplyTypeArguments,
@@ -23,30 +22,27 @@ const checkArgumentType = (
   parameterType: Type,
   context: ExpressionContext,
 ): Either<ElaborationError, undefined> =>
-  either.flatMap(
-    inferType(argument, resolveParameterTypes(context), new Set(), context),
-    argumentType => {
-      // Instantiate type parameters contained in `parameterType` before the
-      // assignability check.
-      const instantiatedParameterType = supplyTypeArguments(
-        parameterType,
-        getTypesForTypeParameters({ parameterType, argumentType }),
-      )
-      return (
-          isAssignable({
-            source: argumentType,
-            target: instantiatedParameterType,
-          })
-        ) ?
-          either.makeRight(undefined)
-        : either.makeLeft({
-            kind: 'typeMismatch',
-            message: `the value \`${stringifySemanticGraphForEndUser(
-              argument,
-            )}\` (inferred to have type \`${showType(argumentType)}\`) is not assignable to the type \`${showType(parameterType)}\``,
-          })
-    },
-  )
+  either.flatMap(inferType(argument, context), argumentType => {
+    // Instantiate type parameters contained in `parameterType` before the
+    // assignability check.
+    const instantiatedParameterType = supplyTypeArguments(
+      parameterType,
+      getTypesForTypeParameters({ parameterType, argumentType }),
+    )
+    return (
+        isAssignable({
+          source: argumentType,
+          target: instantiatedParameterType,
+        })
+      ) ?
+        either.makeRight(undefined)
+      : either.makeLeft({
+          kind: 'typeMismatch',
+          message: `the value \`${stringifySemanticGraphForEndUser(
+            argument,
+          )}\` (inferred to have type \`${showType(argumentType)}\`) is not assignable to the type \`${showType(parameterType)}\``,
+        })
+  })
 
 export const applyKeywordHandler: KeywordHandler = (
   expression: Expression,
@@ -59,12 +55,7 @@ export const applyKeywordHandler: KeywordHandler = (
       const argument = applyExpression[1].argument
 
       const argumentTypeCheck = either.flatMap(
-        inferType(
-          functionToApply,
-          resolveParameterTypes(context),
-          new Set(),
-          context,
-        ),
+        inferType(functionToApply, context),
         functionType =>
           functionType.kind === 'function' ?
             checkArgumentType(

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -12,7 +12,6 @@ import {
 import {
   inferType,
   literalTypeFromSemanticGraph,
-  resolveParameterTypes,
   showType,
 } from '../../../semantics/type-system.js'
 
@@ -25,26 +24,24 @@ const check = ({
   readonly type: SemanticGraph
   readonly context: ExpressionContext
 }): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(
-    inferType(value, resolveParameterTypes(context), new Set(), context),
-    valueAsType =>
-      either.flatMap(literalTypeFromSemanticGraph(type), typeAsType => {
-        if (
-          isAssignable({
-            source: valueAsType,
-            target: typeAsType,
-          })
-        ) {
-          return either.makeRight(value)
-        } else {
-          return either.makeLeft({
-            kind: 'typeMismatch',
-            message: `the value \`${stringifySemanticGraphForEndUser(
-              value,
-            )}\` (inferred to have type \`${showType(valueAsType)}\`) is not assignable to the type \`${showType(typeAsType)}\``,
-          })
-        }
-      }),
+  either.flatMap(inferType(value, context), valueAsType =>
+    either.flatMap(literalTypeFromSemanticGraph(type), typeAsType => {
+      if (
+        isAssignable({
+          source: valueAsType,
+          target: typeAsType,
+        })
+      ) {
+        return either.makeRight(value)
+      } else {
+        return either.makeLeft({
+          kind: 'typeMismatch',
+          message: `the value \`${stringifySemanticGraphForEndUser(
+            value,
+          )}\` (inferred to have type \`${showType(valueAsType)}\`) is not assignable to the type \`${showType(typeAsType)}\``,
+        })
+      }
+    }),
   )
 
 export const checkKeywordHandler: KeywordHandler = (

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -8,7 +8,6 @@ import {
   makeFunctionNode,
   makeObjectNode,
   readFunctionExpression,
-  resolveParameterTypes,
   serialize,
   updateValueAtKeyPathInSemanticGraph,
   type Expression,
@@ -24,33 +23,30 @@ export const functionKeywordHandler: KeywordHandler = (
   context: ExpressionContext,
 ): Either<ElaborationError, FunctionNode> =>
   either.flatMap(readFunctionExpression(expression), functionExpression =>
-    either.flatMap(
-      inferType(expression, resolveParameterTypes(context), new Set(), context),
-      inferredType => {
-        if (inferredType.kind !== 'function') {
-          return either.makeLeft({
-            kind: 'bug',
-            message:
-              'inferred type of function expression was not a function type',
-          })
-        } else {
-          return either.makeRight(
-            makeFunctionNode(
-              inferredType.signature,
-              () => either.makeRight(functionExpression),
-              option.makeSome(getParameterName(functionExpression)),
-              argument =>
-                apply(
-                  functionExpression,
-                  inferredType.signature,
-                  argument,
-                  context,
-                ),
-            ),
-          )
-        }
-      },
-    ),
+    either.flatMap(inferType(expression, context), inferredType => {
+      if (inferredType.kind !== 'function') {
+        return either.makeLeft({
+          kind: 'bug',
+          message:
+            'inferred type of function expression was not a function type',
+        })
+      } else {
+        return either.makeRight(
+          makeFunctionNode(
+            inferredType.signature,
+            () => either.makeRight(functionExpression),
+            option.makeSome(getParameterName(functionExpression)),
+            argument =>
+              apply(
+                functionExpression,
+                inferredType.signature,
+                argument,
+                context,
+              ),
+          ),
+        )
+      }
+    }),
   )
 
 const apply = (

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -11,7 +11,6 @@ import {
   makeIfExpression,
   makeObjectNode,
   readIfExpression,
-  resolveParameterTypes,
   serialize,
   showType,
   types,
@@ -65,12 +64,7 @@ export const ifKeywordHandler: KeywordHandler = (
         } else {
           return either.flatMap(
             either.flatMap(
-              inferType(
-                elaboratedCondition,
-                resolveParameterTypes(context),
-                new Set(),
-                context,
-              ),
+              inferType(elaboratedCondition, context),
               (conditionType): Either<ElaborationError, Output> =>
                 (
                   isAssignable({

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -8,7 +8,6 @@ import {
   inferType,
   keyPathFromObjectNodeOrMolecule,
   readIndexExpression,
-  resolveParameterTypes,
   showType,
   stringifyKeyPathForEndUser,
   type Expression,
@@ -23,22 +22,17 @@ const checkKeyPathExistsInType = (
   keyPath: KeyPath,
   context: ExpressionContext,
 ): Either<ElaborationError, undefined> =>
-  either.flatMap(
-    inferType(object, resolveParameterTypes(context), new Set(), context),
-    objectType => {
-      const typeAtKeyPath = applyKeyPathToType(objectType, keyPath)
-      return (
-          typeAtKeyPath.kind === 'union' && typeAtKeyPath.members.size === 0
-        ) ?
-          either.makeLeft({
-            kind: 'typeMismatch',
-            message: `property \`${stringifyKeyPathForEndUser(
-              keyPath,
-            )}\` does not exist on type \`${showType(objectType)}\``,
-          })
-        : either.makeRight(undefined)
-    },
-  )
+  either.flatMap(inferType(object, context), objectType => {
+    const typeAtKeyPath = applyKeyPathToType(objectType, keyPath)
+    return typeAtKeyPath.kind === 'union' && typeAtKeyPath.members.size === 0 ?
+        either.makeLeft({
+          kind: 'typeMismatch',
+          message: `property \`${stringifyKeyPathForEndUser(
+            keyPath,
+          )}\` does not exist on type \`${showType(objectType)}\``,
+        })
+      : either.makeRight(undefined)
+  })
 
 export const indexKeywordHandler: KeywordHandler = (
   expression: Expression,

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -57,10 +57,10 @@ export const resolveParameterTypes = (
   // their types.
   while (currentLocation.length >= 2) {
     const enclosingFunction = option.flatMap(
-      enclosingExpressionFromPropertyOfExpressionArgument(
-        context.program,
-        currentLocation,
-      ),
+      enclosingExpressionFromPropertyOfExpressionArgument({
+        program: context.program,
+        location: currentLocation,
+      }),
       expression =>
         either.match(readFunctionExpression(expression), {
           left: _ => option.none,
@@ -363,10 +363,7 @@ const getFunctionParameterType = (
       ),
     none: _ => {
       const contextualType = option.flatMap(
-        enclosingExpressionFromPropertyOfExpressionArgument(
-          contextOfFunction.program,
-          contextOfFunction.location,
-        ),
+        enclosingExpressionFromPropertyOfExpressionArgument(contextOfFunction),
         (enclosingExpression): Option<Type> => {
           if (
             isKeywordExpressionWithArgument('@runtime', enclosingExpression)
@@ -420,14 +417,17 @@ const getFunctionParameterType = (
     },
   })
 
-const enclosingExpressionFromPropertyOfExpressionArgument = (
-  program: SemanticGraph,
-  pathToNode: KeyPath,
-): Option<SemanticGraph> => {
-  if (pathToNode.length < 2) {
+const enclosingExpressionFromPropertyOfExpressionArgument = ({
+  program,
+  location,
+}: {
+  readonly program: SemanticGraph
+  readonly location: KeyPath
+}): Option<SemanticGraph> => {
+  if (location.length < 2) {
     return option.none
   } else {
-    const pathToPossibleExpression = pathToNode.slice(0, -2)
+    const pathToPossibleExpression = location.slice(0, -2)
     return option.filter(
       applyKeyPathToSemanticGraph(program, pathToPossibleExpression),
       isExpression,

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -56,41 +56,43 @@ export const resolveParameterTypes = (
   // Walk upwards towards the program root, keeping track of parameter names and
   // their types.
   while (currentLocation.length >= 2) {
-    const pathToCurrentScope = currentLocation.slice(0, -1)
-    const pathToParentScope = pathToCurrentScope.slice(0, -1)
-
-    const parentNodeOption = applyKeyPathToSemanticGraph(
-      context.program,
-      pathToParentScope,
+    const enclosingFunction = option.flatMap(
+      enclosingExpressionFromPropertyOfExpressionArgument(
+        context.program,
+        currentLocation,
+      ),
+      expression =>
+        either.match(readFunctionExpression(expression), {
+          left: _ => option.none,
+          right: option.makeSome,
+        }),
     )
 
-    if (
-      option.isSome(parentNodeOption) &&
-      isExpression(parentNodeOption.value)
-    ) {
-      const functionResult = readFunctionExpression(parentNodeOption.value)
-      if (either.isRight(functionResult)) {
-        const parameterName = getParameterName(functionResult.value)
-        if (!parameterTypes.has(parameterName)) {
-          const parameterTypeResult = getFunctionParameterType(
-            functionResult.value,
-            {
-              keywordHandlers: context.keywordHandlers,
-              program: context.program,
-              location: currentLocation,
-            },
+    if (option.isSome(enclosingFunction)) {
+      const parameterName = getParameterName(enclosingFunction.value)
+      if (!parameterTypes.has(parameterName)) {
+        const parameterTypeResult = getFunctionParameterType(
+          enclosingFunction.value,
+          {
+            keywordHandlers: context.keywordHandlers,
+            program: context.program,
+            location: currentLocation,
+          },
+        )
+
+        if (either.isLeft(parameterTypeResult)) {
+          throw new Error(
+            'Cannot determine parameter type of function. This is a bug!',
+            { cause: parameterTypeResult.value },
           )
-          // Ignore errors here (they should be surfaced elsewhere).
-          if (either.isRight(parameterTypeResult)) {
-            // Side-effect: add the parameter.
-            parameterTypes.set(parameterName, parameterTypeResult.value)
-          }
         }
+
+        // Side-effect: add the parameter.
+        parameterTypes.set(parameterName, parameterTypeResult.value)
       }
-      currentLocation = pathToParentScope
-    } else {
-      currentLocation = pathToCurrentScope
     }
+
+    currentLocation = currentLocation.slice(0, -1)
   }
 
   return parameterTypes

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -76,7 +76,7 @@ export const resolveParameterTypes = (
           {
             keywordHandlers: context.keywordHandlers,
             program: context.program,
-            location: currentLocation,
+            location: currentLocation.slice(0, -2),
           },
         )
 
@@ -98,6 +98,9 @@ export const resolveParameterTypes = (
   return parameterTypes
 }
 
+// TODO: Consider a higher-level externally-visible wrapper which only requires
+// `node` and `context`. External call sites currently all look like this:
+// `inferType(node, resolveParameterTypes(context), new Set(), context)`
 export const inferType = (
   node: SemanticGraph,
   parameterTypes: ReadonlyMap<Atom, Type>,
@@ -116,7 +119,14 @@ export const inferType = (
   const functionExpressionResult = readFunctionExpression(node)
   if (either.isRight(functionExpressionResult)) {
     return either.flatMap(
-      getFunctionParameterType(functionExpressionResult.value, context),
+      getFunctionParameterType(
+        functionExpressionResult.value,
+        // TODO: `getFunctionParameterType` expects `context.location` to point
+        // at the function, but `context.location` isn't updated when
+        // `inferType` recurses, so this context often points somewhere else.
+        // Could be fixed by threading the current path through recursive calls.
+        context,
+      ),
       parameterType =>
         either.map(
           inferType(
@@ -341,7 +351,7 @@ export const inferType = (
  */
 const getFunctionParameterType = (
   expression: FunctionExpression,
-  context: ExpressionContext,
+  contextOfFunction: ExpressionContext,
 ): Either<Bug, Type> =>
   option.match(getParameterTypeAnnotation(expression), {
     some: annotation =>
@@ -352,11 +362,10 @@ const getFunctionParameterType = (
         ),
       ),
     none: _ => {
-      const pathToFunction = context.location.slice(0, -2)
       const contextualType = option.flatMap(
         enclosingExpressionFromPropertyOfExpressionArgument(
-          context.program,
-          pathToFunction,
+          contextOfFunction.program,
+          contextOfFunction.location,
         ),
         (enclosingExpression): Option<Type> => {
           if (
@@ -368,9 +377,9 @@ const getFunctionParameterType = (
           const applyExpressionResult = readApplyExpression(enclosingExpression)
           if (either.isRight(applyExpressionResult)) {
             const contextOfEnclosingExpression: ExpressionContext = {
-              program: context.program,
-              keywordHandlers: context.keywordHandlers,
-              location: pathToFunction.slice(0, -2),
+              program: contextOfFunction.program,
+              keywordHandlers: contextOfFunction.keywordHandlers,
+              location: contextOfFunction.location.slice(0, -2),
             }
             const contextuallyAppliedFunctionType = inferType(
               applyExpressionResult.value[1].function,

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -68,25 +68,22 @@ export const resolveParameterTypes = (
       option.isSome(parentNodeOption) &&
       isExpression(parentNodeOption.value)
     ) {
-      const lastKey = pathToCurrentScope[pathToCurrentScope.length - 1]
-      if (lastKey === '1') {
-        const functionResult = readFunctionExpression(parentNodeOption.value)
-        if (either.isRight(functionResult)) {
-          const parameterName = getParameterName(functionResult.value)
-          if (!parameterTypes.has(parameterName)) {
-            const parameterTypeResult = getFunctionParameterType(
-              functionResult.value,
-              {
-                keywordHandlers: context.keywordHandlers,
-                program: context.program,
-                location: currentLocation,
-              },
-            )
-            // Ignore errors here (they should be surfaced elsewhere).
-            if (either.isRight(parameterTypeResult)) {
-              // Side-effect: add the parameter.
-              parameterTypes.set(parameterName, parameterTypeResult.value)
-            }
+      const functionResult = readFunctionExpression(parentNodeOption.value)
+      if (either.isRight(functionResult)) {
+        const parameterName = getParameterName(functionResult.value)
+        if (!parameterTypes.has(parameterName)) {
+          const parameterTypeResult = getFunctionParameterType(
+            functionResult.value,
+            {
+              keywordHandlers: context.keywordHandlers,
+              program: context.program,
+              location: currentLocation,
+            },
+          )
+          // Ignore errors here (they should be surfaced elsewhere).
+          if (either.isRight(parameterTypeResult)) {
+            // Side-effect: add the parameter.
+            parameterTypes.set(parameterName, parameterTypeResult.value)
           }
         }
       }

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -98,10 +98,18 @@ export const resolveParameterTypes = (
   return parameterTypes
 }
 
-// TODO: Consider a higher-level externally-visible wrapper which only requires
-// `node` and `context`. External call sites currently all look like this:
-// `inferType(node, resolveParameterTypes(context), new Set(), context)`
 export const inferType = (
+  node: SemanticGraph,
+  context: ExpressionContext,
+): Either<ElaborationError, Type> =>
+  inferTypeImplementation(
+    node,
+    resolveParameterTypes(context),
+    new Set(),
+    context,
+  )
+
+const inferTypeImplementation = (
   node: SemanticGraph,
   parameterTypes: ReadonlyMap<Atom, Type>,
   lookingUpKeys: ReadonlySet<Atom>,
@@ -123,13 +131,14 @@ export const inferType = (
         functionExpressionResult.value,
         // TODO: `getFunctionParameterType` expects `context.location` to point
         // at the function, but `context.location` isn't updated when
-        // `inferType` recurses, so this context often points somewhere else.
-        // Could be fixed by threading the current path through recursive calls.
+        // `inferTypeImplementation` recurses, so this context often points
+        // somewhere else. Could be fixed by threading the current path through
+        // recursive calls.
         context,
       ),
       parameterType =>
         either.map(
-          inferType(
+          inferTypeImplementation(
             functionExpressionResult.value[1].body,
             new Map([
               ...parameterTypes,
@@ -158,7 +167,7 @@ export const inferType = (
     } else if (!lookingUpKeys.has(key)) {
       const lookupResult = lookup({ key, context })
       if (either.isRight(lookupResult) && option.isSome(lookupResult.value)) {
-        return inferType(
+        return inferTypeImplementation(
           lookupResult.value.value,
           parameterTypes,
           new Set([...lookingUpKeys, key]),
@@ -178,7 +187,7 @@ export const inferType = (
   const indexExpressionResult = readIndexExpression(node)
   if (either.isRight(indexExpressionResult)) {
     return either.flatMap(
-      inferType(
+      inferTypeImplementation(
         indexExpressionResult.value[1].object,
         parameterTypes,
         lookingUpKeys,
@@ -201,7 +210,7 @@ export const inferType = (
         either.flatMap(runtimeFunction.serialize(), readFunctionExpression)
       : readFunctionExpression(runtimeFunction)
     if (either.isRight(functionExpressionResult)) {
-      return inferType(
+      return inferTypeImplementation(
         functionExpressionResult.value[1].body,
         new Map([
           ...parameterTypes,
@@ -224,7 +233,7 @@ export const inferType = (
   // @apply: infer the return type from the function being applied.
   const applyExpressionResult = readApplyExpression(node)
   if (either.isRight(applyExpressionResult)) {
-    const inferredFunctionType = inferType(
+    const inferredFunctionType = inferTypeImplementation(
       applyExpressionResult.value[1].function,
       parameterTypes,
       lookingUpKeys,
@@ -245,7 +254,7 @@ export const inferType = (
         some: ({
           signature: { parameter: parameterType, return: returnType },
         }) => {
-          const argumentTypeResult = inferType(
+          const argumentTypeResult = inferTypeImplementation(
             applyExpressionResult.value[1].argument,
             parameterTypes,
             lookingUpKeys,
@@ -284,12 +293,17 @@ export const inferType = (
     const { condition, then, else: otherwise } = ifExpressionResult.value[1]
 
     const inferThen = () =>
-      inferType(then, parameterTypes, lookingUpKeys, context)
+      inferTypeImplementation(then, parameterTypes, lookingUpKeys, context)
     const inferElse = () =>
-      inferType(otherwise, parameterTypes, lookingUpKeys, context)
+      inferTypeImplementation(otherwise, parameterTypes, lookingUpKeys, context)
 
     return either.flatMap(
-      inferType(condition, parameterTypes, lookingUpKeys, context),
+      inferTypeImplementation(
+        condition,
+        parameterTypes,
+        lookingUpKeys,
+        context,
+      ),
       conditionType => {
         if (isAssignable({ source: conditionType, target: 'true' })) {
           return inferThen()
@@ -321,7 +335,7 @@ export const inferType = (
     // Infer unelaborated descendants' types.
     const children: Record<string, Type> = {}
     for (const [key, value] of Object.entries(node)) {
-      const childTypeResult = inferType(
+      const childTypeResult = inferTypeImplementation(
         value,
         parameterTypes,
         lookingUpKeys,
@@ -380,8 +394,6 @@ const getFunctionParameterType = (
             }
             const contextuallyAppliedFunctionType = inferType(
               applyExpressionResult.value[1].function,
-              resolveParameterTypes(contextOfEnclosingExpression),
-              new Set(),
               contextOfEnclosingExpression,
             )
 


### PR DESCRIPTION
Nothing in here is intended to change any observable language behavior, though I think 51be36f does slightly shift the blast radius of a pre-existing bug (recursion during type inference doesn't properly update `context.location`). I'll address that bug directly in a future pull request.