### PR TITLE
Don't replace extant type parameters while genericizing functions

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -912,4 +912,24 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      apply_to_1: (identity: (a => :a)) => :identity(1)
+      :apply_to_1(:identity) ~ 1
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      apply_to_1:
+        (integer_identity: (a: :integer.type) => :a) => :integer_identity(1)
+    }.apply_to_1(a => :a) ~ 1`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/semantics/type-system.test.ts
+++ b/src/language/semantics/type-system.test.ts
@@ -1459,4 +1459,11 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   ],
 
   [['empty', makeObjectType('', {})], '{}'],
+
+  [
+    ['identity', makeFunctionType('', { parameter: A, return: A })],
+    `${showType(A)} ~> ${showType(A)}`,
+  ],
+
+  [['wrap', makeObjectType('', { value: A })], `{ value: ${showType(A)} }`],
 ])

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -142,10 +142,9 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
 }
 
 /**
- * Traverse a function parameter type annotation, replacing each leaf (opaque
- * type, union type, or existing type parameter) with a fresh `TypeParameter`
- * constrained to the leaf. This is used to make functions implicitly generic,
- * even when annotated. For example:
+ * Traverse a function parameter type annotation, replacing each opaque or union
+ * leaf with a fresh `TypeParameter` constrained to the leaf. This is used to
+ * make functions implicitly generic, even when annotated. For example:
  *
  * ```plz
  * ((x: { a: :integer.type }) => :x.a)({ a: 42 }) ~ 42
@@ -201,10 +200,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
       makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
         assignableTo: leafType,
       }),
-    parameter: leafType =>
-      makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
-        assignableTo: leafType,
-      }),
+    parameter: leafType => leafType,
     union: leafType =>
       makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
         assignableTo: leafType,


### PR DESCRIPTION
Functions are genericized by replacing leaves within the parameter's annotation with type parameters. For example, in a function like `(user: { name: :atom.type }) => :user.name`, `:atom.type` is replaced by a new type parameter which is constrained to `:atom.type`.

However, when the function parameter type is itself a generic function (as in `(f: (a => :a)) => :f(1)`), replacing leaves of `(a => :a)` with separately-synthesized type parameters was breaking the genericness of `f`.

Now, genericizing keeps any existing type parameters as-is.