### PR TITLE
Preserve object property ordering in `SemanticGraph`

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -137,9 +137,25 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     },
   ],
   ['{a:A, b:{"@lookup", {a}}}', success({ a: 'A', b: 'A' })],
-  ['{a:A, {"@lookup", {a}}}', success({ a: 'A', 0: 'A' })],
+  [
+    '{a:A, {"@lookup", {a}}}',
+    either.makeRight(
+      orderedRecord.make([
+        ['a', 'A'],
+        ['0', 'A'],
+      ]),
+    ),
+  ],
   ['{a:A, b: :a}', success({ a: 'A', b: 'A' })],
-  ['{a:A, :a}', success({ a: 'A', 0: 'A' })],
+  [
+    '{a:A, :a}',
+    either.makeRight(
+      orderedRecord.make([
+        ['a', 'A'],
+        ['0', 'A'],
+      ]),
+    ),
+  ],
   [
     '@runtime {_ => @panic}',
     result => {
@@ -723,7 +739,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{ b: 1, c: 1, d: 1 } object.overlay { a: 1, b: 2, c: 3 }`,
-    success({ b: '2', c: '3', d: '1', a: '1' }),
+    either.makeRight(
+      orderedRecord.make([
+        ['b', '2'],
+        ['c', '3'],
+        ['d', '1'],
+        ['a', '1'],
+      ]),
+    ),
   ],
   [`:object.from_property(key)(value)`, success({ key: 'value' })],
   [`(1 + 1) ~ :integer.type`, success('2')],

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1,5 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import assert from 'node:assert'
+import * as orderedRecord from '../../ordered-record.js'
 import { withPhantomData } from '../../phantom-data.js'
 import { testCases } from '../../test-utilities.test.js'
 import type { JsonValue } from '../../utility-types.js'
@@ -7,13 +8,22 @@ import type { ElaborationError } from '../errors.js'
 import {
   canonicalize,
   type JsonValueForbiddingSymbolicKeys,
+  type Molecule,
 } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import type { Output } from '../semantics.js'
 import { compile } from './compiler.js'
 
-const success = (expectedOutput: JsonValue): Either<ElaborationError, Output> =>
-  either.makeRight(withPhantomData<never>()(canonicalize(expectedOutput)))
+const success = (
+  expectedOutput: JsonValue | Molecule,
+): Either<ElaborationError, Output> =>
+  either.makeRight(
+    withPhantomData<never>()(
+      orderedRecord.isOrderedRecord(expectedOutput) ? expectedOutput : (
+        canonicalize(expectedOutput)
+      ),
+    ),
+  )
 
 const canonicalizeAndCompile = (input: JsonValueForbiddingSymbolicKeys) =>
   compile(canonicalize(input))
@@ -206,16 +216,37 @@ testCases(
 
   ['{ a: :b, b: :identity(42) }', success({ a: '42', b: '42' })],
 
-  ['{ a: @if { true, true, 42 }, :a }', success({ a: 'true', '0': 'true' })],
+  [
+    '{ a: @if { true, true, 42 }, :a }',
+    success(
+      orderedRecord.make([
+        ['a', 'true'],
+        ['0', 'true'],
+      ]),
+    ),
+  ],
 
   [
     '{ a: @if { true, true, 42 }, b: :a, :b }',
-    success({ a: 'true', b: 'true', '0': 'true' }),
+    success(
+      orderedRecord.make([
+        ['a', 'true'],
+        ['b', 'true'],
+        ['0', 'true'],
+      ]),
+    ),
   ],
 
   [
     '{ a: :identity(1), b: :identity(2), :a, :b }',
-    success({ a: '1', b: '2', '0': '1', '1': '2' }),
+    success(
+      orderedRecord.make([
+        ['a', '1'],
+        ['b', '2'],
+        ['0', '1'],
+        ['1', '2'],
+      ]),
+    ),
   ],
 
   [

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -9,7 +9,8 @@ import {
   isExpression,
   isObjectNode,
   makeIfExpression,
-  makeObjectNode,
+  objectNodeFromOrderedEntries,
+  orderedEntriesOfObjectNode,
   readIfExpression,
   serialize,
   showType,
@@ -115,14 +116,14 @@ export const ifKeywordHandler: KeywordHandler = (
                   : isObjectNode(branch) ?
                     either.map(
                       sequenceEithers(
-                        Object.entries(branch).map(([key, value]) =>
+                        orderedEntriesOfObjectNode(branch).map(([key, value]) =>
                           either.map(
                             elaborateNestedIfLookups(value),
                             elaboratedValue => [key, elaboratedValue] as const,
                           ),
                         ),
                       ),
-                      entries => makeObjectNode(Object.fromEntries(entries)),
+                      entries => objectNodeFromOrderedEntries(entries),
                     )
                   : either.makeRight(branch)
 

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -78,6 +78,11 @@ export {
   isObjectNode,
   lookupPropertyOfObjectNode,
   makeObjectNode,
+  objectNodeFromMolecule,
+  objectNodeFromOrderedEntries,
+  orderedEntriesOfObjectNode,
+  orderedKeys,
+  withProperty,
   type ObjectNode,
 } from './semantics/object-node.js'
 export { prelude } from './semantics/prelude.js'

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -11,6 +11,8 @@ import { isKeyword, type Keyword } from './keyword.js'
 import {
   makeObjectNode,
   objectNodeFromMolecule,
+  orderedKeys,
+  withProperty,
   type ObjectNode,
 } from './object-node.js'
 import {
@@ -85,6 +87,10 @@ const elaborateWithinMolecule = (
     const possibleExpressionAsObjectNode: Writable<ObjectNode> = makeObjectNode(
       {},
     )
+
+    // Used to initialize the resulting `ObjectNode`'s `orderedKeys` sidecar.
+    const orderedKeysAccumulator: Atom[] = []
+
     let updatedProgram = context.program
     const keysNeedingReelaboration = new Set<Atom>()
     let moleculeIsKeywordExpression = false
@@ -97,6 +103,9 @@ const elaborateWithinMolecule = (
       } else {
         const updatedKey = keyUpdateResult.value
         if (typeof value === 'string') {
+          if (!(updatedKey in possibleExpressionAsObjectNode)) {
+            orderedKeysAccumulator.push(updatedKey)
+          }
           possibleExpressionAsObjectNode[updatedKey] = value
           if (key === '0' && isKeyword(value)) {
             moleculeIsKeywordExpression = true
@@ -124,6 +133,9 @@ const elaborateWithinMolecule = (
           if (either.isRight(programUpdateResult)) {
             updatedProgram = programUpdateResult.value
           }
+          if (!(updatedKey in possibleExpressionAsObjectNode)) {
+            orderedKeysAccumulator.push(updatedKey)
+          }
           possibleExpressionAsObjectNode[updatedKey] = elaborationResult.value
           if (
             typeof elaborationResult.value !== 'string' &&
@@ -134,6 +146,7 @@ const elaborateWithinMolecule = (
         }
       }
     }
+    possibleExpressionAsObjectNode[orderedKeys] = orderedKeysAccumulator
 
     const {
       0: possibleKeywordAsNode,
@@ -250,14 +263,11 @@ const handleObjectNodeWhichMayBeAExpression = (
   node: ObjectNode & { readonly 0: Atom },
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> => {
-  const { 0: possibleKeyword, ...possibleArguments } = node
+  const possibleKeyword = node[0]
   return (
     isKeyword(possibleKeyword) ?
       context.keywordHandlers[possibleKeyword](
-        makeObjectNode({
-          ...possibleArguments,
-          0: possibleKeyword,
-        }),
+        withProperty(node, '0', possibleKeyword),
         context,
       )
     : /^@[^@]/.test(possibleKeyword) ?
@@ -265,10 +275,9 @@ const handleObjectNodeWhichMayBeAExpression = (
         kind: 'unknownKeyword',
         message: `unknown keyword: \`${possibleKeyword}\``,
       })
-    : either.makeRight({
-        ...node,
-        0: unescapeKeywordSigil(possibleKeyword),
-      })
+    : either.makeRight(
+        withProperty(node, '0', unescapeKeywordSigil(possibleKeyword)),
+      )
   )
 }
 

--- a/src/language/semantics/expressions/panic-expression.ts
+++ b/src/language/semantics/expressions/panic-expression.ts
@@ -1,7 +1,7 @@
 import type { Either } from '@matt.kantor/either'
 import either from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
-import { isObjectNode, type ObjectNode } from '../object-node.js'
+import { isObjectNode, withProperty, type ObjectNode } from '../object-node.js'
 import type { SemanticGraph } from '../semantic-graph.js'
 
 export type PanicExpression = ObjectNode & {
@@ -12,7 +12,7 @@ export const readPanicExpression = (
   node: SemanticGraph,
 ): Either<ElaborationError, PanicExpression> =>
   isObjectNode(node) && node[0] === '@panic' ?
-    either.makeRight({ ...node, 0: '@panic' })
+    either.makeRight(withProperty(node, '0', '@panic'))
   : either.makeLeft({
       kind: 'invalidExpression',
       message: 'not a `@panic` expression',

--- a/src/language/semantics/object-node.ts
+++ b/src/language/semantics/object-node.ts
@@ -8,22 +8,49 @@ import { serializeFunctionNode } from './function-node.js'
 import { nodeTag } from './semantic-graph-node-tag.js'
 import { serialize, type Output, type SemanticGraph } from './semantic-graph.js'
 
+/**
+ * Key for a sidecar property on every `ObjectNode` which records semantic
+ * ordering of properties (source order). Iteration sites that care about order
+ * (serialization, unparsing, elaboration) consult this rather than relying on
+ * `Object.keys`/`Object.entries`, which sort integer-like keys ahead of
+ * string-like keys [as per the ECMAScript specification][1].
+ *
+ * [1]: https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ordinaryownpropertykeys
+ */
+// TODO: Consider ditching this and instead backing `ObjectNode` with an
+// `OrderedRecord` (this would be an invasive change as it'd eliminate direct
+// `node[key]` access and make it impossible to subtype `ObjectNode` with
+// specific properties (e.g. for `Expression`)).
+export const orderedKeys = Symbol('orderedKeys')
+
 export type ObjectNode = {
   readonly [nodeTag]: 'object'
+  readonly [orderedKeys]: readonly Atom[]
   readonly [key: Atom]: SemanticGraph
 }
 
 export const isObjectNode = (node: SemanticGraph) =>
   typeof node === 'object' && node[nodeTag] === 'object'
 
+export const orderedEntriesOfObjectNode = (
+  node: ObjectNode,
+): readonly (readonly [Atom, SemanticGraph])[] =>
+  node[orderedKeys].map(key => {
+    const value = node[key]
+    if (value === undefined) {
+      throw new Error(
+        `ObjectNode declared key \`${key}\` in its orderedKeys sidecar but the property is missing. This is a bug!`,
+      )
+    }
+    return [key, value]
+  })
+
 export const lookupPropertyOfObjectNode = (
   key: Atom,
   node: ObjectNode,
 ): Option<SemanticGraph> =>
   key in node && node[key] !== undefined ?
-    option.makeSome(
-      typeof node[key] === 'object' ? makeObjectNode(node[key]) : node[key],
-    )
+    option.makeSome(node[key])
   : option.none
 
 type PropertyValueToSemanticGraph<
@@ -39,6 +66,10 @@ type PropertiesToSemanticGraphs<
   [K in keyof Properties]: PropertyValueToSemanticGraph<Properties[K]>
 }
 
+/**
+ * @deprecated Does not preserve property order; prefer `objectNodeFromMolecule`
+ * or `objectNodeFromOrderedEntries`.
+ */
 export const makeObjectNode = <
   const Properties extends Readonly<Record<Atom, SemanticGraph | Molecule>>,
 >(
@@ -56,30 +87,53 @@ export const makeObjectNode = <
   return {
     ...propertiesAsSemanticGraphs,
     [nodeTag]: 'object',
+    [orderedKeys]: Object.keys(propertiesAsSemanticGraphs),
   }
 }
 
 /**
- * Convert an OrderedRecord-backed `Molecule` to an `ObjectNode`. Property
- * values that are themselves `Molecule`s are converted recursively.
+ * Construct an `ObjectNode` from an iterable of `[key, value]` pairs. Order
+ * is preserved in the resulting node's `orderedKeys` sidecar.
  */
-export const objectNodeFromMolecule = (molecule: Molecule): ObjectNode => {
-  const propertiesAsSemanticGraphs = Object.fromEntries(
-    molecule.entries.map(
-      ([key, value]) => [key, asSemanticGraph(value)] as const,
-    ),
+export const objectNodeFromOrderedEntries = (
+  entries: Iterable<readonly [Atom, SemanticGraph]>,
+): ObjectNode => ({
+  ...Object.fromEntries(entries),
+  [nodeTag]: 'object',
+  [orderedKeys]: [...entries].map(([key, _value]) => key),
+})
+
+/**
+ * Convert an `OrderedRecord`-backed `Molecule` to an `ObjectNode`, preserving
+ * the molecule's source order via `orderedKeys`. Property values that are
+ * themselves `Molecule`s are converted recursively.
+ */
+export const objectNodeFromMolecule = (molecule: Molecule): ObjectNode =>
+  objectNodeFromOrderedEntries(
+    orderedRecord.mapValues(molecule, asSemanticGraph).entries,
   )
-  return {
-    ...propertiesAsSemanticGraphs,
-    [nodeTag]: 'object',
-  }
-}
+
+/**
+ * Return a new `ObjectNode` with `key` mapped to `value`. If `key` already
+ * exists, its position in `orderedKeys` is preserved; if new, it is appended.
+ */
+export const withProperty = <Key extends Atom, Value extends SemanticGraph>(
+  node: ObjectNode,
+  key: Key,
+  value: Value,
+): ObjectNode & Record<Key, Value> =>
+  ({
+    ...node,
+    [orderedKeys]:
+      key in node ? node[orderedKeys] : [...node[orderedKeys], key],
+    [key satisfies Key]: value satisfies Value,
+  }) satisfies ObjectNode as ObjectNode & Record<Key, Value>
 
 export const serializeObjectNode = (
   node: ObjectNode,
 ): Either<UnserializableValueError, Molecule> => {
   const serializedEntries: (readonly [Atom, Output])[] = []
-  for (const [key, propertyValue] of Object.entries(node)) {
+  for (const [key, propertyValue] of orderedEntriesOfObjectNode(node)) {
     const serializedPropertyValueResult =
       serializeObjectPropertyValue(propertyValue)
     if (either.isLeft(serializedPropertyValueResult)) {

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -21,6 +21,7 @@ import {
   makeObjectNode,
   objectNodeFromMolecule,
   serializeObjectNode,
+  withProperty,
   type ObjectNode,
 } from './object-node.js'
 import { nodeTag } from './semantic-graph-node-tag.js'
@@ -128,11 +129,7 @@ export const updateValueAtKeyPathInSemanticGraph = (
               remainingKeyPath,
               operation,
             ),
-            updatedNode =>
-              (isExpression(node) ? makeObjectNode : makeObjectNode)({
-                ...node,
-                [firstKey]: updatedNode,
-              }),
+            updatedNode => withProperty(node, firstKey, updatedNode),
           )
         }
       },

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -1,5 +1,10 @@
 import either from '@matt.kantor/either'
-import { isObjectNode, makeObjectNode } from '../object-node.js'
+import {
+  isObjectNode,
+  makeObjectNode,
+  objectNodeFromOrderedEntries,
+  orderedEntriesOfObjectNode,
+} from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType } from '../type-system/type-formats.js'
 import {
@@ -108,7 +113,19 @@ export const object = {
               message: '`overlay` expected an object',
             })
           } else {
-            return either.makeRight({ ...object1, ...object2 })
+            // `object1` supplies the initial property order with `object2`
+            // overwriting values for shared keys in-place. New keys from
+            // `object2` are appended at the end in their original order.
+            return either.makeRight(
+              objectNodeFromOrderedEntries([
+                ...orderedEntriesOfObjectNode(object1).map(
+                  ([key, value]) => [key, object2[key] ?? value] as const,
+                ),
+                ...orderedEntriesOfObjectNode(object2).filter(
+                  ([key, _value]) => !(key in object1),
+                ),
+              ]),
+            )
           }
         })
       }


### PR DESCRIPTION
This is the next step of the plan started by #159 and continued by #160.

`ObjectNode` has gained [a new symbol-keyed sidecar property](https://github.com/mkantor/please-lang-prototype/blob/f950fd83585df29b7b16dc2bb6d0394063a2e045/src/language/semantics/object-node.ts#L28) which tracks the order of the Please object properties it models. This sidecar property is consulted whenever objects are iterated/serialized/etc.

Originally I'd planned to adopt `OrderedRecord` in `ObjectNode`, but that change would have a very large footprint (keyword expression implementations would need to fundamentally change, anywhere that properties are looked up would now require a function call, etc). [I might still do this eventually](https://github.com/mkantor/please-lang-prototype/blob/f950fd83585df29b7b16dc2bb6d0394063a2e045/src/language/semantics/object-node.ts#L20-L24), but for now am taking a more minimal approach to get property ordering wired all the way through.

`ObjectNode` has gained a bunch of new helper functions to mostly abstract away key order management.

There's still one remaining step in my plan to get property order stabilized end-to-end: a custom JSON parser which produces `OrderedRecord`s instead of JavaScript objects. At the moment ordering is still lost at the seams between layers since the plo & plt phases consume JSON-encoded input via `JSON.parse` (which sorts integer-like keys first).