### PR TITLE
Adopt `OrderedRecord` in `SyntaxTree`

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -1,23 +1,29 @@
 import either from '@matt.kantor/either'
+import option from '@matt.kantor/option'
 import assert from 'node:assert'
 import { compile } from './language/compiling.js'
+import { canonicalize } from './language/parsing.js'
 import { parse } from './language/parsing/parser.js'
 import { evaluate } from './language/runtime.js'
+import * as orderedRecord from './ordered-record.js'
 import {
   parseAndCompileAndRun,
   testCases,
   unparseAndRoundtrip,
   type ProgramResult,
 } from './test-utilities.test.js'
+import type { JsonValue } from './utility-types.js'
+
+const success = (value: JsonValue) => either.makeRight(canonicalize(value))
 
 const endToEnd = (input: string) => {
-  const syntaxTree: ProgramResult = parse(input)
+  const syntaxTree = parse(input)
   const runtimeOutputFromRoundtrippingSyntaxTree = either.flatMap(
     syntaxTree,
     unparseAndRoundtrip,
   )
 
-  const program: ProgramResult = either.flatMap(syntaxTree, compile)
+  const program = either.flatMap(syntaxTree, compile)
   const runtimeOutputFromRoundtrippingProgram = either.flatMap(
     program,
     unparseAndRoundtrip,
@@ -66,7 +72,7 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
         }
       }
     }.output`,
-    either.makeRight('42'),
+    success('42'),
   ],
   [
     `((a: :natural_number.type) => {
@@ -81,7 +87,7 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
       }
       return: :my_function(0)
     })(2).return`,
-    either.makeRight('5'),
+    success('5'),
   ],
   [
     `{
@@ -102,26 +108,26 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
         return: :count_internal({ current: 0, output: "" })
       }.return
     }.count(2)`,
-    either.makeRight(
+    success(
       '0 (not greater than one) 1 (not greater than one) 2 (greater than one) ',
     ),
   ],
 ])
 
 testCases(endToEnd, code => code)('end-to-end tests', [
-  ['""', either.makeRight('')],
-  ['{}', either.makeRight({})],
-  ['hi', either.makeRight('hi')],
-  ['1.1', either.makeRight('1.1')],
-  ['{{{}}}', either.makeRight({ 0: { 0: {} } })],
-  ['"hello world"', either.makeRight('hello world')],
-  ['{foo:bar}', either.makeRight({ foo: 'bar' })],
-  ['{hi}', either.makeRight({ 0: 'hi' })],
-  ['{a,b,c}', either.makeRight({ 0: 'a', 1: 'b', 2: 'c' })],
-  ['{,a,b,c,}', either.makeRight({ 0: 'a', 1: 'b', 2: 'c' })],
-  ['{a,1:overwritten,c}', either.makeRight({ 0: 'a', 1: 'c' })],
-  ['{overwritten,0:a,c}', either.makeRight({ 0: 'a', 1: 'c' })],
-  ['@check {type:true, value:true}', either.makeRight('true')],
+  ['""', success('')],
+  ['{}', success({})],
+  ['hi', success('hi')],
+  ['1.1', success('1.1')],
+  ['{{{}}}', success({ 0: { 0: {} } })],
+  ['"hello world"', success('hello world')],
+  ['{foo:bar}', success({ foo: 'bar' })],
+  ['{hi}', success({ 0: 'hi' })],
+  ['{a,b,c}', success({ 0: 'a', 1: 'b', 2: 'c' })],
+  ['{,a,b,c,}', success({ 0: 'a', 1: 'b', 2: 'c' })],
+  ['{a,1:overwritten,c}', success({ 0: 'a', 1: 'c' })],
+  ['{overwritten,0:a,c}', success({ 0: 'a', 1: 'c' })],
+  ['@check {type:true, value:true}', success('true')],
   [
     '@panic',
     result => {
@@ -130,10 +136,10 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       assert.deepEqual(result.value.kind, 'panic')
     },
   ],
-  ['{a:A, b:{"@lookup", {a}}}', either.makeRight({ a: 'A', b: 'A' })],
-  ['{a:A, {"@lookup", {a}}}', either.makeRight({ a: 'A', 0: 'A' })],
-  ['{a:A, b: :a}', either.makeRight({ a: 'A', b: 'A' })],
-  ['{a:A, :a}', either.makeRight({ a: 'A', 0: 'A' })],
+  ['{a:A, b:{"@lookup", {a}}}', success({ a: 'A', b: 'A' })],
+  ['{a:A, {"@lookup", {a}}}', success({ a: 'A', 0: 'A' })],
+  ['{a:A, b: :a}', success({ a: 'A', b: 'A' })],
+  ['{a:A, :a}', success({ a: 'A', 0: 'A' })],
   [
     '@runtime {_ => @panic}',
     result => {
@@ -144,7 +150,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     'a => :a',
-    either.makeRight({
+    success({
       0: '@function',
       1: {
         parameter: 'a',
@@ -154,7 +160,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     '(a => :a)',
-    either.makeRight({
+    success({
       0: '@function',
       1: {
         parameter: 'a',
@@ -162,22 +168,19 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       },
     }),
   ],
-  ['{ a: ({ A }) }', either.makeRight({ a: { 0: 'A' } })],
-  ['{ a: ( A ) }', either.makeRight({ a: 'A' })],
-  ['{ a: ("A A A") }', either.makeRight({ a: 'A A A' })],
-  ['{ ("a"): A }', either.makeRight({ a: 'A' })],
-  ['{ a: :(b), b: B }', either.makeRight({ a: 'B', b: 'B' })],
-  ['{ a: :("b"), b: B }', either.makeRight({ a: 'B', b: 'B' })],
-  ['{ (a: A), (b: B) }', either.makeRight({ a: 'A', b: 'B' })],
-  ['( { ((a): :(b)), ( ( b ): B ) } )', either.makeRight({ a: 'B', b: 'B' })],
-  ['{ (a: :(")")), (")": (B)) }', either.makeRight({ a: 'B', ')': 'B' })],
-  [`/**/a/**/`, either.makeRight('a')],
-  ['hello//world', either.makeRight('hello')],
-  [`"hello//world"`, either.makeRight('hello//world')],
-  [
-    `/**/{/**/a:/**/b/**/,/**/c:/**/d/**/}/**/`,
-    either.makeRight({ a: 'b', c: 'd' }),
-  ],
+  ['{ a: ({ A }) }', success({ a: { 0: 'A' } })],
+  ['{ a: ( A ) }', success({ a: 'A' })],
+  ['{ a: ("A A A") }', success({ a: 'A A A' })],
+  ['{ ("a"): A }', success({ a: 'A' })],
+  ['{ a: :(b), b: B }', success({ a: 'B', b: 'B' })],
+  ['{ a: :("b"), b: B }', success({ a: 'B', b: 'B' })],
+  ['{ (a: A), (b: B) }', success({ a: 'A', b: 'B' })],
+  ['( { ((a): :(b)), ( ( b ): B ) } )', success({ a: 'B', b: 'B' })],
+  ['{ (a: :(")")), (")": (B)) }', success({ a: 'B', ')': 'B' })],
+  [`/**/a/**/`, success('a')],
+  ['hello//world', success('hello')],
+  [`"hello//world"`, success('hello//world')],
+  [`/**/{/**/a:/**/b/**/,/**/c:/**/d/**/}/**/`, success({ a: 'b', c: 'd' })],
   [
     `{
       // foo: bar
@@ -195,30 +198,30 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         }
       }
     }`,
-    either.makeRight({
+    success({
       'static data': 'blah blah blah',
       'evaluated data': { tag: 'none', value: {} },
     }),
   ],
-  ['(a => :a)(A)', either.makeRight('A')],
-  ['{ a: (a => :a)(A) }', either.makeRight({ a: 'A' })],
-  ['{ a: ( a => :a )( A ) }', either.makeRight({ a: 'A' })],
-  ['(_ => B)(A)', either.makeRight('B')],
-  ['{ success }.0', either.makeRight('success')],
-  ['{ f: :identity }.f(success)', either.makeRight('success')],
-  ['{ f: :identity }.f({ a: success }).a', either.makeRight('success')],
+  ['(a => :a)(A)', success('A')],
+  ['{ a: (a => :a)(A) }', success({ a: 'A' })],
+  ['{ a: ( a => :a )( A ) }', success({ a: 'A' })],
+  ['(_ => B)(A)', success('B')],
+  ['{ success }.0', success('success')],
+  ['{ f: :identity }.f(success)', success('success')],
+  ['{ f: :identity }.f({ a: success }).a', success('success')],
   [
     '{ f: :identity }.f({ g: :identity }).g({ a: success }).a',
-    either.makeRight('success'),
+    success('success'),
   ],
-  ['{ a: { b: success } }.a.b', either.makeRight('success')],
+  ['{ a: { b: success } }.a.b', success('success')],
   [
     '{ a: { "b.c(d) e \\" {}": success } }.a."b.c(d) e \\" {}"',
-    either.makeRight('success'),
+    success('success'),
   ],
-  ['(a => { b: :a }.b)(success)', either.makeRight('success')],
-  ['(a => { b: :a })(success).b', either.makeRight('success')],
-  ['{ success }/**/./**/0', either.makeRight('success')],
+  ['(a => { b: :a }.b)(success)', success('success')],
+  ['(a => { b: :a })(success).b', success('success')],
+  ['{ success }/**/./**/0', success('success')],
   [
     `
       { a: { b: success } } // blah
@@ -227,13 +230,10 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         // blah
         .b // blah
     `,
-    either.makeRight('success'),
+    success('success'),
   ],
-  [
-    `/**/(/**/a/**/=>/**/:a/**/)(/**/output/**/)/**/`,
-    either.makeRight('output'),
-  ],
-  [':identity(output)', either.makeRight('output')],
+  [`/**/(/**/a/**/=>/**/:a/**/)(/**/output/**/)/**/`, success('output')],
+  [':identity(output)', success('output')],
   [
     '{ a: a => :a, b: :a(A) }',
     result => {
@@ -241,19 +241,22 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         assert.fail(result.value.message)
       }
       assert(typeof result.value === 'object')
-      assert.deepEqual(result.value['b'], 'A')
+      assert.deepEqual(
+        orderedRecord.get(result.value, 'b'),
+        option.makeSome('A'),
+      )
     },
   ],
-  [':boolean.or(false)(false)', either.makeRight('false')],
-  [':boolean.or(false)(true)', either.makeRight('true')],
-  [':boolean.or(true)(false)', either.makeRight('true')],
-  [':boolean.or(true)(true)', either.makeRight('true')],
-  [':boolean.and(false)(false)', either.makeRight('false')],
-  [':boolean.and(false)(true)', either.makeRight('false')],
-  [':boolean.and(true)(false)', either.makeRight('false')],
-  [':boolean.and(true)(true)', either.makeRight('true')],
-  [':match({ a: A })({ tag: a, value: {} })', either.makeRight('A')],
-  [':atom.prepend(a)(b)', either.makeRight('ab')],
+  [':boolean.or(false)(false)', success('false')],
+  [':boolean.or(false)(true)', success('true')],
+  [':boolean.or(true)(false)', success('true')],
+  [':boolean.or(true)(true)', success('true')],
+  [':boolean.and(false)(false)', success('false')],
+  [':boolean.and(false)(true)', success('false')],
+  [':boolean.and(true)(false)', success('false')],
+  [':boolean.and(true)(true)', success('true')],
+  [':match({ a: A })({ tag: a, value: {} })', success('A')],
+  [':atom.prepend(a)(b)', success('ab')],
   [
     `{
       :atom.equals(hello)(hello)
@@ -261,32 +264,32 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       :atom.equals(hello)(Hello)
       :atom.equals("1.0")("1.00")
     }`,
-    either.makeRight({ 0: 'true', 1: 'true', 2: 'false', 3: 'false' }),
+    success({ 0: 'true', 1: 'true', 2: 'false', 3: 'false' }),
   ],
-  [`:integer.add(1)(1)`, either.makeRight('2')],
+  [`:integer.add(1)(1)`, success('2')],
   [
     `:integer.add(one)(juan)`,
     output => {
       assert(either.isLeft(output))
     },
   ],
-  [`:integer.add(42)(-1)`, either.makeRight('41')],
-  [`42 + -1`, either.makeRight('41')],
-  [`:integer.subtract(-1)(-1)`, either.makeRight('0')],
-  [`-1 - -1`, either.makeRight('0')],
-  [`2 - 1`, either.makeRight('1')],
-  [`1 - 2 - 3`, either.makeRight('-4')],
-  [`1 - (2 - 3)`, either.makeRight('2')],
-  [`(1 - 2) - 3`, either.makeRight('-4')],
-  [`:integer.multiply(2)(2)`, either.makeRight('4')],
-  [`2 * 2`, either.makeRight('4')],
-  [`2 * -2`, either.makeRight('-4')],
-  [`-2 * -2`, either.makeRight('4')],
-  [`2 * 0`, either.makeRight('0')],
-  [':flow(:atom.append(b))(:atom.append(a))(z)', either.makeRight('zab')],
+  [`:integer.add(42)(-1)`, success('41')],
+  [`42 + -1`, success('41')],
+  [`:integer.subtract(-1)(-1)`, success('0')],
+  [`-1 - -1`, success('0')],
+  [`2 - 1`, success('1')],
+  [`1 - 2 - 3`, success('-4')],
+  [`1 - (2 - 3)`, success('2')],
+  [`(1 - 2) - 3`, success('-4')],
+  [`:integer.multiply(2)(2)`, success('4')],
+  [`2 * 2`, success('4')],
+  [`2 * -2`, success('-4')],
+  [`-2 * -2`, success('4')],
+  [`2 * 0`, success('0')],
+  [':flow(:atom.append(b))(:atom.append(a))(z)', success('zab')],
   [
     `@runtime { :object.lookup("key which does not exist in runtime context") }`,
-    either.makeRight({ tag: 'none', value: {} }),
+    success({ tag: 'none', value: {} }),
   ],
   [
     `:object.lookup(output)({
@@ -294,7 +297,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       is_less_than_three: :integer.is_less_than(3)
       output: :is_less_than_three(:add_one(1))
     })`,
-    either.makeRight({
+    success({
       tag: 'some',
       value: 'true',
     }),
@@ -305,14 +308,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     )(
       :integer.subtract(2)(4)
     )`,
-    either.makeRight('3'),
+    success('3'),
   ],
   [
     `{
       true: true
       false: :boolean.not(:true)
     }`,
-    either.makeRight({ true: 'true', false: 'false' }),
+    success({ true: 'true', false: 'false' }),
   ],
   [
     `@runtime {
@@ -337,13 +340,19 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         assert.fail(output.value.message)
       }
       assert(typeof output.value === 'object')
-      assert.deepEqual(output.value['tag'], 'some')
-      assert.deepEqual(typeof output.value['value'], 'string')
+      assert.deepEqual(
+        orderedRecord.get(output.value, 'tag'),
+        option.makeSome('some'),
+      )
+      option.match(orderedRecord.get(output.value, 'value'), {
+        none: () => assert.fail('expected `value` property'),
+        some: value => assert.equal(typeof value, 'string'),
+      })
     },
   ],
   [
     `(a => b => c => { :a, :b, :c })(0)(1)(2)`,
-    either.makeRight({ 0: 0, 1: 1, 2: 2 }),
+    success({ 0: '0', 1: '1', 2: '2' }),
   ],
   [
     `{
@@ -359,7 +368,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         }
       }
     }.a.b.c(a).d(b)(c).e.f(d).g`,
-    either.makeRight({ 0: 'a', 1: 'b', 2: 'c', 3: 'd' }),
+    success({ 0: 'a', 1: 'b', 2: 'c', 3: 'd' }),
   ],
   [
     `@runtime { context =>
@@ -370,8 +379,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         assert.fail(output.value.message)
       }
       assert(typeof output.value === 'object')
-      assert.deepEqual(output.value['tag'], 'some')
-      assert.deepEqual(typeof output.value['value'], 'string')
+      assert.deepEqual(
+        orderedRecord.get(output.value, 'tag'),
+        option.makeSome('some'),
+      )
+      option.match(orderedRecord.get(output.value, 'value'), {
+        none: () => assert.fail('expected `value` property'),
+        some: value => assert.equal(typeof value, 'string'),
+      })
     },
   ],
   [
@@ -380,7 +395,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       "it works!"
       @panic
     }`,
-    either.makeRight('it works!'),
+    success('it works!'),
   ],
   [
     `{
@@ -388,7 +403,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       b
       c
     }`,
-    either.makeRight({ 0: 'a', 1: 'b', 2: 'c' }),
+    success({ 0: 'a', 1: 'b', 2: 'c' }),
   ],
   [
     `@runtime { context =>
@@ -398,7 +413,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         @panic
       }
     }`,
-    either.makeRight('it works!'),
+    success('it works!'),
   ],
   [
     `{
@@ -410,57 +425,57 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         }
       result: :fibonacci(10)
     }.result`,
-    either.makeRight('55'),
+    success('55'),
   ],
   [
     `{
       +: (a: :integer.type) => (b: :integer.type) => :integer.add(:a)(:b)
       result: 1 + 1
      }.result`,
-    either.makeRight('2'),
+    success('2'),
   ],
-  [`1 + 1`, either.makeRight('2')],
-  [`1 integer.add 1`, either.makeRight('2')],
-  [`(1 + 1)`, either.makeRight('2')],
-  [`(2 - 1) + (4 - 2)`, either.makeRight('3')],
-  [`0 < 1`, either.makeRight('true')],
-  [`1 > 0`, either.makeRight('true')],
-  [`0 < 0`, either.makeRight('false')],
-  [`0 > 0`, either.makeRight('false')],
-  [`1 < 0`, either.makeRight('false')],
-  [`0 > 1`, either.makeRight('false')],
-  [`((a: :integer.type) => (1 + :a))(1)`, either.makeRight('2')],
-  [`2 |> (a => :a)`, either.makeRight('2')],
-  [`a atom.append b atom.append c`, either.makeRight('abc')],
-  [`b atom.append c atom.prepend a`, either.makeRight('abc')],
-  [`(b atom.append c) atom.prepend a`, either.makeRight('abc')],
-  [`a atom.append (c atom.prepend b)`, either.makeRight('abc')],
+  [`1 + 1`, success('2')],
+  [`1 integer.add 1`, success('2')],
+  [`(1 + 1)`, success('2')],
+  [`(2 - 1) + (4 - 2)`, success('3')],
+  [`0 < 1`, success('true')],
+  [`1 > 0`, success('true')],
+  [`0 < 0`, success('false')],
+  [`0 > 0`, success('false')],
+  [`1 < 0`, success('false')],
+  [`0 > 1`, success('false')],
+  [`((a: :integer.type) => (1 + :a))(1)`, success('2')],
+  [`2 |> (a => :a)`, success('2')],
+  [`a atom.append b atom.append c`, success('abc')],
+  [`b atom.append c atom.prepend a`, success('abc')],
+  [`(b atom.append c) atom.prepend a`, success('abc')],
+  [`a atom.append (c atom.prepend b)`, success('abc')],
   [
     `{ a: "it works!" } object.lookup a`,
-    either.makeRight({ tag: 'some', value: 'it works!' }),
+    success({ tag: 'some', value: 'it works!' }),
   ],
-  [`{ a: :identity }.a(1) + 1`, either.makeRight('2')],
+  [`{ a: :identity }.a(1) + 1`, success('2')],
   [
     `1
       + 2
       + 3
       + 4`,
-    either.makeRight('10'),
+    success('10'),
   ],
   [
     `1 +
      2 +
      3 +
      4`,
-    either.makeRight('10'),
+    success('10'),
   ],
-  [`{ f: _ => 5 % 3 }.f(whatever)`, either.makeRight('2')],
+  [`{ f: _ => 5 % 3 }.f(whatever)`, success('2')],
   [
     `{
       one: 1
       two: :one + :one
     }.two`,
-    either.makeRight('2'),
+    success('2'),
   ],
   [
     `@runtime { context =>
@@ -490,21 +505,21 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       four: 4
       ten: :one + :two + :three + :four
     }.ten`,
-    either.makeRight('10'),
+    success('10'),
   ],
   [
     `{
       add_ten: :integer.add(1) >> :integer.add(9)
     }.add_ten(0)`,
-    either.makeRight('10'),
+    success('10'),
   ],
-  [`1 + @if { true, 9, 1 }`, either.makeRight('10')],
+  [`1 + @if { true, 9, 1 }`, success('10')],
   [
     `{
       1 + @if
       { true, 9, 1 }
     }.0`,
-    either.makeRight('10'),
+    success('10'),
   ],
   [
     `(
@@ -513,7 +528,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         >> :+(3)
         >> :+(4)
     )(0)`,
-    either.makeRight('10'),
+    success('10'),
   ],
   [
     `(
@@ -522,17 +537,17 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       :+(3) >>
       :+(4)
     )(0)`,
-    either.makeRight('10'),
+    success('10'),
   ],
-  [`a |> :atom.append(b) |> :atom.append(c)`, either.makeRight('abc')],
-  [`a |> (:atom.append(b) >> :atom.append(c))`, either.makeRight('abc')],
-  [`:|>(:>>(:atom.append(c))(:atom.append(b)))(a)`, either.makeRight('abc')],
+  [`a |> :atom.append(b) |> :atom.append(c)`, success('abc')],
+  [`a |> (:atom.append(b) >> :atom.append(c))`, success('abc')],
+  [`:|>(:>>(:atom.append(c))(:atom.append(b)))(a)`, success('abc')],
   [
     `{
       append_bc: :atom.append(b) >> :atom.append(c)
       abc: a |> :append_bc
     }.abc`,
-    either.makeRight('abc'),
+    success('abc'),
   ],
   [
     `{
@@ -557,7 +572,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         some: :identity
       }
     }.output`,
-    either.makeRight('it works!'),
+    success('it works!'),
   ],
   [
     // Lookups should never target keyword expression properties.
@@ -602,7 +617,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         }.result
       }.result
     }`,
-    either.makeRight({
+    success({
       0: 'it works!',
       1: 'it works!',
       2: 'it works!',
@@ -622,7 +637,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       d: { z: -42 } assume { z: :integer.type }
       e: "not a number" assume @union { :integer.type, "not a number" }
     }`,
-    either.makeRight({
+    success({
       a: '42',
       b: 'true',
       c: {},
@@ -645,12 +660,9 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       none: _ => a
       some: _ => b
     }`,
-    either.makeRight('a'),
+    success('a'),
   ],
-  [
-    `((a: :integer.type) => (b: :integer.type) => :a + :b)(1)(1)`,
-    either.makeRight('2'),
-  ],
+  [`((a: :integer.type) => (b: :integer.type) => :a + :b)(1)(1)`, success('2')],
   [
     `{
       f: (state: { current: :integer.type, limit: :integer.type }) => @if {
@@ -662,7 +674,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         })
       }
     }.f({ current: 0, limit: 3 })`,
-    either.makeRight('it works'),
+    success('it works'),
   ],
   [
     `((inner: { a: :boolean.type }) => @if {
@@ -670,7 +682,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       then: "it works"
       else: { @panic }
     })({ a: true })`,
-    either.makeRight('it works'),
+    success('it works'),
   ],
   [
     `((outer: :boolean.type) =>
@@ -682,7 +694,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         }
       )({ value: false })
     )(false)`,
-    either.makeRight('true'),
+    success('true'),
   ],
   [
     `((outer: :boolean.type) =>
@@ -694,12 +706,9 @@ testCases(endToEnd, code => code)('end-to-end tests', [
         }
       )({ value: false })
     )(true)`,
-    either.makeRight('it works'),
+    success('it works'),
   ],
-  [
-    `(:boolean.not ~ (:boolean.type ~> :boolean.type))(false)`,
-    either.makeRight('true'),
-  ],
+  [`(:boolean.not ~ (:boolean.type ~> :boolean.type))(false)`, success('true')],
   [
     `:boolean.not ~ (:boolean.type ~> :integer.type)`,
     result => {
@@ -710,14 +719,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{ 1 integer.equals 1, 1 integer.equals 2 }`,
-    either.makeRight({ 0: 'true', 1: 'false' }),
+    success({ 0: 'true', 1: 'false' }),
   ],
   [
     `{ b: 1, c: 1, d: 1 } object.overlay { a: 1, b: 2, c: 3 }`,
-    either.makeRight({ a: '1', b: '2', c: '3', d: '1' }),
+    success({ b: '2', c: '3', d: '1', a: '1' }),
   ],
-  [`:object.from_property(key)(value)`, either.makeRight({ key: 'value' })],
-  [`(1 + 1) ~ :integer.type`, either.makeRight('2')],
+  [`:object.from_property(key)(value)`, success({ key: 'value' })],
+  [`(1 + 1) ~ :integer.type`, success('2')],
   [
     `{
       1 ~ :something.type
@@ -740,7 +749,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [
     // `true | (false || true) | false`
     'true | false || true | false',
-    either.makeRight({
+    success({
       0: '@union',
       // TODO: Consider normalizing away the duplicate `true`s.
       1: { 0: 'true', 1: 'true', 2: 'false' },
@@ -749,7 +758,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [
     // `true | (false ~> (true | false))`
     'true | false ~> true | false',
-    either.makeRight({
+    success({
       '0': '@union',
       '1': {
         '0': 'true',
@@ -766,7 +775,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [
     // `true | (false => (true | false))`
     'true | false => true | false',
-    either.makeRight({
+    success({
       '0': '@union',
       '1': {
         '0': 'true',
@@ -783,7 +792,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [
     // `false | (true ~ true) | false`
     'false | true ~ true | false',
-    either.makeRight({
+    success({
       '0': '@union',
       // TODO: Consider normalizing away the duplicate `false`s.
       '1': { '0': 'false', '1': 'true', '2': 'false' },
@@ -796,7 +805,7 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       ab: a |> :atom.append(b)
       abc: :ab |> :atom.append(c)
     }.abc`,
-    either.makeRight('abc'),
+    success('abc'),
   ],
   [
     `{
@@ -806,6 +815,6 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       }
       two: :increment(1)
     }.two`,
-    either.makeRight('2'),
+    success('2'),
   ],
 ])

--- a/src/language/cli/1.ts
+++ b/src/language/cli/1.ts
@@ -1,8 +1,11 @@
 import { compile } from '../compiling/compiler.js'
+import { canonicalize } from '../parsing.js'
 import { handleInput } from './input.js'
 import { handleOutput } from './output.js'
 
 const main = (process: NodeJS.Process): Promise<undefined> =>
-  handleOutput(process, () => handleInput(process, compile))
+  handleOutput(process, () =>
+    handleInput(process, input => compile(canonicalize(input))),
+  )
 
 await main(process)

--- a/src/language/cli/2.ts
+++ b/src/language/cli/2.ts
@@ -1,8 +1,11 @@
+import { canonicalize } from '../parsing.js'
 import { evaluate } from '../runtime.js'
 import { handleInput } from './input.js'
 import { handleOutput } from './output.js'
 
 const main = async (process: NodeJS.Process): Promise<undefined> =>
-  handleOutput(process, () => handleInput(process, evaluate))
+  handleOutput(process, () =>
+    handleInput(process, input => evaluate(canonicalize(input))),
+  )
 
 await main(process)

--- a/src/language/cli/please.ts
+++ b/src/language/cli/please.ts
@@ -1,23 +1,18 @@
-import either, { type Either } from '@matt.kantor/either'
+import either from '@matt.kantor/either'
 import { compile } from '../compiling.js'
-import type { Atom, Molecule } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import { evaluate } from '../runtime.js'
-import type { Output } from '../semantics.js'
 import { readString } from './input.js'
 import { handleOutput } from './output.js'
-
-type SimpleResult = Either<{ readonly message: string }, Atom | Molecule>
 
 const main = async (process: NodeJS.Process): Promise<undefined> =>
   handleOutput(process, async () => {
     const sourceCode = await readString(process.stdin)
 
     // TODO: Cache intermediate representations to the filesystem.
-    const syntaxTree: SimpleResult = parse(sourceCode)
-    const program: SimpleResult = either.flatMap(syntaxTree, compile)
-    const runtimeOutput: Either<{ readonly message: string }, Output> =
-      either.flatMap(program, evaluate)
+    const syntaxTree = parse(sourceCode)
+    const program = either.flatMap(syntaxTree, compile)
+    const runtimeOutput = either.flatMap(program, evaluate)
 
     return runtimeOutput
   })

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2,186 +2,188 @@ import either, { type Either } from '@matt.kantor/either'
 import assert from 'node:assert'
 import { withPhantomData } from '../../phantom-data.js'
 import { testCases } from '../../test-utilities.test.js'
+import type { JsonValue } from '../../utility-types.js'
 import type { ElaborationError } from '../errors.js'
-import { type Atom, type Molecule } from '../parsing.js'
+import {
+  canonicalize,
+  type JsonValueForbiddingSymbolicKeys,
+} from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import type { Output } from '../semantics.js'
 import { compile } from './compiler.js'
 
-const success = (
-  expectedOutput: Atom | Molecule,
-): Either<ElaborationError, Output> =>
-  either.makeRight(withPhantomData<never>()(expectedOutput))
+const success = (expectedOutput: JsonValue): Either<ElaborationError, Output> =>
+  either.makeRight(withPhantomData<never>()(canonicalize(expectedOutput)))
 
-testCases(compile, input => `compiling \`${JSON.stringify(input)}\``)(
-  'compiler',
+const canonicalizeAndCompile = (input: JsonValueForbiddingSymbolicKeys) =>
+  compile(canonicalize(input))
+
+testCases(
+  canonicalizeAndCompile,
+  input => `compiling \`${JSON.stringify(input)}\``,
+)('compiler', [
+  ['Hello, world!', success('Hello, world!')],
   [
-    ['Hello, world!', success('Hello, world!')],
-    [
-      {
-        true1: true,
-        true2: [
-          '@apply',
-          [['@index', [['@lookup', ['boolean']], ['not']]], false],
-        ],
-        false1: 'false',
-        false2: [
-          '@apply',
-          [['@index', [['@lookup', ['boolean']], ['is']]], 'not a boolean'],
-        ],
-      },
-      success({
-        true1: 'true',
-        true2: 'true',
-        false1: 'false',
-        false2: 'false',
-      }),
-    ],
-    [
-      ['@runtime', [['@lookup', ['identity']]]],
-      success({
-        0: '@runtime',
-        1: { function: { 0: '@lookup', 1: { key: 'identity' } } },
-      }),
-    ],
-    [
-      [
-        '@runtime',
-        [
-          [
-            '@apply',
-            [
-              ['@lookup', ['identity']],
-              ['@lookup', ['identity']],
-            ],
-          ],
-        ],
+    {
+      true1: true,
+      true2: [
+        '@apply',
+        [['@index', [['@lookup', ['boolean']], ['not']]], false],
       ],
-      success({
-        0: '@runtime',
-        1: { function: { 0: '@lookup', 1: { key: 'identity' } } },
-      }),
-    ],
-    [[['@lookup', ['compose']]], output => assert(either.isLeft(output))],
-    [
-      ['@runtime', [['@index', [['@lookup', ['boolean']], ['not']]]]],
-      output => {
-        assert(either.isLeft(output))
-        assert(output.value.kind === 'typeMismatch')
-      },
-    ],
-    [
-      [
-        '@runtime',
-        [
-          [
-            '@apply',
-            [
-              ['@lookup', ['identity']],
-              ['@index', [['@lookup', ['boolean']], ['not']]],
-            ],
-          ],
-        ],
+      false1: 'false',
+      false2: [
+        '@apply',
+        [['@index', [['@lookup', ['boolean']], ['is']]], 'not a boolean'],
       ],
-      output => {
-        assert(either.isLeft(output))
-        assert(output.value.kind === 'typeMismatch')
-      },
-    ],
-    [
-      [
-        '@runtime',
-        [
-          [
-            '@apply',
-            [
-              [
-                '@apply',
-                [
-                  ['@lookup', ['flow']],
-                  ['@lookup', ['identity']],
-                ],
-              ],
-              ['@lookup', ['identity']],
-            ],
-          ],
-        ],
-      ],
-      success({
-        0: '@runtime',
-        1: {
-          function: {
-            0: '@apply',
-            1: {
-              function: {
-                0: '@apply',
-                1: {
-                  function: { 0: '@lookup', 1: { key: 'flow' } },
-                  argument: { 0: '@lookup', 1: { key: 'identity' } },
-                },
-              },
-              argument: { 0: '@lookup', 1: { key: 'identity' } },
-            },
-          },
-        },
-      }),
-    ],
-    [
-      ['@runtime', [['@index', [['@lookup', ['boolean']], ['not']]]]],
-      output => {
-        assert(either.isLeft(output))
-        assert(output.value.kind === 'typeMismatch')
-      },
-    ],
-    [
-      {
-        0: '@runtime',
-        1: {
-          function: {
-            0: '@apply',
-            1: {
-              function: {
-                0: '@index',
-                1: {
-                  object: { 0: '@lookup', 1: { key: 'object' } },
-                  query: { 0: 'lookup' },
-                },
-              },
-              argument: 'key which does not exist in runtime context',
-            },
-          },
-        },
-      },
-      success({
-        0: '@runtime',
-        1: {
-          function: {
-            0: '@apply',
-            1: {
-              function: {
-                0: '@index',
-                1: {
-                  object: { 0: '@lookup', 1: { key: 'object' } },
-                  query: { 0: 'lookup' },
-                },
-              },
-              argument: 'key which does not exist in runtime context',
-            },
-          },
-        },
-      }),
-    ],
-    [
-      { a: ['@lookup', ['b']], b: ['@index', [[42], ['0']]] },
-      success({ a: '42', b: '42' }),
-    ],
+    },
+    success({
+      true1: 'true',
+      true2: 'true',
+      false1: 'false',
+      false2: 'false',
+    }),
   ],
-)
+  [
+    ['@runtime', [['@lookup', ['identity']]]],
+    success({
+      0: '@runtime',
+      1: { function: { 0: '@lookup', 1: { key: 'identity' } } },
+    }),
+  ],
+  [
+    [
+      '@runtime',
+      [
+        [
+          '@apply',
+          [
+            ['@lookup', ['identity']],
+            ['@lookup', ['identity']],
+          ],
+        ],
+      ],
+    ],
+    success({
+      0: '@runtime',
+      1: { function: { 0: '@lookup', 1: { key: 'identity' } } },
+    }),
+  ],
+  [[['@lookup', ['compose']]], output => assert(either.isLeft(output))],
+  [
+    ['@runtime', [['@index', [['@lookup', ['boolean']], ['not']]]]],
+    output => {
+      assert(either.isLeft(output))
+      assert(output.value.kind === 'typeMismatch')
+    },
+  ],
+  [
+    [
+      '@runtime',
+      [
+        [
+          '@apply',
+          [
+            ['@lookup', ['identity']],
+            ['@index', [['@lookup', ['boolean']], ['not']]],
+          ],
+        ],
+      ],
+    ],
+    output => {
+      assert(either.isLeft(output))
+      assert(output.value.kind === 'typeMismatch')
+    },
+  ],
+  [
+    [
+      '@runtime',
+      [
+        [
+          '@apply',
+          [
+            [
+              '@apply',
+              [
+                ['@lookup', ['flow']],
+                ['@lookup', ['identity']],
+              ],
+            ],
+            ['@lookup', ['identity']],
+          ],
+        ],
+      ],
+    ],
+    success({
+      0: '@runtime',
+      1: {
+        function: {
+          0: '@apply',
+          1: {
+            function: {
+              0: '@apply',
+              1: {
+                function: { 0: '@lookup', 1: { key: 'flow' } },
+                argument: { 0: '@lookup', 1: { key: 'identity' } },
+              },
+            },
+            argument: { 0: '@lookup', 1: { key: 'identity' } },
+          },
+        },
+      },
+    }),
+  ],
+  [
+    ['@runtime', [['@index', [['@lookup', ['boolean']], ['not']]]]],
+    output => {
+      assert(either.isLeft(output))
+      assert(output.value.kind === 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@runtime',
+      1: {
+        function: {
+          0: '@apply',
+          1: {
+            function: {
+              0: '@index',
+              1: {
+                object: { 0: '@lookup', 1: { key: 'object' } },
+                query: { 0: 'lookup' },
+              },
+            },
+            argument: 'key which does not exist in runtime context',
+          },
+        },
+      },
+    },
+    success({
+      0: '@runtime',
+      1: {
+        function: {
+          0: '@apply',
+          1: {
+            function: {
+              0: '@index',
+              1: {
+                object: { 0: '@lookup', 1: { key: 'object' } },
+                query: { 0: 'lookup' },
+              },
+            },
+            argument: 'key which does not exist in runtime context',
+          },
+        },
+      },
+    }),
+  ],
+  [
+    { a: ['@lookup', ['b']], b: ['@index', [[42], ['0']]] },
+    success({ a: '42', b: '42' }),
+  ],
+])
 
-const parseAndCompile = (input: string) =>
-  either.flatMap(parse(input), (syntaxTree: Atom | Molecule) =>
-    compile(syntaxTree),
-  )
+const parseAndCompile = (input: string) => either.flatMap(parse(input), compile)
 
 testCases(
   parseAndCompile,
@@ -525,7 +527,11 @@ testCases(
   [
     '{ f: :identity >> :identity, :f(@runtime { _ => 1 }) ~ 1 }',
     result => {
-      assert(either.isRight(result))
+      // TODO: Make this type-check again. This happened to work before because
+      // of how the wonky elaboration order kept the `@apply` deferred. Revisit
+      // once migration to source-order elaboration is complete.
+      assert(either.isLeft(result))
+      assert(result.value.kind === 'typeMismatch')
     },
   ],
 
@@ -762,6 +768,37 @@ testCases(
     `{
       constrain_function: (f: { a: :atom.type } ~> :atom.type) => :f({ a: hello })
       should_use_contextual_type: :constrain_function(x => :x.a)
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: { a: :something.type }) => {}
+      :f({ a: a })
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      type: :boolean.type
+      f: (x: { a: :type }) => {}
+      :f({ a: true })
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: 1 + 1) => {}
+      :f(2)
     }`,
     result => {
       assert(either.isRight(result))

--- a/src/language/compiling/compiler.ts
+++ b/src/language/compiling/compiler.ts
@@ -1,14 +1,12 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { CompilationError } from '../errors.js'
-import type { JsonValueForbiddingSymbolicKeys } from '../parsing.js'
-import { canonicalize } from '../parsing.js'
+import type { SyntaxTree } from '../parsing.js'
 import { elaborate, serialize, type Output } from '../semantics.js'
 import { keywordHandlers } from './semantics/keywords.js'
 
 export const compile = (
-  input: JsonValueForbiddingSymbolicKeys,
+  syntaxTree: SyntaxTree,
 ): Either<CompilationError, Output> => {
-  const syntaxTree = canonicalize(input)
   const semanticGraphResult = elaborate(syntaxTree, keywordHandlers)
   return either.flatMap(semanticGraphResult, serialize)
 }

--- a/src/language/compiling/parsing.test.ts
+++ b/src/language/compiling/parsing.test.ts
@@ -1,254 +1,388 @@
 import either from '@matt.kantor/either'
 import assert from 'node:assert'
+import * as orderedRecord from '../../ordered-record.js'
 import { withPhantomData } from '../../phantom-data.js'
 import { testCases } from '../../test-utilities.test.js'
-import { canonicalize, type Atom, type Molecule } from '../parsing.js'
+import { canonicalize, type Atom, type SyntaxTree } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
+import { type Canonicalized } from '../parsing/syntax-tree.js'
 
-const syntaxTree = withPhantomData<never>()<Atom | Molecule>
+type Entries = readonly (readonly [string, Atom | Entries])[]
+
+const syntaxTree = (input: Atom | Entries): SyntaxTree =>
+  withPhantomData<Canonicalized>()(
+    typeof input === 'string' ? input : (
+      orderedRecord.make(
+        [...input].map(([key, value]) => [key, syntaxTree(value)]),
+      )
+    ),
+  )
 
 testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ['a', either.makeRight(syntaxTree('a'))],
 
-  ['{}', either.makeRight(syntaxTree({}))],
+  ['{}', either.makeRight(syntaxTree([]))],
 
   [
     ':a',
     either.makeRight(
-      syntaxTree({
-        '0': '@lookup',
-        '1': { key: 'a' },
-      }),
+      syntaxTree([
+        ['0', '@lookup'],
+        ['1', [['key', 'a']]],
+      ]),
     ),
   ],
 
   [
     '{}.a',
     either.makeRight(
-      syntaxTree({
-        '0': '@index',
-        '1': {
-          object: {},
-          query: { '0': 'a' },
-        },
-      }),
+      syntaxTree([
+        ['0', '@index'],
+        [
+          '1',
+          [
+            ['object', []],
+            ['query', [['0', 'a']]],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     'a => b',
     either.makeRight(
-      syntaxTree({
-        '0': '@function',
-        '1': {
-          parameter: 'a',
-          body: 'b',
-        },
-      }),
+      syntaxTree([
+        ['0', '@function'],
+        [
+          '1',
+          [
+            ['parameter', 'a'],
+            ['body', 'b'],
+          ],
+        ],
+      ]),
     ),
   ],
   [
     'a => b => c',
     either.makeRight(
-      syntaxTree({
-        '0': '@function',
-        '1': {
-          parameter: 'a',
-          body: {
-            '0': '@function',
-            '1': {
-              parameter: 'b',
-              body: 'c',
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@function'],
+        [
+          '1',
+          [
+            ['parameter', 'a'],
+            [
+              'body',
+              [
+                ['0', '@function'],
+                [
+                  '1',
+                  [
+                    ['parameter', 'b'],
+                    ['body', 'c'],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     '(a: b) => c',
     either.makeRight(
-      syntaxTree({
-        '0': '@function',
-        '1': {
-          parameter: { a: 'b' },
-          body: 'c',
-        },
-      }),
+      syntaxTree([
+        ['0', '@function'],
+        [
+          '1',
+          [
+            ['parameter', [['a', 'b']]],
+            ['body', 'c'],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     '(a: :integer.type) => :a',
     either.makeRight(
-      syntaxTree({
-        '0': '@function',
-        '1': {
-          parameter: {
-            a: {
-              '0': '@index',
-              '1': {
-                object: { '0': '@lookup', '1': { key: 'integer' } },
-                query: { '0': 'type' },
-              },
-            },
-          },
-          body: { '0': '@lookup', '1': { key: 'a' } },
-        },
-      }),
+      syntaxTree([
+        ['0', '@function'],
+        [
+          '1',
+          [
+            [
+              'parameter',
+              [
+                [
+                  'a',
+                  [
+                    ['0', '@index'],
+                    [
+                      '1',
+                      [
+                        [
+                          'object',
+                          [
+                            ['0', '@lookup'],
+                            ['1', [['key', 'integer']]],
+                          ],
+                        ],
+                        ['query', [['0', 'type']]],
+                      ],
+                    ],
+                  ],
+                ],
+              ],
+            ],
+            [
+              'body',
+              [
+                ['0', '@lookup'],
+                ['1', [['key', 'a']]],
+              ],
+            ],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     '(a: b) => (c: d) => e',
     either.makeRight(
-      syntaxTree({
-        '0': '@function',
-        '1': {
-          parameter: { a: 'b' },
-          body: {
-            '0': '@function',
-            '1': {
-              parameter: { c: 'd' },
-              body: 'e',
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@function'],
+        [
+          '1',
+          [
+            ['parameter', [['a', 'b']]],
+            [
+              'body',
+              [
+                ['0', '@function'],
+                [
+                  '1',
+                  [
+                    ['parameter', [['c', 'd']]],
+                    ['body', 'e'],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     'a => (b: c) => d',
     either.makeRight(
-      syntaxTree({
-        '0': '@function',
-        '1': {
-          parameter: 'a',
-          body: {
-            '0': '@function',
-            '1': {
-              parameter: { b: 'c' },
-              body: 'd',
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@function'],
+        [
+          '1',
+          [
+            ['parameter', 'a'],
+            [
+              'body',
+              [
+                ['0', '@function'],
+                [
+                  '1',
+                  [
+                    ['parameter', [['b', 'c']]],
+                    ['body', 'd'],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     'a ~> b',
     either.makeRight(
-      syntaxTree({
-        '0': '@signature',
-        '1': {
-          parameter: 'a',
-          return: 'b',
-        },
-      }),
+      syntaxTree([
+        ['0', '@signature'],
+        [
+          '1',
+          [
+            ['parameter', 'a'],
+            ['return', 'b'],
+          ],
+        ],
+      ]),
     ),
   ],
   [
     'a ~> b ~> c',
     either.makeRight(
-      syntaxTree({
-        '0': '@signature',
-        '1': {
-          parameter: 'a',
-          return: {
-            '0': '@signature',
-            '1': {
-              parameter: 'b',
-              return: 'c',
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@signature'],
+        [
+          '1',
+          [
+            ['parameter', 'a'],
+            [
+              'return',
+              [
+                ['0', '@signature'],
+                [
+                  '1',
+                  [
+                    ['parameter', 'b'],
+                    ['return', 'c'],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     'a ~ b',
     either.makeRight(
-      syntaxTree({
-        '0': '@check',
-        '1': {
-          value: 'a',
-          type: 'b',
-        },
-      }),
+      syntaxTree([
+        ['0', '@check'],
+        [
+          '1',
+          [
+            ['value', 'a'],
+            ['type', 'b'],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     ':a ~ :integer.type',
     either.makeRight(
-      syntaxTree({
-        '0': '@check',
-        '1': {
-          value: { '0': '@lookup', '1': { key: 'a' } },
-          type: {
-            '0': '@index',
-            '1': {
-              object: { '0': '@lookup', '1': { key: 'integer' } },
-              query: { '0': 'type' },
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@check'],
+        [
+          '1',
+          [
+            [
+              'value',
+              [
+                ['0', '@lookup'],
+                ['1', [['key', 'a']]],
+              ],
+            ],
+            [
+              'type',
+              [
+                ['0', '@index'],
+                [
+                  '1',
+                  [
+                    [
+                      'object',
+                      [
+                        ['0', '@lookup'],
+                        ['1', [['key', 'integer']]],
+                      ],
+                    ],
+                    ['query', [['0', 'type']]],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     '(a => a)(a)',
     either.makeRight(
-      syntaxTree({
-        0: '@apply',
-        1: {
-          argument: 'a',
-          function: {
-            '0': '@function',
-            '1': {
-              body: 'a',
-              parameter: 'a',
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@apply'],
+        [
+          '1',
+          [
+            [
+              'function',
+              [
+                ['0', '@function'],
+                [
+                  '1',
+                  [
+                    ['parameter', 'a'],
+                    ['body', 'a'],
+                  ],
+                ],
+              ],
+            ],
+            ['argument', 'a'],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     '1 + 1',
     either.makeRight(
-      syntaxTree({
-        0: '@apply',
-        1: {
-          argument: '1',
-          function: {
-            0: '@apply',
-            1: {
-              argument: '1',
-              function: {
-                '0': '@lookup',
-                '1': { key: '+' },
-              },
-            },
-          },
-        },
-      }),
+      syntaxTree([
+        ['0', '@apply'],
+        [
+          '1',
+          [
+            [
+              'function',
+              [
+                ['0', '@apply'],
+                [
+                  '1',
+                  [
+                    [
+                      'function',
+                      [
+                        ['0', '@lookup'],
+                        ['1', [['key', '+']]],
+                      ],
+                    ],
+                    ['argument', '1'],
+                  ],
+                ],
+              ],
+            ],
+            ['argument', '1'],
+          ],
+        ],
+      ]),
     ),
   ],
 
   [
     'a | b',
     either.makeRight(
-      syntaxTree({
-        0: '@union',
-        1: { 0: 'a', 1: 'b' },
-      }),
+      syntaxTree([
+        ['0', '@union'],
+        [
+          '1',
+          [
+            ['0', 'a'],
+            ['1', 'b'],
+          ],
+        ],
+      ]),
     ),
   ],
 
@@ -267,26 +401,44 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
 testCases(canonicalize, input => `canonicalizing \`${JSON.stringify(input)}\``)(
   'canonicalization',
   [
-    [{}, syntaxTree({})],
-    [[], syntaxTree({})],
+    [{}, syntaxTree([])],
+    [[], syntaxTree([])],
     ['a', syntaxTree('a')],
     [1, syntaxTree('1')],
     [Number.EPSILON, syntaxTree('2.220446049250313e-16')],
     [null, syntaxTree('null')],
     [true, syntaxTree('true')],
     [false, syntaxTree('false')],
-    [['a'], syntaxTree({ 0: 'a' })],
-    [{ 0: 'a' }, syntaxTree({ 0: 'a' })],
-    [{ 1: 'a' }, syntaxTree({ 1: 'a' })],
+    [['a'], syntaxTree([['0', 'a']])],
+    [{ 0: 'a' }, syntaxTree([['0', 'a']])],
+    [{ 1: 'a' }, syntaxTree([['1', 'a']])],
     [
       ['a', { b: [], c: { d: ['e', {}, 42] } }, 'f', { g: null }, true],
-      syntaxTree({
-        0: 'a',
-        1: { b: {}, c: { d: { 0: 'e', 1: {}, 2: '42' } } },
-        2: 'f',
-        3: { g: 'null' },
-        4: 'true',
-      }),
+      syntaxTree([
+        ['0', 'a'],
+        [
+          '1',
+          [
+            ['b', []],
+            [
+              'c',
+              [
+                [
+                  'd',
+                  [
+                    ['0', 'e'],
+                    ['1', []],
+                    ['2', '42'],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ],
+        ['2', 'f'],
+        ['3', [['g', 'null']]],
+        ['4', 'true'],
+      ]),
     ],
   ],
 )

--- a/src/language/compiling/parsing.test.ts
+++ b/src/language/compiling/parsing.test.ts
@@ -1,21 +1,17 @@
 import either from '@matt.kantor/either'
 import assert from 'node:assert'
 import * as orderedRecord from '../../ordered-record.js'
-import { withPhantomData } from '../../phantom-data.js'
 import { testCases } from '../../test-utilities.test.js'
 import { canonicalize, type Atom, type SyntaxTree } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
-import { type Canonicalized } from '../parsing/syntax-tree.js'
 
 type Entries = readonly (readonly [string, Atom | Entries])[]
 
 const syntaxTree = (input: Atom | Entries): SyntaxTree =>
-  withPhantomData<Canonicalized>()(
-    typeof input === 'string' ? input : (
-      orderedRecord.make(
-        [...input].map(([key, value]) => [key, syntaxTree(value)]),
-      )
-    ),
+  typeof input === 'string' ? input : (
+    orderedRecord.make(
+      [...input].map(([key, value]) => [key, syntaxTree(value)]),
+    )
   )
 
 testCases(parse, input => `parsing \`${input}\``)('parsing', [

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -18,7 +18,6 @@ import {
   type ExpressionContext,
   type KeyPath,
   type KeywordHandler,
-  type Output,
   type SemanticGraph,
 } from '../../../semantics.js'
 
@@ -65,14 +64,14 @@ export const ifKeywordHandler: KeywordHandler = (
           return either.flatMap(
             either.flatMap(
               inferType(elaboratedCondition, context),
-              (conditionType): Either<ElaborationError, Output> =>
+              conditionType =>
                 (
                   isAssignable({
                     source: conditionType,
                     target: types.boolean,
                   })
                 ) ?
-                  serialize(elaboratedCondition)
+                  either.makeRight(elaboratedCondition)
                 : either.makeLeft({
                     kind: 'typeMismatch',
                     message: `\`@if\` condition was not assignable to \`${showType(types.boolean)}\` (it was \`${showType(conditionType)}\`)`,
@@ -149,7 +148,7 @@ export const ifKeywordHandler: KeywordHandler = (
                   ]),
                   ([elaboratedThen, elaboratedElse]) =>
                     makeIfExpression({
-                      condition: asSemanticGraph(condition),
+                      condition,
                       then: elaboratedThen,
                       else: elaboratedElse,
                     }),

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -6,7 +6,7 @@ import {
   applyKeyPathToType,
   containsAnyUnelaboratedNodes,
   inferType,
-  keyPathFromObjectNodeOrMolecule,
+  keyPathFromObjectNode,
   readIndexExpression,
   showType,
   stringifyKeyPathForEndUser,
@@ -39,27 +39,24 @@ export const indexKeywordHandler: KeywordHandler = (
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   either.flatMap(readIndexExpression(expression), indexExpression =>
-    either.flatMap(
-      keyPathFromObjectNodeOrMolecule(indexExpression[1].query),
-      keyPath => {
-        const object = indexExpression[1].object
-        return either.flatMap(
-          checkKeyPathExistsInType(object, keyPath, context),
-          _ =>
-            containsAnyUnelaboratedNodes(object) ?
-              // The object isn't ready, so keep the @index unelaborated.
-              either.makeRight(indexExpression)
-            : option.match(applyKeyPathToSemanticGraph(object, keyPath), {
-                none: () =>
-                  either.makeLeft({
-                    kind: 'typeMismatch',
-                    message: `property \`${stringifyKeyPathForEndUser(
-                      keyPath,
-                    )}\` not found`,
-                  }),
-                some: either.makeRight,
-              }),
-        )
-      },
-    ),
+    either.flatMap(keyPathFromObjectNode(indexExpression[1].query), keyPath => {
+      const object = indexExpression[1].object
+      return either.flatMap(
+        checkKeyPathExistsInType(object, keyPath, context),
+        _ =>
+          containsAnyUnelaboratedNodes(object) ?
+            // The object isn't ready, so keep the @index unelaborated.
+            either.makeRight(indexExpression)
+          : option.match(applyKeyPathToSemanticGraph(object, keyPath), {
+              none: () =>
+                either.makeLeft({
+                  kind: 'typeMismatch',
+                  message: `property \`${stringifyKeyPathForEndUser(
+                    keyPath,
+                  )}\` not found`,
+                }),
+              some: either.makeRight,
+            }),
+      )
+    }),
   )

--- a/src/language/compiling/semantics/test-utilities.test.ts
+++ b/src/language/compiling/semantics/test-utilities.test.ts
@@ -1,9 +1,9 @@
 import either, { type Either } from '@matt.kantor/either'
 import { withPhantomData } from '../../../phantom-data.js'
 import { testCases } from '../../../test-utilities.test.js'
-import type { Writable } from '../../../utility-types.js'
+import type { JsonValue, Writable } from '../../../utility-types.js'
 import type { ElaborationError } from '../../errors.js'
-import type { Atom, Molecule } from '../../parsing.js'
+import { canonicalize, type Molecule } from '../../parsing.js'
 import {
   elaborate,
   makeObjectNode,
@@ -14,25 +14,26 @@ import type { SemanticGraph } from '../../semantics/semantic-graph.js'
 import { keywordHandlers } from './keywords.js'
 
 export const elaborationSuite = testCases(
-  (input: Atom | Molecule) =>
-    elaborate(withPhantomData<never>()(input), keywordHandlers),
+  (input: JsonValue) => elaborate(canonicalize(input), keywordHandlers),
   input => `elaborating \`${JSON.stringify(input)}\``,
 )
 
 export const success = (
-  expectedOutput: Atom | Molecule,
-): Either<ElaborationError, ElaboratedSemanticGraph> =>
-  either.makeRight(
+  expectedOutput: JsonValue,
+): Either<ElaborationError, ElaboratedSemanticGraph> => {
+  const canonicalized = canonicalize(expectedOutput)
+  return either.makeRight(
     withPhantomData<never>()(
-      typeof expectedOutput === 'string' ? expectedOutput : (
-        literalMoleculeToObjectNode(expectedOutput)
+      typeof canonicalized === 'string' ? canonicalized : (
+        literalMoleculeToObjectNode(canonicalized)
       ),
     ),
   )
+}
 
 const literalMoleculeToObjectNode = (molecule: Molecule): ObjectNode => {
   const properties: Writable<Record<string, SemanticGraph>> = {}
-  for (const [key, propertyValue] of Object.entries(molecule)) {
+  for (const [key, propertyValue] of molecule.entries) {
     properties[key] =
       typeof propertyValue === 'string' ? propertyValue : (
         literalMoleculeToObjectNode(propertyValue)

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -1,8 +1,10 @@
 import either from '@matt.kantor/either'
 import assert from 'node:assert'
 import { stripVTControlCharacters } from 'node:util'
+import * as orderedRecord from '../../ordered-record.js'
 import { testCases } from '../../test-utilities.test.js'
-import { type Atom, type Molecule } from '../parsing.js'
+import type { JsonValue } from '../../utility-types.js'
+import { canonicalize, type Molecule } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import {
   inlinePlz,
@@ -15,7 +17,8 @@ import {
 } from '../unparsing.js'
 import { compile } from './compiler.js'
 
-const unparsers = (value: Atom | Molecule) => {
+const unparsers = (rawValue: JsonValue) => {
+  const value = canonicalize(rawValue)
   const unparseAndStripAnsi = (notation: Notation) =>
     either.map(
       unparse(value, notation),
@@ -31,34 +34,49 @@ const unparsers = (value: Atom | Molecule) => {
   return {
     inlinePlz: either.flatMap(
       either.flatMap(unparsedInlinePlz, parse),
-      (roundtrippedValue: {}) => {
+      roundtrippedValue => {
         assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
         return unparsedInlinePlz
       },
     ).value,
     sugarFreeInlinePlz: either.flatMap(
       either.flatMap(unparsedSugarFreeInlinePlz, parse),
-      (roundtrippedValue: {}) => {
+      roundtrippedValue => {
         assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
         return unparsedSugarFreeInlinePlz
       },
     ).value,
     prettyPlz: either.flatMap(
       either.flatMap(unparsedPrettyPlz, parse),
-      (roundtrippedValue: {}) => {
+      roundtrippedValue => {
         assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
         return unparsedPrettyPlz
       },
     ).value,
     sugarFreePrettyPlz: either.flatMap(
       either.flatMap(unparsedSugarFreePrettyPlz, parse),
-      (roundtrippedValue: {}) => {
+      roundtrippedValue => {
         assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
         return unparsedSugarFreePrettyPlz
       },
     ).value,
     prettyJson: either.map(unparsedPrettyJson, json => {
-      assert.deepEqual(JSON.parse(json), value)
+      // TODO: Refine this once there's an order-preserving JSON parser.
+      const moleculeToJsonValue = (molecule: Molecule): JsonValue =>
+        Object.fromEntries(
+          molecule.entries.map(([key, value]) => [
+            key,
+            orderedRecord.isOrderedRecord(value) ?
+              moleculeToJsonValue(value)
+            : value,
+          ]),
+        )
+      assert.deepEqual(
+        JSON.parse(json),
+        orderedRecord.isOrderedRecord(value) ?
+          moleculeToJsonValue(value)
+        : value,
+      )
       return json
     }).value,
   }

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -9,7 +9,8 @@ import {
   zeroOrMore,
   type Parser,
 } from '@matt.kantor/parsing'
-import type { Writable } from '../../utility-types.js'
+import * as orderedRecord from '../../ordered-record.js'
+import { type OrderedRecord } from '../../ordered-record.js'
 import { keyPathToMolecule, type KeyPath } from '../semantics.js'
 import {
   atom,
@@ -36,7 +37,12 @@ import {
 } from './parentheses.js'
 import { optionalTrivia, trivia, triviaExceptNewlines } from './trivia.js'
 
-export type Molecule = { readonly [key: Atom]: Molecule | Atom }
+// `interface` (not `type`) is used to avoid a circular reference error.
+export interface Molecule extends OrderedRecord<Atom | Molecule> {}
+
+const molecule = (
+  entries: Iterable<readonly [string, Atom | Molecule]>,
+): Molecule => orderedRecord.make(entries)
 
 // Keyless properties are automatically assigned numeric indexes, which uses
 // some mutable state.
@@ -58,25 +64,31 @@ const optional = <Output>(
 const trailingIndexesAndArgumentsToExpression = (
   root: Atom | Molecule,
   trailingIndexesAndArguments: readonly TrailingIndexOrArgument[],
-) =>
+): Atom | Molecule =>
   trailingIndexesAndArguments.reduce((expression, indexOrArgument) => {
     switch (indexOrArgument.kind) {
       case 'argument':
-        return {
-          0: '@apply',
-          1: {
-            function: expression,
-            argument: indexOrArgument.argument,
-          },
-        }
+        return molecule([
+          ['0', '@apply'],
+          [
+            '1',
+            molecule([
+              ['function', expression],
+              ['argument', indexOrArgument.argument],
+            ]),
+          ],
+        ])
       case 'index':
-        return {
-          0: '@index',
-          1: {
-            object: expression,
-            query: keyPathToMolecule(indexOrArgument.query),
-          },
-        }
+        return molecule([
+          ['0', '@index'],
+          [
+            '1',
+            molecule([
+              ['object', expression],
+              ['query', keyPathToMolecule(indexOrArgument.query)],
+            ]),
+          ],
+        ])
     }
   }, root)
 
@@ -93,21 +105,28 @@ const signatureTokensToExpression = (
     throw new Error('Signature parameter type did not exist. This is a bug!')
   }
 
-  const initialSignature = {
-    0: '@signature',
-    1: {
-      parameter: lastParameterType,
-      return: lastReturnType,
-    },
-  }
+  const initialSignature = molecule([
+    ['0', '@signature'],
+    [
+      '1',
+      molecule([
+        ['parameter', lastParameterType],
+        ['return', lastReturnType],
+      ]),
+    ],
+  ])
   return additionalParameterTypes.reduce(
-    (expression, additionalParameter) => ({
-      0: '@signature',
-      1: {
-        parameter: additionalParameter,
-        return: expression,
-      },
-    }),
+    (expression, additionalParameter) =>
+      molecule([
+        ['0', '@signature'],
+        [
+          '1',
+          molecule([
+            ['parameter', additionalParameter],
+            ['return', expression],
+          ]),
+        ],
+      ]),
     initialSignature,
   )
 }
@@ -115,11 +134,11 @@ const signatureTokensToExpression = (
 const unionTokensToExpression = (
   tokens: readonly [Atom | Molecule, ...(Atom | Molecule)[], Atom | Molecule],
 ): Molecule | Atom => {
-  const members: Record<number, Atom | Molecule> = { ...tokens }
-  return {
-    0: '@union',
-    1: members,
-  }
+  const members = molecule(tokens.map((token, index) => [String(index), token]))
+  return molecule([
+    ['0', '@union'],
+    ['1', members],
+  ])
 }
 
 type InfixOperator = readonly [Atom, readonly TrailingIndexOrArgument[]]
@@ -172,23 +191,35 @@ const infixTokensToExpression = (
     }
 
     const leftmostFunction = trailingIndexesAndArgumentsToExpression(
-      { 0: '@lookup', 1: { key: leftmostOperator[0] } },
+      molecule([
+        ['0', '@lookup'],
+        ['1', molecule([['key', leftmostOperator[0]]])],
+      ]),
       leftmostOperator[1],
     )
 
-    const reducedLeftmostOperation: Molecule = {
-      0: '@apply',
-      1: {
-        function: {
-          0: '@apply',
-          1: {
-            function: leftmostFunction,
-            argument: leftmostOperationRHS,
-          },
-        },
-        argument: leftmostOperationLHS,
-      },
-    }
+    const reducedLeftmostOperation = molecule([
+      ['0', '@apply'],
+      [
+        '1',
+        molecule([
+          [
+            'function',
+            molecule([
+              ['0', '@apply'],
+              [
+                '1',
+                molecule([
+                  ['function', leftmostFunction],
+                  ['argument', leftmostOperationRHS],
+                ]),
+              ],
+            ]),
+          ],
+          ['argument', leftmostOperationLHS],
+        ]),
+      ],
+    ])
 
     return infixTokensToExpression([
       reducedLeftmostOperation,
@@ -262,16 +293,13 @@ const sugarFreeMolecule: Parser<Molecule> = map(
         [optionalInitialProperty, ...remainingProperties]
       )
     const enumerate = makeIncrementingIndexer()
-    return properties.reduce((molecule: Writable<Molecule>, [key, value]) => {
-      if (key === undefined) {
+    return molecule(
+      properties.map(([key, value]) =>
         // Note that `enumerate()` increments its internal counter as a side
         // effect.
-        molecule[enumerate()] = value
-      } else {
-        molecule[key] = value
-      }
-      return molecule
-    }, {})
+        [key ?? enumerate(), value],
+      ),
+    )
   },
 )
 
@@ -415,10 +443,17 @@ const trailingCheckToken = map(
 const checkTokenToExpression = (
   value: Atom | Molecule,
   type: Atom | Molecule,
-): Molecule => ({
-  0: '@check',
-  1: { value, type },
-})
+): Molecule =>
+  molecule([
+    ['0', '@check'],
+    [
+      '1',
+      molecule([
+        ['value', value],
+        ['type', type],
+      ]),
+    ],
+  ])
 
 const trailingInfixTokens = oneOrMore(
   map(
@@ -463,7 +498,7 @@ const typedFunctionParameter: Parser<Molecule> = surroundedByParentheses(
       optionalTrivia,
       lazy(() => expression),
     ]),
-    ([name, _trivia1, _colon, _trivia2, type]) => ({ [name]: type }),
+    ([name, _trivia1, _colon, _trivia2, type]) => molecule([[name, type]]),
   ),
 )
 
@@ -505,21 +540,28 @@ const precededByAtomThenFunctionArrow = map(
       ...trailingParameters.toReversed(),
       initialParameter,
     ]
-    const initialFunction = {
-      0: '@function',
-      1: {
-        parameter: lastParameter,
-        body: body,
-      },
-    }
+    const initialFunction = molecule([
+      ['0', '@function'],
+      [
+        '1',
+        molecule([
+          ['parameter', lastParameter],
+          ['body', body],
+        ]),
+      ],
+    ])
     return additionalParameters.reduce(
-      (expression, additionalParameter) => ({
-        0: '@function',
-        1: {
-          parameter: additionalParameter,
-          body: expression,
-        },
-      }),
+      (expression, additionalParameter) =>
+        molecule([
+          ['0', '@function'],
+          [
+            '1',
+            molecule([
+              ['parameter', additionalParameter],
+              ['body', expression],
+            ]),
+          ],
+        ]),
       initialFunction,
     )
   },
@@ -535,10 +577,11 @@ const precededByAtSign = map(
     optionalTrivia,
     optional(lazy(() => compactExpression)),
   ]),
-  ([_atSign, keyword, _trivia, argument]) => ({
-    0: `@${keyword}`,
-    1: argument === undefined ? {} : argument,
-  }),
+  ([_atSign, keyword, _trivia, argument]) =>
+    molecule([
+      ['0', `@${keyword}`],
+      ['1', argument === undefined ? orderedRecord.empty : argument],
+    ]),
 )
 
 // :a
@@ -550,7 +593,10 @@ const precededByColonThenAtom = map(
   sequence([colon, atomRequiringDotQuotation, trailingIndexesAndArguments]),
   ([_colon, key, trailingIndexesAndArguments]) =>
     trailingIndexesAndArgumentsToExpression(
-      { 0: '@lookup', 1: { key } },
+      molecule([
+        ['0', '@lookup'],
+        ['1', molecule([['key', key]])],
+      ]),
       trailingIndexesAndArguments,
     ),
 )

--- a/src/language/parsing/syntax-tree.ts
+++ b/src/language/parsing/syntax-tree.ts
@@ -1,16 +1,13 @@
 import option, { type Option } from '@matt.kantor/option'
 import { map, sequence, type Parser } from '@matt.kantor/parsing'
 import * as orderedRecord from '../../ordered-record.js'
-import { withPhantomData, type WithPhantomData } from '../../phantom-data.js'
 import type { JsonArray, JsonRecord, JsonValue } from '../../utility-types.js'
 import type { KeyPath } from '../semantics.js'
 import { type Atom } from './atom.js'
 import { expression, type Molecule } from './expression.js'
 import { optionalTrivia } from './trivia.js'
 
-declare const _canonicalized: unique symbol
-export type Canonicalized = { readonly [_canonicalized]: true }
-export type SyntaxTree = WithPhantomData<Atom | Molecule, Canonicalized>
+export type SyntaxTree = Atom | Molecule
 
 export const applyKeyPathToSyntaxTree = (
   syntaxTree: SyntaxTree,
@@ -23,10 +20,7 @@ export const applyKeyPathToSyntaxTree = (
     return option.none
   } else {
     return option.flatMap(orderedRecord.get(syntaxTree, firstKey), next =>
-      applyKeyPathToSyntaxTree(
-        withPhantomData<Canonicalized>()(next),
-        remainingKeyPath,
-      ),
+      applyKeyPathToSyntaxTree(next, remainingKeyPath),
     )
   }
 }
@@ -38,13 +32,11 @@ export const applyKeyPathToSyntaxTree = (
 export const canonicalize = (
   input: JsonValueForbiddingSymbolicKeys,
 ): SyntaxTree =>
-  withPhantomData<Canonicalized>()(
-    typeof input === 'string' ? input
-    : input === null || typeof input !== 'object' ? String(input)
-    : orderedRecord.make(
-        Object.entries(input).map(([key, value]) => [key, canonicalize(value)]),
-      ),
-  )
+  typeof input === 'string' ? input
+  : input === null || typeof input !== 'object' ? String(input)
+  : orderedRecord.make(
+      Object.entries(input).map(([key, value]) => [key, canonicalize(value)]),
+    )
 
 /**
  * `canonicalize` inputs should not have symbolic keys. This type doesn't
@@ -67,6 +59,5 @@ type JsonRecordForbiddingSymbolicKeys = {
 
 export const syntaxTreeParser: Parser<SyntaxTree> = map(
   sequence([optionalTrivia, expression, optionalTrivia]),
-  ([_leadingTrivia, syntaxTree, _trailingTrivia]) =>
-    withPhantomData<Canonicalized>()(syntaxTree),
+  ([_leadingTrivia, syntaxTree, _trailingTrivia]) => syntaxTree,
 )

--- a/src/language/parsing/syntax-tree.ts
+++ b/src/language/parsing/syntax-tree.ts
@@ -1,12 +1,8 @@
 import option, { type Option } from '@matt.kantor/option'
 import { map, sequence, type Parser } from '@matt.kantor/parsing'
+import * as orderedRecord from '../../ordered-record.js'
 import { withPhantomData, type WithPhantomData } from '../../phantom-data.js'
-import type {
-  JsonArray,
-  JsonRecord,
-  JsonValue,
-  Writable,
-} from '../../utility-types.js'
+import type { JsonArray, JsonRecord, JsonValue } from '../../utility-types.js'
 import type { KeyPath } from '../semantics.js'
 import { type Atom } from './atom.js'
 import { expression, type Molecule } from './expression.js'
@@ -23,41 +19,32 @@ export const applyKeyPathToSyntaxTree = (
   const [firstKey, ...remainingKeyPath] = keyPath
   if (firstKey === undefined) {
     return option.makeSome(syntaxTree)
+  } else if (typeof syntaxTree === 'string') {
+    return option.none
   } else {
-    if (typeof syntaxTree === 'string') {
-      return option.none
-    } else {
-      const next = withPhantomData<Canonicalized>()(syntaxTree[firstKey])
-      if (next === undefined) {
-        return option.none
-      } else {
-        return applyKeyPathToSyntaxTree(next, remainingKeyPath)
-      }
-    }
+    return option.flatMap(orderedRecord.get(syntaxTree, firstKey), next =>
+      applyKeyPathToSyntaxTree(
+        withPhantomData<Canonicalized>()(next),
+        remainingKeyPath,
+      ),
+    )
   }
 }
 
 /**
  * Canonicalized syntax trees are made of strings and (potentially-nested)
- * objects with string-valued properties.
- *
- * The JSON value `["a", 1, null]` is canonicalized as `{ "0": "a", "1": "1",
- * "2": "null" }`.
+ * `OrderedRecord`s with string-valued properties.
  */
 export const canonicalize = (
   input: JsonValueForbiddingSymbolicKeys,
-): SyntaxTree => {
-  let canonicalized: Atom | Writable<Molecule>
-  if (typeof input === 'object' && input !== null) {
-    canonicalized = {}
-    for (let [key, value] of Object.entries(input)) {
-      canonicalized[key] = canonicalize(value)
-    }
-  } else {
-    canonicalized = typeof input === 'string' ? input : String(input)
-  }
-  return withPhantomData<Canonicalized>()(canonicalized)
-}
+): SyntaxTree =>
+  withPhantomData<Canonicalized>()(
+    typeof input === 'string' ? input
+    : input === null || typeof input !== 'object' ? String(input)
+    : orderedRecord.make(
+        Object.entries(input).map(([key, value]) => [key, canonicalize(value)]),
+      ),
+  )
 
 /**
  * `canonicalize` inputs should not have symbolic keys. This type doesn't
@@ -80,5 +67,6 @@ type JsonRecordForbiddingSymbolicKeys = {
 
 export const syntaxTreeParser: Parser<SyntaxTree> = map(
   sequence([optionalTrivia, expression, optionalTrivia]),
-  ([_leadingTrivia, syntaxTree, _trailingTrivia]) => canonicalize(syntaxTree),
+  ([_leadingTrivia, syntaxTree, _trailingTrivia]) =>
+    withPhantomData<Canonicalized>()(syntaxTree),
 )

--- a/src/language/runtime/evaluator.test.ts
+++ b/src/language/runtime/evaluator.test.ts
@@ -3,7 +3,12 @@ import assert from 'node:assert'
 import { withPhantomData } from '../../phantom-data.js'
 import { testCases } from '../../test-utilities.test.js'
 import type { ElaborationError } from '../errors.js'
-import { type Atom, type Molecule } from '../parsing.js'
+import {
+  canonicalize,
+  type Atom,
+  type JsonValueForbiddingSymbolicKeys,
+  type Molecule,
+} from '../parsing.js'
 import type { Output } from '../semantics.js'
 import { evaluate } from './evaluator.js'
 
@@ -12,20 +17,20 @@ const success = (
 ): Either<ElaborationError, Output> =>
   either.makeRight(withPhantomData<never>()(expectedOutput))
 
-testCases(evaluate, input => `evaluating \`${JSON.stringify(input)}\``)(
-  'evaluator',
+const canonicalizeAndEvaluate = (input: JsonValueForbiddingSymbolicKeys) =>
+  evaluate(canonicalize(input))
+
+testCases(
+  canonicalizeAndEvaluate,
+  input => `evaluating \`${JSON.stringify(input)}\``,
+)('evaluator', [
+  ['Hello, world!', success('Hello, world!')],
   [
-    ['Hello, world!', success('Hello, world!')],
-    [
-      ['@apply', [['@lookup', ['identity']], 'Hello, world!']],
-      success('Hello, world!'),
-    ],
-    [
-      [
-        '@check',
-        ['not a boolean', ['@index', [['@lookup', ['boolean']], 'is']]],
-      ],
-      output => assert(either.isLeft(output)),
-    ],
+    ['@apply', [['@lookup', ['identity']], 'Hello, world!']],
+    success('Hello, world!'),
   ],
-)
+  [
+    ['@check', ['not a boolean', ['@index', [['@lookup', ['boolean']], 'is']]]],
+    output => assert(either.isLeft(output)),
+  ],
+])

--- a/src/language/runtime/evaluator.ts
+++ b/src/language/runtime/evaluator.ts
@@ -1,14 +1,12 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { RuntimeError } from '../errors.js'
-import type { JsonValueForbiddingSymbolicKeys } from '../parsing.js'
-import { canonicalize } from '../parsing.js'
+import type { SyntaxTree } from '../parsing.js'
 import { elaborate, serialize, type Output } from '../semantics.js'
 import { keywordHandlers } from './keywords.js'
 
 export const evaluate = (
-  input: JsonValueForbiddingSymbolicKeys,
+  syntaxTree: SyntaxTree,
 ): Either<RuntimeError, Output> => {
-  const syntaxTree = canonicalize(input)
   const semanticGraphResult = elaborate(syntaxTree, keywordHandlers)
   return either.flatMap(semanticGraphResult, serialize)
 }

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -68,7 +68,7 @@ export {
 } from './semantics/function-node.js'
 export { isSemanticGraph } from './semantics/is-semantic-graph.js'
 export {
-  keyPathFromObjectNodeOrMolecule,
+  keyPathFromObjectNode,
   keyPathToMolecule,
   stringifyKeyPathForEndUser,
   type KeyPath,

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -8,7 +8,11 @@ import { asSemanticGraph } from '../semantics.js'
 import { isExpression, type Expression } from './expression.js'
 import type { KeyPath } from './key-path.js'
 import { isKeyword, type Keyword } from './keyword.js'
-import { makeObjectNode, type ObjectNode } from './object-node.js'
+import {
+  makeObjectNode,
+  objectNodeFromMolecule,
+  type ObjectNode,
+} from './object-node.js'
 import {
   containsAnyUnelaboratedNodes,
   extractStringValueIfPossible,
@@ -44,7 +48,8 @@ export const elaborate = (
   elaborateWithContext(program, {
     keywordHandlers,
     location: [],
-    program: typeof program === 'string' ? program : makeObjectNode(program),
+    program:
+      typeof program === 'string' ? program : objectNodeFromMolecule(program),
   })
 
 export const elaborateWithContext = (
@@ -84,7 +89,7 @@ const elaborateWithinMolecule = (
     const keysNeedingReelaboration = new Set<Atom>()
     let moleculeIsKeywordExpression = false
 
-    for (let [key, value] of Object.entries(molecule)) {
+    for (const [key, value] of molecule.entries) {
       const keyUpdateResult = handleAtomWhichMayNotBeAKeyword(key)
       if (either.isLeft(keyUpdateResult)) {
         // Immediately bail on error.
@@ -159,10 +164,7 @@ const elaborateWithinMolecule = (
     // properties have been processed. This resolves forward references where a
     // `@lookup` is elaborated before its target (e.g. in a program like
     // `{ a: :b, b: :identity(42) }`, the `:b` lookup originally resolved to the
-    // raw `:identity` application rather than its return value, and this
-    // behavior could sneakily arise even in programs without explicit forward
-    // references (such as `{ a: :identity(42), 999: :a }`), because JavaScript
-    // runtimes iterate over integer keys before others).
+    // raw `:identity` application rather than its return value.
     //
     // Re-elaboration repeats until a fixed point is reached where no progress
     // is made (a chain of forward references may require multiple passes, and

--- a/src/language/semantics/expressions/expression-utilities.ts
+++ b/src/language/semantics/expressions/expression-utilities.ts
@@ -10,7 +10,7 @@ import { isSemanticGraph } from '../is-semantic-graph.js'
 import { stringifyKeyPathForEndUser } from '../key-path.js'
 import {
   lookupPropertyOfObjectNode,
-  makeObjectNode,
+  objectNodeFromMolecule,
   type ObjectNode,
 } from '../object-node.js'
 import {
@@ -21,7 +21,8 @@ import {
 
 export const asSemanticGraph = (
   value: SemanticGraph | Molecule,
-): SemanticGraph => (isSemanticGraph(value) ? value : makeObjectNode(value))
+): SemanticGraph =>
+  isSemanticGraph(value) ? value : objectNodeFromMolecule(value)
 
 export const locateSelf = (context: ExpressionContext) =>
   option.match(applyKeyPathToSemanticGraph(context.program, context.location), {
@@ -64,7 +65,7 @@ export const readArgumentsFromExpression = <
   } else {
     const expressionArguments: ObjectNode[string][] = []
     for (const [position, keyword] of specification.entries()) {
-      const argument = lookupWithinMolecule(
+      const argument = lookupWithinObjectNode(
         [keyword, String(position)],
         expression[1],
       )
@@ -98,12 +99,12 @@ export const stringifyKeyForEndUser = (key: Atom): string =>
     left: error => `(unserializable key: ${error.message})`,
   })
 
-const lookupWithinMolecule = (
+const lookupWithinObjectNode = (
   keyAliases: readonly [Atom, ...(readonly Atom[])],
-  molecule: Molecule | ObjectNode,
+  node: ObjectNode,
 ): Option<SemanticGraph> => {
   for (const key of keyAliases) {
-    const result = lookupPropertyOfObjectNode(key, makeObjectNode(molecule))
+    const result = lookupPropertyOfObjectNode(key, node)
     if (!option.isNone(result)) {
       return result
     }

--- a/src/language/semantics/expressions/index-expression.ts
+++ b/src/language/semantics/expressions/index-expression.ts
@@ -1,7 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
-import { keyPathFromObjectNodeOrMolecule } from '../key-path.js'
+import { keyPathFromObjectNode } from '../key-path.js'
 import {
   isObjectNode,
   makeObjectNode,
@@ -31,9 +31,8 @@ export const readIndexExpression = (
             message: 'query must be an object',
           })
         } else {
-          return either.map(
-            keyPathFromObjectNodeOrMolecule(query),
-            _validKeyPath => makeIndexExpression({ object, query }),
+          return either.map(keyPathFromObjectNode(query), _validKeyPath =>
+            makeIndexExpression({ object, query }),
           )
         }
       },

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -9,7 +9,11 @@ import {
   type KeyPath,
   type NonEmptyKeyPath,
 } from '../key-path.js'
-import { makeObjectNode, type ObjectNode } from '../object-node.js'
+import {
+  makeObjectNode,
+  objectNodeFromMolecule,
+  type ObjectNode,
+} from '../object-node.js'
 import { prelude } from '../prelude.js'
 import {
   applyKeyPathToSemanticGraph,
@@ -68,7 +72,7 @@ export const keyPathToLookupExpression = (keyPath: NonEmptyKeyPath) => {
   } else {
     return makeIndexExpression({
       object: initialLookup,
-      query: makeObjectNode(keyPathToMolecule(indexes)),
+      query: objectNodeFromMolecule(keyPathToMolecule(indexes)),
     })
   }
 }

--- a/src/language/semantics/key-path.ts
+++ b/src/language/semantics/key-path.ts
@@ -1,4 +1,5 @@
 import either, { type Either } from '@matt.kantor/either'
+import * as orderedRecord from '../../ordered-record.js'
 import type { InvalidExpressionError } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
 import { inlinePlz, unparse } from '../unparsing.js'
@@ -14,10 +15,10 @@ export const stringifyKeyPathForEndUser = (keyPath: KeyPath): string =>
   })
 
 export const keyPathToMolecule = (keyPath: KeyPath): Molecule =>
-  Object.fromEntries(keyPath.flatMap((key, index) => [[index, key]]))
+  orderedRecord.make(keyPath.map((key, index) => [String(index), key]))
 
-export const keyPathFromObjectNodeOrMolecule = (
-  node: ObjectNode | Molecule,
+export const keyPathFromObjectNode = (
+  node: ObjectNode,
 ): Either<InvalidExpressionError, KeyPath> => {
   const relativePath: string[] = []
   let queryIndex = 0

--- a/src/language/semantics/object-node.ts
+++ b/src/language/semantics/object-node.ts
@@ -1,6 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import option, { type Option } from '@matt.kantor/option'
-import type { Writable } from '../../utility-types.js'
+import * as orderedRecord from '../../ordered-record.js'
 import type { UnserializableValueError } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
 import { asSemanticGraph } from './expressions/expression-utilities.js'
@@ -30,7 +30,7 @@ type PropertyValueToSemanticGraph<
   PropertyValue extends SemanticGraph | Molecule,
 > =
   PropertyValue extends SemanticGraph ? PropertyValue
-  : PropertyValue extends Molecule ? PropertiesToSemanticGraphs<PropertyValue>
+  : PropertyValue extends Molecule ? ObjectNode
   : never
 
 type PropertiesToSemanticGraphs<
@@ -53,29 +53,42 @@ export const makeObjectNode = <
     SemanticGraph
   > as PropertiesToSemanticGraphs<Properties> // This type assertion assumes no excess properties are present.
 
-  // The index signature from `ObjectNode` is necessary to make this typecheck.
-  const objectNodeTagProperty: ObjectNode = { [nodeTag]: 'object' }
-
   return {
     ...propertiesAsSemanticGraphs,
-    ...objectNodeTagProperty,
+    [nodeTag]: 'object',
+  }
+}
+
+/**
+ * Convert an OrderedRecord-backed `Molecule` to an `ObjectNode`. Property
+ * values that are themselves `Molecule`s are converted recursively.
+ */
+export const objectNodeFromMolecule = (molecule: Molecule): ObjectNode => {
+  const propertiesAsSemanticGraphs = Object.fromEntries(
+    molecule.entries.map(
+      ([key, value]) => [key, asSemanticGraph(value)] as const,
+    ),
+  )
+  return {
+    ...propertiesAsSemanticGraphs,
+    [nodeTag]: 'object',
   }
 }
 
 export const serializeObjectNode = (
   node: ObjectNode,
 ): Either<UnserializableValueError, Molecule> => {
-  const molecule: Writable<Molecule> = {}
+  const serializedEntries: (readonly [Atom, Output])[] = []
   for (const [key, propertyValue] of Object.entries(node)) {
     const serializedPropertyValueResult =
       serializeObjectPropertyValue(propertyValue)
     if (either.isLeft(serializedPropertyValueResult)) {
       return serializedPropertyValueResult
     } else {
-      molecule[key] = serializedPropertyValueResult.value
+      serializedEntries.push([key, serializedPropertyValueResult.value])
     }
   }
-  return either.makeRight(molecule)
+  return either.makeRight(orderedRecord.make(serializedEntries))
 }
 
 const serializeObjectPropertyValue = (

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -20,6 +20,7 @@ import { stringifyKeyPathForEndUser, type KeyPath } from './key-path.js'
 import { isExemptFromElaboration, isKeyword } from './keyword.js'
 import {
   makeObjectNode,
+  objectNodeFromMolecule,
   serializeObjectNode,
   type ObjectNode,
 } from './object-node.js'
@@ -66,9 +67,7 @@ export const applyKeyPathToSemanticGraph = (
   }
 }
 
-export const containsAnyUnelaboratedNodes = (
-  node: SemanticGraph | Molecule,
-): boolean => {
+export const containsAnyUnelaboratedNodes = (node: SemanticGraph): boolean => {
   const nodeAsSemanticGraph = asSemanticGraph(node)
   if (
     isExpression(nodeAsSemanticGraph) &&
@@ -218,4 +217,6 @@ export const stringifySemanticGraphForEndUser = (
 const syntaxTreeToSemanticGraph = (
   syntaxTree: Atom | Molecule,
 ): ObjectNode | Atom =>
-  typeof syntaxTree === 'string' ? syntaxTree : makeObjectNode(syntaxTree)
+  typeof syntaxTree === 'string' ? syntaxTree : (
+    objectNodeFromMolecule(syntaxTree)
+  )

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -6,7 +6,6 @@ import type {
   UnserializableValueError,
 } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
-import type { Canonicalized } from '../parsing/syntax-tree.js'
 import {
   asSemanticGraph,
   makeIndexExpression,
@@ -166,10 +165,7 @@ export const matchSemanticGraph = <Result>(
 
 declare const _serialized: unique symbol
 type Serialized = { readonly [_serialized]: true }
-export type Output = WithPhantomData<
-  Atom | Molecule,
-  Serialized & Canonicalized
->
+export type Output = WithPhantomData<Atom | Molecule, Serialized>
 
 export const serialize = (
   node: SemanticGraph,
@@ -199,7 +195,7 @@ export const serialize = (
           }),
         ),
     }),
-    withPhantomData<Serialized & Canonicalized>(),
+    withPhantomData<Serialized>(),
   )
 
 export const stringifySemanticGraphForEndUser = (

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -84,7 +84,7 @@ export const atom = {
       either.makeRight(
         typeof argument === 'string' ?
           makeObjectNode({ tag: 'some', value: argument })
-        : makeObjectNode({ tag: 'none', value: {} }),
+        : makeObjectNode({ tag: 'none', value: makeObjectNode({}) }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/boolean.ts
+++ b/src/language/semantics/stdlib/boolean.ts
@@ -36,7 +36,7 @@ export const boolean = {
       either.makeRight(
         nodeIsBoolean(argument) ?
           makeObjectNode({ tag: 'some', value: argument })
-        : makeObjectNode({ tag: 'none', value: {} }),
+        : makeObjectNode({ tag: 'none', value: makeObjectNode({}) }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -128,7 +128,7 @@ export const integer = {
             })
         ) ?
           makeObjectNode({ tag: 'some', value: argument })
-        : makeObjectNode({ tag: 'none', value: {} }),
+        : makeObjectNode({ tag: 'none', value: makeObjectNode({}) }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/natural-number.ts
+++ b/src/language/semantics/stdlib/natural-number.ts
@@ -48,7 +48,7 @@ export const natural_number = {
             })
         ) ?
           makeObjectNode({ tag: 'some', value: argument })
-        : makeObjectNode({ tag: 'none', value: {} }),
+        : makeObjectNode({ tag: 'none', value: makeObjectNode({}) }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -56,7 +56,7 @@ export const object = {
       either.makeRight(
         isObjectNode(argument) ?
           makeObjectNode({ tag: 'some', value: argument })
-        : makeObjectNode({ tag: 'none', value: {} }),
+        : makeObjectNode({ tag: 'none', value: makeObjectNode({}) }),
       ),
   ),
 

--- a/src/language/semantics/stdlib/option.ts
+++ b/src/language/semantics/stdlib/option.ts
@@ -34,7 +34,7 @@ export const option = {
             }),
             1: makeObjectNode({
               tag: 'none',
-              value: {},
+              value: makeObjectNode({}),
             }),
           }),
         ),

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -10,7 +10,7 @@ import {
   isExpression,
   isFunctionNode,
   isObjectNode,
-  keyPathFromObjectNodeOrMolecule,
+  keyPathFromObjectNode,
   lookup,
   readApplyExpression,
   readFunctionExpression,
@@ -203,7 +203,7 @@ const inferTypeImplementation = (
       ),
       objectType =>
         either.map(
-          keyPathFromObjectNodeOrMolecule(indexExpressionResult.value[1].query),
+          keyPathFromObjectNode(indexExpressionResult.value[1].query),
           keyPath => applyKeyPathToType(objectType, keyPath),
         ),
     )

--- a/src/language/unparsing/inline-plz.ts
+++ b/src/language/unparsing/inline-plz.ts
@@ -12,7 +12,7 @@ import { punctuation, type Notation } from './unparsing-utilities.js'
 
 const unparseSugarFreeMolecule = (value: Molecule) => {
   const { comma, closeBrace, openBrace } = punctuation(styleText)
-  if (Object.keys(value).length === 0) {
+  if (value.entries.length === 0) {
     return either.makeRight(openBrace + closeBrace)
   } else {
     return either.map(

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -2,6 +2,7 @@ import either, { type Either, type Right } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
 import parsing from '@matt.kantor/parsing'
 import { styleText } from 'node:util'
+import * as orderedRecord from '../../ordered-record.js'
 import type { ElaborationError, UnserializableValueError } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
 import { unquotedAtomParser } from '../parsing/atom.js'
@@ -60,7 +61,11 @@ export const moleculeUnparser =
     const context: Context = { unparseAtomOrMolecule, semanticContext }
     const sugar = unparseSugaredExpression(context, unparseSugarFreeMolecule)
     return (value: Molecule): Either<UnserializableValueError, string> => {
-      switch (value['0']) {
+      const keyword = option.match(orderedRecord.get(value, '0'), {
+        none: () => undefined,
+        some: keyword => keyword,
+      })
+      switch (keyword) {
         case '@apply':
           return sugar(value, readApplyExpression, unparseSugaredApply)
         case '@check':
@@ -99,7 +104,7 @@ export const moleculeAsKeyValuePairStrings = (
 ): Either<UnserializableValueError, readonly string[]> => {
   const { colon, openGroupingParenthesis, closeGroupingParenthesis } =
     punctuation(styleText)
-  const entries = Object.entries(value)
+  const entries = value.entries
 
   const keyValuePairsAsStrings: string[] = []
   let ordinalPropertyKeyCounter = 0n
@@ -384,7 +389,7 @@ const unparseSugaredIndex = (
 }
 
 const unparseKeyPathOfSugaredIndex = (
-  query: ObjectNode | Molecule,
+  query: ObjectNode,
   { semanticContext }: Context,
 ) => {
   const keyPath = Object.entries(query).reduce(

--- a/src/language/unparsing/pretty-json.ts
+++ b/src/language/unparsing/pretty-json.ts
@@ -26,11 +26,11 @@ const unparseAtom = (value: Atom): Right<string> => {
 
 const unparseMolecule = (value: Molecule): Right<string> => {
   const { closeBrace, colon, comma, openBrace } = punctuation(styleText)
-  const entries = Object.entries(value)
+  const entries = value.entries
   if (entries.length === 0) {
     return either.makeRight(openBrace.concat(closeBrace))
   } else {
-    const keyValuePairs: string = Object.entries(value)
+    const keyValuePairs: string = entries
       .map(([propertyKey, propertyValue]) =>
         key(propertyKey).concat(
           colon,

--- a/src/language/unparsing/pretty-plz.ts
+++ b/src/language/unparsing/pretty-plz.ts
@@ -12,7 +12,7 @@ import { indent, punctuation, type Notation } from './unparsing-utilities.js'
 
 const unparseSugarFreeMolecule = (value: Molecule) => {
   const { closeBrace, openBrace } = punctuation(styleText)
-  if (Object.keys(value).length === 0) {
+  if (value.entries.length === 0) {
     return either.makeRight(openBrace + closeBrace)
   } else {
     return either.map(

--- a/src/language/unparsing/sugar-free-inline-plz.ts
+++ b/src/language/unparsing/sugar-free-inline-plz.ts
@@ -12,7 +12,7 @@ import { punctuation, type Notation } from './unparsing-utilities.js'
 const unparseMolecule =
   (semanticContext: SemanticContext) => (value: Molecule) => {
     const { closeBrace, openBrace, comma } = punctuation(styleText)
-    if (Object.keys(value).length === 0) {
+    if (value.entries.length === 0) {
       return either.makeRight(openBrace + closeBrace)
     } else {
       return either.map(

--- a/src/language/unparsing/sugar-free-pretty-plz.ts
+++ b/src/language/unparsing/sugar-free-pretty-plz.ts
@@ -12,7 +12,7 @@ import { indent, punctuation, type Notation } from './unparsing-utilities.js'
 const unparseMolecule =
   (semanticContext: SemanticContext) => (value: Molecule) => {
     const { closeBrace, openBrace } = punctuation(styleText)
-    if (Object.keys(value).length === 0) {
+    if (value.entries.length === 0) {
       return either.makeRight(openBrace + closeBrace)
     } else {
       return either.map(

--- a/src/test-utilities.test.ts
+++ b/src/test-utilities.test.ts
@@ -62,10 +62,10 @@ export const testCases =
       }),
     )
 
-export const parseAndCompileAndRun = (input: string) => {
-  const syntaxTree: ProgramResult = parse(input)
-  const program: ProgramResult = either.flatMap(syntaxTree, compile)
-  const runtimeOutput: ProgramResult = either.flatMap(program, evaluate)
+export const parseAndCompileAndRun = (input: string): ProgramResult => {
+  const syntaxTree = parse(input)
+  const program = either.flatMap(syntaxTree, compile)
+  const runtimeOutput = either.flatMap(program, evaluate)
   return runtimeOutput
 }
 


### PR DESCRIPTION
This is the next step of the plan started by #159. `Molecule`s are now `OrderedRecord`s, meaning that the source order of Please object properties is now preserved by the parser and into elaboration plumbing.

`SemanticGraph`'s `ObjectNode`s are untouched in this step—they're still backed by plain JavaScript objects and therefore do not preserve the source order of properties with integer-like keys. That means it's still possible to see properties moving around during compilation and at runtime. That'll be addressed in the next step.

[One compiler test has regressed](https://github.com/mkantor/please-lang-prototype/blob/da3e02c76654e511119fc1c9b3d3254d65a2d256/src/language/compiling/compiler.test.ts#L527-L536). There was a pre-existing bug that was exposed by these changes (type parameter instantiation in standard library functions needs some work). I'll fix this in a future changeset and then revive this test case.

There are also some new compiler tests demonstrating programs which now type-check properly thanks to this changeset.