### PR TITLE
Add a property-order-preserving JSON parser

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -2,19 +2,19 @@ import either from '@matt.kantor/either'
 import option from '@matt.kantor/option'
 import assert from 'node:assert'
 import { compile } from './language/compiling.js'
-import { canonicalize } from './language/parsing.js'
 import { parse } from './language/parsing/parser.js'
 import { evaluate } from './language/runtime.js'
 import * as orderedRecord from './ordered-record.js'
 import {
   parseAndCompileAndRun,
   testCases,
+  toSyntaxTree,
   unparseAndRoundtrip,
   type ProgramResult,
 } from './test-utilities.test.js'
 import type { JsonValue } from './utility-types.js'
 
-const success = (value: JsonValue) => either.makeRight(canonicalize(value))
+const success = (value: JsonValue) => either.makeRight(toSyntaxTree(value))
 
 const endToEnd = (input: string) => {
   const syntaxTree = parse(input)

--- a/src/language/cli/1.ts
+++ b/src/language/cli/1.ts
@@ -1,11 +1,8 @@
 import { compile } from '../compiling/compiler.js'
-import { canonicalize } from '../parsing.js'
 import { handleInput } from './input.js'
 import { handleOutput } from './output.js'
 
 const main = (process: NodeJS.Process): Promise<undefined> =>
-  handleOutput(process, () =>
-    handleInput(process, input => compile(canonicalize(input))),
-  )
+  handleOutput(process, () => handleInput(process, compile))
 
 await main(process)

--- a/src/language/cli/2.ts
+++ b/src/language/cli/2.ts
@@ -1,11 +1,8 @@
-import { canonicalize } from '../parsing.js'
 import { evaluate } from '../runtime.js'
 import { handleInput } from './input.js'
 import { handleOutput } from './output.js'
 
 const main = async (process: NodeJS.Process): Promise<undefined> =>
-  handleOutput(process, () =>
-    handleInput(process, input => evaluate(canonicalize(input))),
-  )
+  handleOutput(process, () => handleInput(process, evaluate))
 
 await main(process)

--- a/src/language/cli/input.ts
+++ b/src/language/cli/input.ts
@@ -1,6 +1,8 @@
 import either, { type Either } from '@matt.kantor/either'
 import { parseArgs } from 'node:util'
-import { type JsonValueForbiddingSymbolicKeys } from '../parsing.js'
+import * as orderedRecord from '../../ordered-record.js'
+import { parseJson, type Atom, type Molecule } from '../parsing.js'
+import type { ParsedJsonValue } from '../parsing/json.js'
 
 export type InvalidJsonError = {
   readonly kind: 'invalidJson'
@@ -9,7 +11,7 @@ export type InvalidJsonError = {
 
 export const handleInput = async <Result>(
   process: NodeJS.Process,
-  command: (input: JsonValueForbiddingSymbolicKeys) => Result,
+  command: (input: Atom | Molecule) => Result,
 ): Promise<Result> => {
   const args = parseArgs({
     args: process.argv.slice(2), // remove `execPath` and `filename`
@@ -29,20 +31,25 @@ export const handleInput = async <Result>(
       `Unsupported input format: "${args.values['input-format']}"`,
     )
   } else {
-    const input = await readJson(process.stdin)
-    return either.match(input, {
-      left: error => {
-        throw new Error(error.message) // TODO: Improve error reporting.
+    return either.match(
+      either.map(await readJson(process.stdin), jsonValueToAtomOrMolecule),
+      {
+        left: error => {
+          throw new Error(error.message) // TODO: Improve error reporting.
+        },
+        right: command,
       },
-      right: command,
-    })
+    )
   }
 }
 
 export const readJson = async (
   stream: AsyncIterable<string>,
-): Promise<Either<InvalidJsonError, JsonValueForbiddingSymbolicKeys>> =>
-  parseJson(await readString(stream))
+): Promise<Either<InvalidJsonError, ParsedJsonValue>> =>
+  either.mapLeft(parseJson(await readString(stream)), parseError => ({
+    kind: 'invalidJson',
+    message: parseError.message,
+  }))
 
 export const readString = async (
   stream: AsyncIterable<string>,
@@ -54,16 +61,23 @@ export const readString = async (
   return input
 }
 
-const parseJson = (
-  source: string,
-): Either<InvalidJsonError, JsonValueForbiddingSymbolicKeys> =>
-  either.mapLeft(
-    either.tryCatch((): JsonValueForbiddingSymbolicKeys => JSON.parse(source)),
-    jsonParseError => ({
-      kind: 'invalidJson',
-      message:
-        jsonParseError instanceof Error ?
-          jsonParseError.message
-        : 'Invalid JSON',
-    }),
-  )
+/**
+ * Deeply-convert `ParsedJsonValue`s to `Atom | Molecule`s. All non-`string`
+ * primitives are converted to strings, and arrays become `OrderedRecord`s with
+ * `"0"`, `"1"`, … keys.
+ */
+const jsonValueToAtomOrMolecule = (value: ParsedJsonValue): Atom | Molecule =>
+  isArrayOfParsedJsonValues(value) ?
+    orderedRecord.make(
+      value.map((element, index) => [
+        String(index),
+        jsonValueToAtomOrMolecule(element),
+      ]),
+    )
+  : orderedRecord.isOrderedRecord(value) ?
+    orderedRecord.mapValues(value, jsonValueToAtomOrMolecule)
+  : String(value satisfies string | number | boolean | null)
+
+const isArrayOfParsedJsonValues = (
+  value: ParsedJsonValue,
+): value is readonly ParsedJsonValue[] => Array.isArray(value)

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2,14 +2,10 @@ import either, { type Either } from '@matt.kantor/either'
 import assert from 'node:assert'
 import * as orderedRecord from '../../ordered-record.js'
 import { withPhantomData } from '../../phantom-data.js'
-import { testCases } from '../../test-utilities.test.js'
+import { testCases, toSyntaxTree } from '../../test-utilities.test.js'
 import type { JsonValue } from '../../utility-types.js'
 import type { ElaborationError } from '../errors.js'
-import {
-  canonicalize,
-  type JsonValueForbiddingSymbolicKeys,
-  type Molecule,
-} from '../parsing.js'
+import type { Molecule } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import type { Output } from '../semantics.js'
 import { compile } from './compiler.js'
@@ -20,13 +16,13 @@ const success = (
   either.makeRight(
     withPhantomData<never>()(
       orderedRecord.isOrderedRecord(expectedOutput) ? expectedOutput : (
-        canonicalize(expectedOutput)
+        toSyntaxTree(expectedOutput)
       ),
     ),
   )
 
-const canonicalizeAndCompile = (input: JsonValueForbiddingSymbolicKeys) =>
-  compile(canonicalize(input))
+const canonicalizeAndCompile = (input: JsonValue) =>
+  compile(toSyntaxTree(input))
 
 testCases(
   canonicalizeAndCompile,

--- a/src/language/compiling/parsing.test.ts
+++ b/src/language/compiling/parsing.test.ts
@@ -2,7 +2,7 @@ import either from '@matt.kantor/either'
 import assert from 'node:assert'
 import * as orderedRecord from '../../ordered-record.js'
 import { testCases } from '../../test-utilities.test.js'
-import { canonicalize, type Atom, type SyntaxTree } from '../parsing.js'
+import { type Atom, type SyntaxTree } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 
 type Entries = readonly (readonly [string, Atom | Entries])[]
@@ -393,48 +393,3 @@ testCases(parse, input => `parsing \`${input}\``)('parsing', [
   ['"||valid"', either.makeRight(syntaxTree('||valid'))],
   ['"valid||"', either.makeRight(syntaxTree('valid||'))],
 ])
-
-testCases(canonicalize, input => `canonicalizing \`${JSON.stringify(input)}\``)(
-  'canonicalization',
-  [
-    [{}, syntaxTree([])],
-    [[], syntaxTree([])],
-    ['a', syntaxTree('a')],
-    [1, syntaxTree('1')],
-    [Number.EPSILON, syntaxTree('2.220446049250313e-16')],
-    [null, syntaxTree('null')],
-    [true, syntaxTree('true')],
-    [false, syntaxTree('false')],
-    [['a'], syntaxTree([['0', 'a']])],
-    [{ 0: 'a' }, syntaxTree([['0', 'a']])],
-    [{ 1: 'a' }, syntaxTree([['1', 'a']])],
-    [
-      ['a', { b: [], c: { d: ['e', {}, 42] } }, 'f', { g: null }, true],
-      syntaxTree([
-        ['0', 'a'],
-        [
-          '1',
-          [
-            ['b', []],
-            [
-              'c',
-              [
-                [
-                  'd',
-                  [
-                    ['0', 'e'],
-                    ['1', []],
-                    ['2', '42'],
-                  ],
-                ],
-              ],
-            ],
-          ],
-        ],
-        ['2', 'f'],
-        ['3', [['g', 'null']]],
-        ['4', 'true'],
-      ]),
-    ],
-  ],
-)

--- a/src/language/compiling/semantics/test-utilities.test.ts
+++ b/src/language/compiling/semantics/test-utilities.test.ts
@@ -1,9 +1,9 @@
 import either, { type Either } from '@matt.kantor/either'
 import { withPhantomData } from '../../../phantom-data.js'
-import { testCases } from '../../../test-utilities.test.js'
+import { testCases, toSyntaxTree } from '../../../test-utilities.test.js'
 import type { JsonValue, Writable } from '../../../utility-types.js'
 import type { ElaborationError } from '../../errors.js'
-import { canonicalize, type Molecule } from '../../parsing.js'
+import { type Molecule } from '../../parsing.js'
 import {
   elaborate,
   makeObjectNode,
@@ -14,14 +14,14 @@ import type { SemanticGraph } from '../../semantics/semantic-graph.js'
 import { keywordHandlers } from './keywords.js'
 
 export const elaborationSuite = testCases(
-  (input: JsonValue) => elaborate(canonicalize(input), keywordHandlers),
+  (input: JsonValue) => elaborate(toSyntaxTree(input), keywordHandlers),
   input => `elaborating \`${JSON.stringify(input)}\``,
 )
 
 export const success = (
   expectedOutput: JsonValue,
 ): Either<ElaborationError, ElaboratedSemanticGraph> => {
-  const canonicalized = canonicalize(expectedOutput)
+  const canonicalized = toSyntaxTree(expectedOutput)
   return either.makeRight(
     withPhantomData<never>()(
       typeof canonicalized === 'string' ? canonicalized : (

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -1,10 +1,9 @@
 import either from '@matt.kantor/either'
 import assert from 'node:assert'
 import { stripVTControlCharacters } from 'node:util'
-import * as orderedRecord from '../../ordered-record.js'
-import { testCases } from '../../test-utilities.test.js'
+import { testCases, toSyntaxTree } from '../../test-utilities.test.js'
 import type { JsonValue } from '../../utility-types.js'
-import { canonicalize, type Molecule } from '../parsing.js'
+import { parseJson } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import {
   inlinePlz,
@@ -18,7 +17,7 @@ import {
 import { compile } from './compiler.js'
 
 const unparsers = (rawValue: JsonValue) => {
-  const value = canonicalize(rawValue)
+  const value = toSyntaxTree(rawValue)
   const unparseAndStripAnsi = (notation: Notation) =>
     either.map(
       unparse(value, notation),
@@ -60,25 +59,13 @@ const unparsers = (rawValue: JsonValue) => {
         return unparsedSugarFreePrettyPlz
       },
     ).value,
-    prettyJson: either.map(unparsedPrettyJson, json => {
-      // TODO: Refine this once there's an order-preserving JSON parser.
-      const moleculeToJsonValue = (molecule: Molecule): JsonValue =>
-        Object.fromEntries(
-          molecule.entries.map(([key, value]) => [
-            key,
-            orderedRecord.isOrderedRecord(value) ?
-              moleculeToJsonValue(value)
-            : value,
-          ]),
-        )
-      assert.deepEqual(
-        JSON.parse(json),
-        orderedRecord.isOrderedRecord(value) ?
-          moleculeToJsonValue(value)
-        : value,
-      )
-      return json
-    }).value,
+    prettyJson: either.flatMap(
+      either.flatMap(unparsedPrettyJson, parseJson),
+      roundtrippedValue => {
+        assert.deepEqual(roundtrippedValue, value)
+        return unparsedPrettyJson
+      },
+    ).value,
   }
 }
 

--- a/src/language/parsing.ts
+++ b/src/language/parsing.ts
@@ -1,7 +1,4 @@
 export type { Atom } from './parsing/atom.js'
 export type { Molecule } from './parsing/expression.js'
-export {
-  canonicalize,
-  type JsonValueForbiddingSymbolicKeys,
-  type SyntaxTree,
-} from './parsing/syntax-tree.js'
+export { parseJson } from './parsing/json.js'
+export type { SyntaxTree } from './parsing/syntax-tree.js'

--- a/src/language/parsing/json.test.ts
+++ b/src/language/parsing/json.test.ts
@@ -1,0 +1,159 @@
+import either from '@matt.kantor/either'
+import assert from 'node:assert'
+import test, { suite } from 'node:test'
+import * as orderedRecord from '../../ordered-record.js'
+import { parseJson } from './json.js'
+
+suite('order-preserving JSON parser', () => {
+  test('strings', () => {
+    assert.deepEqual(parseJson('"hello"'), either.makeRight('hello'))
+    assert.deepEqual(parseJson('""'), either.makeRight(''))
+  })
+
+  test('numbers', () => {
+    assert.deepEqual(parseJson('42'), either.makeRight(42))
+    assert.deepEqual(parseJson('0'), either.makeRight(0))
+    assert.deepEqual(parseJson('-5'), either.makeRight(-5))
+    assert.deepEqual(parseJson('3.14'), either.makeRight(3.14))
+    assert.deepEqual(parseJson('1e3'), either.makeRight(1e3))
+    assert.deepEqual(parseJson('-1.5e-2'), either.makeRight(-1.5e-2))
+  })
+
+  test('booleans', () => {
+    assert.deepEqual(parseJson('true'), either.makeRight(true))
+    assert.deepEqual(parseJson('false'), either.makeRight(false))
+  })
+
+  test('null', () => {
+    assert.deepEqual(parseJson('null'), either.makeRight(null))
+  })
+
+  test('strings with escape sequences', () => {
+    assert.deepEqual(
+      parseJson('"hello\\nworld"'),
+      either.makeRight('hello\nworld'),
+    )
+    assert.deepEqual(parseJson('"quote: \\""'), either.makeRight('quote: "'))
+    assert.deepEqual(
+      parseJson('"backslash: \\\\"'),
+      either.makeRight('backslash: \\'),
+    )
+    assert.deepEqual(parseJson('"\\t\\r\\b\\f"'), either.makeRight('\t\r\b\f'))
+  })
+
+  test('unicode escape sequences', () => {
+    assert.deepEqual(parseJson('"\\u0041"'), either.makeRight('A'))
+    assert.deepEqual(
+      parseJson('"snowman: \\u2603"'),
+      either.makeRight('snowman: ☃'),
+    )
+  })
+
+  test('empty object', () => {
+    assert.deepEqual(parseJson('{}'), either.makeRight(orderedRecord.empty))
+  })
+
+  test('simple object', () => {
+    assert.deepEqual(
+      parseJson('{"a":"b"}'),
+      either.makeRight(orderedRecord.make([['a', 'b']])),
+    )
+  })
+
+  test('object with potentially-reorderable properties', () => {
+    // The initial motivation for this parser was to work around the fact that
+    // integer-like keys appear first when iterating objects returned from
+    // `JSON.parse`, rather than in insertion/source order.
+
+    const plainObject = JSON.parse('{"a":"first","999":"second"}')
+    // This is what we want to avoid:
+    assert.deepEqual(Object.keys(plainObject), ['999', 'a'])
+
+    assert.deepEqual(
+      parseJson(
+        '{"a":"first","999":"second","0":"third","b":"forth","c":"fifth"}',
+      ),
+      either.makeRight(
+        orderedRecord.make([
+          ['a', 'first'],
+          ['999', 'second'],
+          ['0', 'third'],
+          ['b', 'forth'],
+          ['c', 'fifth'],
+        ]),
+      ),
+    )
+  })
+
+  test('nested objects', () => {
+    assert.deepEqual(
+      parseJson('{"outer":{"inner":"value"}}'),
+      either.makeRight(
+        orderedRecord.make([
+          ['outer', orderedRecord.make([['inner', 'value']])],
+        ]),
+      ),
+    )
+  })
+
+  test('whitespace between tokens', () => {
+    assert.deepEqual(
+      parseJson('  {\n  "a"  :  1  ,\n  "b"  :  2\n  }  '),
+      either.makeRight(
+        orderedRecord.make([
+          ['a', 1],
+          ['b', 2],
+        ]),
+      ),
+    )
+  })
+
+  test('empty array', () => {
+    assert.deepEqual(parseJson('[]'), either.makeRight([]))
+  })
+
+  test('non-empty array', () => {
+    assert.deepEqual(
+      parseJson('[1,true,null,"text"]'),
+      either.makeRight([1, true, null, 'text']),
+    )
+  })
+
+  test('nested array', () => {
+    assert.deepEqual(parseJson('[[1,2],[3]]'), either.makeRight([[1, 2], [3]]))
+  })
+
+  test('array of objects', () => {
+    assert.deepEqual(
+      parseJson('[{"a":1},{"b":2}]'),
+      either.makeRight([
+        orderedRecord.make([['a', 1]]),
+        orderedRecord.make([['b', 2]]),
+      ]),
+    )
+  })
+
+  test('unterminated string', () => {
+    assert(either.isLeft(parseJson('"unterminated')))
+  })
+
+  test('invalid escape', () => {
+    assert(either.isLeft(parseJson('"\\x"')))
+  })
+
+  test('trailing comma in object', () => {
+    assert(either.isLeft(parseJson('{"a":1,}')))
+  })
+
+  test('trailing comma in array', () => {
+    assert(either.isLeft(parseJson('[1,]')))
+  })
+
+  test('non-string object key', () => {
+    assert(either.isLeft(parseJson('{1:"a"}')))
+  })
+
+  test('completely empty input', () => {
+    assert(either.isLeft(parseJson('')))
+  })
+})

--- a/src/language/parsing/json.ts
+++ b/src/language/parsing/json.ts
@@ -1,0 +1,166 @@
+import { type Either } from '@matt.kantor/either'
+import {
+  anySingleCharacter,
+  as,
+  butNot,
+  flatMap,
+  lazy,
+  literal,
+  map,
+  nothing,
+  oneOf,
+  parse,
+  regularExpression,
+  sequence,
+  zeroOrMore,
+  type InvalidInputError,
+  type Parser,
+} from '@matt.kantor/parsing'
+import type { OrderedRecord } from '../../ordered-record.js'
+import * as orderedRecord from '../../ordered-record.js'
+
+/**
+ * The shape produced by `parseJson`. Models a JSON value, but with objects
+ * represented as `OrderedRecord`s, preserving the source order of their
+ * properties (plain JavaScript objects sort integer-like keys first).
+ */
+export type ParsedJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly ParsedJsonValue[]
+  | ParsedJsonRecord
+
+// `interface` (not `type`) is used to avoid a circular reference error.
+interface ParsedJsonRecord extends OrderedRecord<ParsedJsonValue> {}
+
+const whitespace = regularExpression(/^[ \t\n\r]+/)
+const optionalWhitespace = oneOf([whitespace, nothing])
+
+const optionallySurroundedByWhitespace = <Output>(
+  parser: Parser<Output>,
+): Parser<Output> =>
+  map(
+    sequence([optionalWhitespace, parser, optionalWhitespace]),
+    ([_leadingWhitespace, value, _trailingWhitespace]) => value,
+  )
+
+const quote = literal('"')
+const backslash = literal('\\')
+
+const unicodeEscape: Parser<string> = map(
+  sequence([backslash, literal('u'), regularExpression(/^[0-9A-Fa-f]{4}/)]),
+  ([_backslash, _u, hex]) => String.fromCharCode(parseInt(hex, 16)),
+)
+const simpleEscape: Parser<string> = map(
+  sequence([
+    backslash,
+    oneOf([
+      literal('"'),
+      literal('\\'),
+      literal('/'),
+      as(literal('b'), '\b'),
+      as(literal('f'), '\f'),
+      as(literal('n'), '\n'),
+      as(literal('r'), '\r'),
+      as(literal('t'), '\t'),
+    ]),
+  ]),
+  ([_backslash, unescaped]) => unescaped,
+)
+
+const stringCharacter: Parser<string> = oneOf([
+  unicodeEscape,
+  simpleEscape,
+  butNot(
+    anySingleCharacter,
+    oneOf([quote, backslash]),
+    'an unescaped `"` or `\\`',
+  ),
+])
+
+// This is recursive: `jsonValue` references `jsonObject` and `jsonArray`, each
+// of which references `jsonValue`.
+const jsonValue: Parser<ParsedJsonValue> = lazy(() =>
+  optionallySurroundedByWhitespace(
+    oneOf([
+      jsonString,
+      jsonNumber,
+      jsonBoolean,
+      jsonNull,
+      jsonObject,
+      jsonArray,
+    ]),
+  ),
+)
+
+const jsonString: Parser<string> = map(
+  sequence([quote, zeroOrMore(stringCharacter), quote]),
+  ([_open, characters, _close]) => characters.join(''),
+)
+
+const jsonNumber: Parser<number> = map(
+  regularExpression(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/),
+  Number,
+)
+
+const jsonBoolean: Parser<boolean> = oneOf([
+  as(literal('true'), true),
+  as(literal('false'), false),
+])
+
+const jsonNull: Parser<null> = as(literal('null'), null)
+
+const property: Parser<readonly [string, ParsedJsonValue]> = map(
+  sequence([
+    optionallySurroundedByWhitespace(jsonString),
+    literal(':'),
+    jsonValue,
+  ]),
+  ([key, _colon, value]) => [key, value],
+)
+
+const properties: Parser<readonly (readonly [string, ParsedJsonValue])[]> =
+  flatMap(property, first =>
+    map(
+      zeroOrMore(
+        map(
+          sequence([literal(','), property]),
+          ([_comma, property]) => property,
+        ),
+      ),
+      rest => [first, ...rest],
+    ),
+  )
+
+const jsonObject: Parser<ParsedJsonRecord> = map(
+  sequence([
+    literal('{'),
+    oneOf([properties, as(nothing, [])]),
+    optionallySurroundedByWhitespace(literal('}')),
+  ]),
+  ([_openBrace, properties, _closeBrace]) => orderedRecord.make(properties),
+)
+
+const elements: Parser<readonly ParsedJsonValue[]> = flatMap(jsonValue, first =>
+  map(
+    zeroOrMore(
+      map(sequence([literal(','), jsonValue]), ([_comma, value]) => value),
+    ),
+    rest => [first, ...rest],
+  ),
+)
+
+const jsonArray: Parser<readonly ParsedJsonValue[]> = map(
+  sequence([
+    literal('['),
+    oneOf([elements, as(nothing, [])]),
+    optionallySurroundedByWhitespace(literal(']')),
+  ]),
+  ([_openBracket, elements, _closeBracket]) => elements,
+)
+
+export const parseJson = (
+  source: string,
+): Either<InvalidInputError, ParsedJsonValue> => parse(jsonValue, source)

--- a/src/language/parsing/syntax-tree.ts
+++ b/src/language/parsing/syntax-tree.ts
@@ -1,61 +1,9 @@
-import option, { type Option } from '@matt.kantor/option'
 import { map, sequence, type Parser } from '@matt.kantor/parsing'
-import * as orderedRecord from '../../ordered-record.js'
-import type { JsonArray, JsonRecord, JsonValue } from '../../utility-types.js'
-import type { KeyPath } from '../semantics.js'
 import { type Atom } from './atom.js'
 import { expression, type Molecule } from './expression.js'
 import { optionalTrivia } from './trivia.js'
 
 export type SyntaxTree = Atom | Molecule
-
-export const applyKeyPathToSyntaxTree = (
-  syntaxTree: SyntaxTree,
-  keyPath: KeyPath,
-): Option<SyntaxTree> => {
-  const [firstKey, ...remainingKeyPath] = keyPath
-  if (firstKey === undefined) {
-    return option.makeSome(syntaxTree)
-  } else if (typeof syntaxTree === 'string') {
-    return option.none
-  } else {
-    return option.flatMap(orderedRecord.get(syntaxTree, firstKey), next =>
-      applyKeyPathToSyntaxTree(next, remainingKeyPath),
-    )
-  }
-}
-
-/**
- * Canonicalized syntax trees are made of strings and (potentially-nested)
- * `OrderedRecord`s with string-valued properties.
- */
-export const canonicalize = (
-  input: JsonValueForbiddingSymbolicKeys,
-): SyntaxTree =>
-  typeof input === 'string' ? input
-  : input === null || typeof input !== 'object' ? String(input)
-  : orderedRecord.make(
-      Object.entries(input).map(([key, value]) => [key, canonicalize(value)]),
-    )
-
-/**
- * `canonicalize` inputs should not have symbolic keys. This type doesn't
- * robustly guarantee that (because symbolic keys can always be widened away),
- * but will catch simple mistakes like directly feeding an `Option<…>` into
- * `canonicalize`.
- */
-export type JsonValueForbiddingSymbolicKeys =
-  | Exclude<JsonValue, JsonArray | JsonRecord>
-  | JsonArrayForbiddingSymbolicKeys
-  | JsonRecordForbiddingSymbolicKeys
-
-type JsonArrayForbiddingSymbolicKeys =
-  readonly JsonValueForbiddingSymbolicKeys[]
-type JsonRecordForbiddingSymbolicKeys = {
-  readonly [key: string]: JsonValueForbiddingSymbolicKeys
-} & Partial<{
-  readonly [key: symbol]: undefined
-}>
 
 export const syntaxTreeParser: Parser<SyntaxTree> = map(
   sequence([optionalTrivia, expression, optionalTrivia]),

--- a/src/language/runtime/evaluator.test.ts
+++ b/src/language/runtime/evaluator.test.ts
@@ -1,14 +1,10 @@
 import either, { type Either } from '@matt.kantor/either'
 import assert from 'node:assert'
 import { withPhantomData } from '../../phantom-data.js'
-import { testCases } from '../../test-utilities.test.js'
+import { testCases, toSyntaxTree } from '../../test-utilities.test.js'
+import type { JsonValue } from '../../utility-types.js'
 import type { ElaborationError } from '../errors.js'
-import {
-  canonicalize,
-  type Atom,
-  type JsonValueForbiddingSymbolicKeys,
-  type Molecule,
-} from '../parsing.js'
+import type { Atom, Molecule } from '../parsing.js'
 import type { Output } from '../semantics.js'
 import { evaluate } from './evaluator.js'
 
@@ -17,8 +13,8 @@ const success = (
 ): Either<ElaborationError, Output> =>
   either.makeRight(withPhantomData<never>()(expectedOutput))
 
-const canonicalizeAndEvaluate = (input: JsonValueForbiddingSymbolicKeys) =>
-  evaluate(canonicalize(input))
+const canonicalizeAndEvaluate = (input: JsonValue) =>
+  evaluate(toSyntaxTree(input))
 
 testCases(
   canonicalizeAndEvaluate,

--- a/src/test-utilities.test.ts
+++ b/src/test-utilities.test.ts
@@ -7,7 +7,7 @@ import type {
   ParseError,
   RuntimeError,
 } from './language/errors.js'
-import type { Atom, Molecule } from './language/parsing.js'
+import type { Atom, Molecule, SyntaxTree } from './language/parsing.js'
 import { parse } from './language/parsing/parser.js'
 import { evaluate } from './language/runtime.js'
 import {
@@ -16,6 +16,8 @@ import {
   unparse,
   type Notation,
 } from './language/unparsing.js'
+import * as orderedRecord from './ordered-record.js'
+import type { JsonValue } from './utility-types.js'
 
 // Disable colors. This yields more readable test failure messages, at the cost
 // of not being able to test colors.
@@ -60,6 +62,13 @@ export const testCases =
           },
         )
       }),
+    )
+
+export const toSyntaxTree = (input: JsonValue): SyntaxTree =>
+  typeof input === 'string' ? input
+  : input === null || typeof input !== 'object' ? String(input)
+  : orderedRecord.make(
+      Object.entries(input).map(([key, value]) => [key, toSyntaxTree(value)]),
     )
 
 export const parseAndCompileAndRun = (input: string): ProgramResult => {


### PR DESCRIPTION
This is the final step of the plan started by #159 and continued by #160 and #161. Property source order in Please objects is now preserved end-to-end! 🎉

`JSON.parse` produces plain JavaScript objects, which meant properties with integer-like keys ended up not reflecting their original locations from the JSON source. Please's intermediate formats are currently serialized as JSON, so when the next layer consumed the output of the previous layer, `JSON.parse` undid the work we'd done to preserve property order.

To address this, this changeset introduces a custom JSON parser which produces `OrderedRecord`s from JSON objects,  and adopts it to handle JSON input in CLI commands.