### PR TITLE
Fix a sneaky bug related to type checking of higher-order functions

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -845,4 +845,20 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `(_ => (f: :atom.type) => :f) ~ (:something.type ~> (:atom.type ~> :atom.type))`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(@runtime { _ =>
+      { constrain_function: (f: { a: :atom.type } ~> :atom.type) => :f({ a: hello }) }
+    }).constrain_function(x => :x.a) ~ :atom.type`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -88,7 +88,9 @@ const apply = (
             ),
             // Put the argument in scope.
             [parameterName]: argument,
-            [returnKey]: body,
+            // Use the serialized form so the body in the program matches what
+            // gets re-elaborated.
+            [returnKey]: serializedBody,
           }),
       ),
       updatedProgram =>

--- a/src/language/semantics/expressions/function-expression.ts
+++ b/src/language/semantics/expressions/function-expression.ts
@@ -8,11 +8,8 @@ import {
   makeObjectNode,
   type ObjectNode,
 } from '../object-node.js'
-import { serialize, type SemanticGraph } from '../semantic-graph.js'
-import {
-  asSemanticGraph,
-  readArgumentsFromExpression,
-} from './expression-utilities.js'
+import { type SemanticGraph } from '../semantic-graph.js'
+import { readArgumentsFromExpression } from './expression-utilities.js'
 
 export type FunctionExpression = ObjectNode & {
   readonly 0: '@function'
@@ -39,9 +36,7 @@ export const readFunctionExpression = (
             kind: 'invalidExpression',
             message: 'typed parameter object must contain exactly one property',
           })
-        : either.map(serialize(body), body =>
-            makeFunctionExpression(parameter, asSemanticGraph(body)),
-          ),
+        : either.makeRight(makeFunctionExpression(parameter, body)),
     )
   : either.makeLeft({
       kind: 'invalidExpression',


### PR DESCRIPTION
Eagerly re-serializing the function body in `readFunctionExpression` caused trouble for type inference of higher-order functions with their inner function's parameter annotated with a `symbol`-backed type (e.g. `:atom.type`). It'd end up eventually receiving a raw `@lookup` expression rather than the `TypeSymbol`, and this would leak back into the outer function's signature as an object type via `genericizeFunctionParameterAnnotation`. Quite the edge case!

To address this I'm now deferring body serialization until functions are applied.

See the new compiler tests for examples of programs which now type-check correctly.