### PR TITLE
Fix type parameter instantiation in generic standard library functions

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -554,11 +554,14 @@ testCases(
   [
     '{ f: :identity >> :identity, :f(@runtime { _ => 1 }) ~ 1 }',
     result => {
-      // TODO: Make this type-check again. This happened to work before because
-      // of how the wonky elaboration order kept the `@apply` deferred. Revisit
-      // once migration to source-order elaboration is complete.
-      assert(either.isLeft(result))
-      assert(result.value.kind === 'typeMismatch')
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(:identity >> :identity)(@runtime { _ => 1 }) ~ 1`,
+    result => {
+      assert(either.isRight(result))
     },
   ],
 

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -28,7 +28,7 @@ import {
 
 const A = makeTypeParameter('a', { assignableTo: types.something })
 const B = makeTypeParameter('b', { assignableTo: types.something })
-const C = makeTypeParameter('b', { assignableTo: types.something })
+const C = makeTypeParameter('c', { assignableTo: types.something })
 
 type TaggedNode = ObjectNode & {
   readonly tag: Atom

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -22,7 +22,7 @@ export const object = {
       parameter: types.atom,
       return: makeFunctionType('', {
         parameter: types.object,
-        return: types.something,
+        return: types.option(types.something),
       }),
     },
     key => {

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -15,6 +15,11 @@ import {
   type SemanticGraph,
 } from '../semantic-graph.js'
 import { type FunctionType, type Type } from '../type-system/type-formats.js'
+import {
+  getTypesForTypeParameters,
+  literalTypeFromSemanticGraph,
+  supplyTypeArguments,
+} from '../type-system/type-utilities.js'
 
 const handleUnavailableDependencies =
   (f: FunctionNodeCallSignature) =>
@@ -75,13 +80,21 @@ export const preludeFunctionArity2 = (
   ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
 ) =>
   preludeFunctionArity1(keyPath, signature, argument1 =>
-    either.map(f(argument1), f1 =>
-      makeFunctionNode(
-        signature.return.signature,
-        serializeOnceAppliedFunction(keyPath, argument1),
-        option.none,
-        handleUnavailableDependencies(f1),
+    either.flatMap(
+      refineReturnedFunctionType(
+        signature.parameter,
+        signature.return,
+        argument1,
       ),
+      refinedReturn =>
+        either.map(f(argument1), f1 =>
+          makeFunctionNode(
+            refinedReturn.signature,
+            serializeOnceAppliedFunction(keyPath, argument1),
+            option.none,
+            handleUnavailableDependencies(f1),
+          ),
+        ),
     ),
   )
 
@@ -106,21 +119,73 @@ export const preludeFunctionArity3 = (
   >,
 ) =>
   preludeFunctionArity1(keyPath, signature, argument1 =>
-    either.map(f(argument1), f1 =>
-      makeFunctionNode(
-        signature.return.signature,
-        serializeOnceAppliedFunction(keyPath, argument1),
-        option.none,
-        handleUnavailableDependencies(argument2 =>
-          either.map(f1(argument2), f2 =>
-            makeFunctionNode(
-              signature.return.signature.return.signature,
-              serializeTwiceAppliedFunction(keyPath, argument1, argument2),
-              option.none,
-              handleUnavailableDependencies(f2),
+    either.flatMap(
+      refineReturnedFunctionType(
+        signature.parameter,
+        signature.return,
+        argument1,
+      ),
+      refinedReturn1 =>
+        either.map(f(argument1), f1 =>
+          makeFunctionNode(
+            refinedReturn1.signature,
+            serializeOnceAppliedFunction(keyPath, argument1),
+            option.none,
+            handleUnavailableDependencies(argument2 =>
+              either.flatMap(
+                refinedReturn1.signature.return.kind === 'function' ?
+                  refineReturnedFunctionType(
+                    refinedReturn1.signature.parameter,
+                    refinedReturn1.signature.return,
+                    argument2,
+                  )
+                : either.makeLeft({
+                    kind: 'bug',
+                    message: `supplying type arguments in an arity-3 standard library function somehow transformed its first return type into a ${refinedReturn1.signature.return.kind} type (it should be a function type)`,
+                  }),
+                refinedReturn2 =>
+                  either.map(f1(argument2), f2 =>
+                    makeFunctionNode(
+                      refinedReturn2.signature,
+                      serializeTwiceAppliedFunction(
+                        keyPath,
+                        argument1,
+                        argument2,
+                      ),
+                      option.none,
+                      handleUnavailableDependencies(f2),
+                    ),
+                  ),
+              ),
             ),
           ),
         ),
-      ),
     ),
   )
+
+/**
+ * Substitute type parameters using an argument's type into the returned
+ * function type of a higher-order function. Without this, each partial
+ * application would carry the outermost static signature, leaving type
+ * parameters uninstantiated.
+ */
+const refineReturnedFunctionType = (
+  parameterType: Type,
+  returnedType: FunctionType,
+  argument: SemanticGraph,
+): Either<FunctionNodeCallError, FunctionType> =>
+  either.flatMap(literalTypeFromSemanticGraph(argument), argumentType => {
+    const refinedReturnType = supplyTypeArguments(
+      returnedType,
+      getTypesForTypeParameters({
+        parameterType,
+        argumentType,
+      }),
+    )
+    return refinedReturnType.kind === 'function' ?
+        either.makeRight(refinedReturnType)
+      : either.makeLeft({
+          kind: 'bug',
+          message: `supplying type arguments to a standard library function somehow transformed it into a ${refinedReturnType.kind} type`,
+        })
+  })


### PR DESCRIPTION
Generic standard library functions of arity 2 or higher (like `flow`) previously did not correctly instantiate type parameters within the function types returned by partial applications.

This changeset re-enables the test case that was disabled in #160 (as well as adding a new test case).

The diff for this changeset looks a bit better if you ignore whitespace changes.