### PR TITLE
Simplify unparsing of single-property-argument keyword expressions

### DIFF
--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -562,9 +562,18 @@ const unparseSugaredGeneralizedKeywordExpression = (
     const unparsedKeyword = styleText(['bold', 'underline'], expression['0'])
     if ('1' in expression) {
       return either.map(
-        either.flatMap(
-          serializeIfNeeded(expression['1']),
-          unparseAtomOrMolecule(semanticContext),
+        either.flatMap(serializeIfNeeded(expression['1']), expressionArgument =>
+          unparseAtomOrMolecule(semanticContext)(
+            // If there's only a single property in the argument, unparse it
+            // with an implicit key (e.g. `@runtime { a => b }` rather than
+            // `@runtime { function: a => b }`).
+            (
+              typeof expressionArgument !== 'string' &&
+                orderedRecord.size(expressionArgument) === 1
+            ) ?
+              orderedRecord.mapKeys(expressionArgument, _ => '0')
+            : expressionArgument,
+          ),
         ),
         unparsedArgument => unparsedKeyword.concat(' ', unparsedArgument),
       )

--- a/src/ordered-record.ts
+++ b/src/ordered-record.ts
@@ -131,6 +131,14 @@ export const mapValues = <Value, NewValue>(
     record.entries.map(([key, value]) => [key, transform(value, key)]),
   )
 
+export const mapKeys = <Value>(
+  record: OrderedRecord<Value>,
+  transform: (key: string, value: Value) => string,
+): OrderedRecord<Value> =>
+  fromUniqueEntries(
+    record.entries.map(([key, value]) => [transform(key, value), value]),
+  )
+
 export const filter = <Value>(
   record: OrderedRecord<Value>,
   predicate: (value: Value, key: string) => boolean,


### PR DESCRIPTION
For example, unparsing now produces `@runtime { a => b }` rather than `@runtime { function: a => b }`.