### PR TITLE
Add `OrderedRecord` type and associated functions

### DIFF
--- a/src/ordered-record.test.ts
+++ b/src/ordered-record.test.ts
@@ -1,0 +1,222 @@
+import option from '@matt.kantor/option'
+import assert from 'node:assert'
+import test, { suite } from 'node:test'
+import {
+  empty,
+  filter,
+  get,
+  has,
+  isOrderedRecord,
+  keys,
+  make,
+  mapValues,
+  merge,
+  remove,
+  set,
+  size,
+  values,
+} from './ordered-record.js'
+
+suite('OrderedRecord', () => {
+  test('`make` with empty source yields size 0', () => {
+    const record = make([])
+    assert.equal(size(record), 0)
+    assert.deepEqual(record.entries, [])
+    assert.deepEqual(keys(record), [])
+    assert.deepEqual(values(record), [])
+  })
+
+  test('`empty` returns an empty record', () => {
+    assert.equal(size(empty), 0)
+  })
+
+  test('`make` preserves initial order of integer-like keys', () => {
+    // The initial motivation for `OrderedRecord` was to work around the fact
+    // that integer-like keys appear first when iterating JavaScript objects,
+    // rather than in insertion/source order.
+
+    const jsObject = { a: 1, '999': 2, b: 3, '0': 4, c: 5 }
+    // This is what we want to avoid:
+    assert.deepEqual(Object.keys(jsObject), ['0', '999', 'a', 'b', 'c'])
+
+    const record = make([
+      ['a', 1],
+      ['0', 2],
+      ['b', 3],
+      ['999', 4],
+      ['c', 5],
+    ])
+    assert.deepEqual(keys(record), ['a', '0', 'b', '999', 'c'])
+    assert.deepEqual(values(record), [1, 2, 3, 4, 5])
+  })
+
+  test('`make` with duplicate keys: first determines position, last determines value', () => {
+    const record = make([
+      ['a', 1],
+      ['b', 2],
+      ['a', 3],
+    ])
+    assert.deepEqual(keys(record), ['a', 'b'])
+    assert.deepEqual(get(record, 'a'), option.makeSome(3))
+    assert.deepEqual(get(record, 'b'), option.makeSome(2))
+  })
+
+  test('`get`ting missing key returns `none`', () => {
+    const record = make([['a', 1]])
+    assert.deepEqual(get(record, 'missing'), option.none)
+  })
+
+  test('`has`', () => {
+    const record = make([['a', 1]])
+    assert.equal(has(record, 'a'), true)
+    assert.equal(has(record, 'b'), false)
+  })
+
+  test('`set` appends new keys at the end', () => {
+    const original = make([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const updated = set(original, 'c', 3)
+    assert.deepEqual(keys(updated), ['a', 'b', 'c'])
+    assert.deepEqual(get(updated, 'c'), option.makeSome(3))
+  })
+
+  test('`set` replaces existing key without moving it', () => {
+    const original = make([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const updated = set(original, 'b', 99)
+    assert.deepEqual(keys(updated), ['a', 'b', 'c'])
+    assert.deepEqual(values(updated), [1, 99, 3])
+  })
+
+  test("`set` doesn't mutate", () => {
+    const original = make([['a', 1]])
+    const originalEntries = original.entries
+    const _updated = set(original, 'b', 2)
+    assert.equal(original.entries, originalEntries)
+    assert.deepEqual(keys(original), ['a'])
+  })
+
+  test('`remove`ing a key preserves order of remaining keys', () => {
+    const original = make([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const updated = remove(original, 'b')
+    assert.deepEqual(keys(updated), ['a', 'c'])
+    assert.deepEqual(values(updated), [1, 3])
+  })
+
+  test('`remove`ing a missing key is a no-op', () => {
+    const original = make([['a', 1]])
+    const updated = remove(original, 'missing')
+    assert.deepEqual(keys(updated), ['a'])
+  })
+
+  test("`remove` doesn't mutate", () => {
+    const original = make([['a', 1]])
+    const _updated = remove(original, 'a')
+    assert.equal(size(original), 1)
+  })
+
+  test('`merge`ing mixed overlapping and new keys', () => {
+    const first = make([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const second = make([
+      ['b', 99],
+      ['d', 4],
+      ['e', 5],
+    ])
+    const result = merge(first, second)
+    assert.deepEqual(keys(result), ['a', 'b', 'c', 'd', 'e'])
+    assert.deepEqual(values(result), [1, 99, 3, 4, 5])
+  })
+
+  test('integer-string keys preserve their position through `merge`', () => {
+    const first = make([
+      ['a', 1],
+      ['0', 2],
+      ['b', 3],
+    ])
+    const second = make([['0', 99]])
+    const result = merge(first, second)
+    assert.deepEqual(keys(result), ['a', '0', 'b'])
+    assert.deepEqual(values(result), [1, 99, 3])
+  })
+
+  test('`mapValues` preserves order and transforms values', () => {
+    const record = make([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+    ])
+    const doubled = mapValues(record, value => value * 2)
+    assert.deepEqual(keys(doubled), ['a', 'b', 'c'])
+    assert.deepEqual(values(doubled), [2, 4, 6])
+  })
+
+  test('`mapValues` passes the key to the transform', () => {
+    const record = make([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const result = mapValues(record, (value, key) => `${key}=${value}`)
+    assert.deepEqual(values(result), ['a=1', 'b=2'])
+  })
+
+  test('`filter` preserves order and keeps passing entries', () => {
+    const record = make([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+      ['d', 4],
+    ])
+    const evens = filter(record, value => value % 2 === 0)
+    assert.deepEqual(keys(evens), ['b', 'd'])
+    assert.deepEqual(values(evens), [2, 4])
+  })
+
+  test('records with same entries in same order are deeply-equal', () => {
+    const first = make([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const second = make([
+      ['a', 1],
+      ['b', 2],
+    ])
+    assert.deepEqual(first, second)
+  })
+
+  test("records with same entries in different order aren't deeply-equal", () => {
+    // Ensure that `assert.deepEqual` validates ordering in tests.
+    const first = make([
+      ['a', 1],
+      ['b', 2],
+    ])
+    const second = make([
+      ['b', 2],
+      ['a', 1],
+    ])
+    assert.notDeepEqual(first, second)
+  })
+
+  test('`isOrderedRecord`', () => {
+    assert.equal(isOrderedRecord(make([['a', 1]])), true)
+    assert.equal(isOrderedRecord(empty), true)
+    assert.equal(isOrderedRecord({ entries: [['a', 1]] }), false)
+    assert.equal(isOrderedRecord(null), false)
+    assert.equal(isOrderedRecord(undefined), false)
+    assert.equal(isOrderedRecord('string'), false)
+    assert.equal(isOrderedRecord(42), false)
+    assert.equal(isOrderedRecord([]), false)
+  })
+})

--- a/src/ordered-record.ts
+++ b/src/ordered-record.ts
@@ -1,0 +1,140 @@
+import option, { type Option } from '@matt.kantor/option'
+
+const orderedRecordTag = Symbol('orderedRecordTag')
+
+export type OrderedRecord<Value> = {
+  readonly [orderedRecordTag]: true
+  readonly entries: readonly (readonly [string, Value])[]
+}
+
+const fromUniqueEntries = <Value>(
+  entries: readonly (readonly [string, Value])[],
+): OrderedRecord<Value> => ({
+  [orderedRecordTag]: true,
+  entries,
+})
+
+export const empty: OrderedRecord<never> = fromUniqueEntries([])
+
+/**
+ * Create an `OrderedRecord`.
+ *
+ * Behavior in the face of duplicate keys is the same as building up an
+ * `OrderedRecord` with repeated `set` calls: the first occurrence determines
+ * the position and the last occurrence determines the value.
+ */
+export const make = <Value>(
+  source: Iterable<readonly [string, Value]>,
+): OrderedRecord<Value> => {
+  const sourceArray = [...source]
+  const orderedUniqueKeys = sourceArray
+    .map(([key, _value]) => key)
+    .filter((key, index, allKeys) => allKeys.indexOf(key) === index)
+  const dedupedEntries = orderedUniqueKeys.map(key => {
+    const lastOccurrence = sourceArray.findLast(
+      ([sourceKey, _sourceValue]) => sourceKey === key,
+    )
+    if (lastOccurrence === undefined) {
+      throw new Error(
+        'Key disappeared between `filter` and `findLast`. This is a bug!',
+      )
+    }
+    return [key, lastOccurrence[1]] as const
+  })
+  return fromUniqueEntries(dedupedEntries)
+}
+
+export const isOrderedRecord = (
+  value: unknown,
+): value is OrderedRecord<unknown> =>
+  typeof value === 'object' && value !== null && orderedRecordTag in value
+
+export const get = <Value>(
+  record: OrderedRecord<Value>,
+  key: string,
+): Option<Value> => {
+  const entry = record.entries.find(
+    ([keyInRecord, _valueInRecord]) => keyInRecord === key,
+  )
+  return entry === undefined ? option.none : option.makeSome(entry[1])
+}
+
+export const has = (
+  record: OrderedRecord<unknown>,
+  keyToFind: string,
+): boolean => record.entries.some(([key, _value]) => key === keyToFind)
+
+export const keys = (record: OrderedRecord<unknown>): readonly string[] =>
+  record.entries.map(([key, _value]) => key)
+
+export const values = <Value>(record: OrderedRecord<Value>): readonly Value[] =>
+  record.entries.map(([_key, value]) => value)
+
+export const size = (record: OrderedRecord<unknown>): number =>
+  record.entries.length
+
+/**
+ * Return a new `OrderedRecord` with `key` mapped to `value`. If `key` is
+ * already present, its position is preserved and only the value is replaced. If
+ * `key` is new, it's appended to the end.
+ */
+export const set = <Value>(
+  record: OrderedRecord<Value>,
+  key: string,
+  value: Value,
+): OrderedRecord<Value> => {
+  const existingIndex = record.entries.findIndex(
+    ([existingKey, _existingValue]) => existingKey === key,
+  )
+  return existingIndex === -1 ?
+      fromUniqueEntries([...record.entries, [key, value]])
+    : fromUniqueEntries(
+        record.entries.map((entry, index) =>
+          index === existingIndex ? [key, value] : entry,
+        ),
+      )
+}
+
+export const remove = <Value>(
+  record: OrderedRecord<Value>,
+  keyToRemove: string,
+): OrderedRecord<Value> =>
+  fromUniqueEntries(
+    record.entries.filter(([key, _value]) => key !== keyToRemove),
+  )
+
+/**
+ * Overlay `second` onto `first`. Keys present in both records keep their
+ * position from `first` but take their value from `second`.
+ */
+export const merge = <Value>(
+  first: OrderedRecord<Value>,
+  second: OrderedRecord<Value>,
+): OrderedRecord<Value> => {
+  const updatedFirst = first.entries.map(
+    ([key1, value1]) =>
+      second.entries.find(([key2, _value2]) => key2 === key1) ??
+      ([key1, value1] as const),
+  )
+  const newKeysFromSecond = second.entries.filter(
+    ([key2, _value2]) =>
+      !first.entries.some(([key1, _value1]) => key1 === key2),
+  )
+  return fromUniqueEntries([...updatedFirst, ...newKeysFromSecond])
+}
+
+export const mapValues = <Value, NewValue>(
+  record: OrderedRecord<Value>,
+  transform: (value: Value, key: string) => NewValue,
+): OrderedRecord<NewValue> =>
+  fromUniqueEntries(
+    record.entries.map(([key, value]) => [key, transform(value, key)]),
+  )
+
+export const filter = <Value>(
+  record: OrderedRecord<Value>,
+  predicate: (value: Value, key: string) => boolean,
+): OrderedRecord<Value> =>
+  fromUniqueEntries(
+    record.entries.filter(([key, value]) => predicate(value, key)),
+  )


### PR DESCRIPTION
This is the first step of a set of deep changes I have in the works: I'm revamping the core `SyntaxTree` and `SemanticGraph` data structures to maintain the source order of Please object properties through parsing/compilation/evaluation.

Currently, plain JavaScript objects are used to model Please objects. This is very convenient, especially given Please's JSONy heritage (the initial parser was just `JSON.parse`).

However, JavaScript objects have downsides. The biggest pain point has been that when iterating over object properties, [keys that could be array indexes are visited first](https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys). For example, given an object like `{ a: 1, 999: 2, 0: 3 }` Please's internals see `{ 0: 3, 999: 2, a: 1 }`. This can subtly affect program semantics in ways that are undesirable, and merely renaming a key from `a` to `0` should not have surprising implications. Using plain JavaScript objects also yields a very wide type (even when there's [an index signature](https://github.com/mkantor/please-lang-prototype/blob/9d42008804150b19f429ca7e4bc04e978a330976/src/language/parsing/expression.ts#L39)), and there have been mistakes like accidentally using an `Option<Molecule>` where a `Molecule` was desired[^1].

So, the plan is to adopt `OrderedRecord` instead as the core primitive. `OrderedRecord` maintains an explicit ordering of properties, at the cost of not being as optimized as plain JavaScript objects[^2]. It'll also be difficult (impossible?) to have narrower subtypes with specific known properties once `OrderedRecord` is in use, though I think the payoff will be worth it.

This changeset merely introduces `OrderedRecord` without using it anywhere. Future pull requests will incrementally adopt it within Please's innards.

`OrderedRecord` may eventually move to its own package, but I'm going to see how it shakes out here first.

[^1]:  Though I've gotten pretty good at avoiding such mistakes via branding and tricks like [`JsonValueForbiddingSymbolicKeys`](https://github.com/mkantor/please-lang-prototype/blob/9d42008804150b19f429ca7e4bc04e978a330976/src/language/parsing/syntax-tree.ts#L62-L79).

[^2]: Most egregiously, direct key lookups are currently O(n) rather than O(1), but that could be fixed if it becomes significant.