### PR TITLE
Run full inference when interpreting parameter types

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -932,4 +932,34 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `((a: @runtime { _ => 1 } + 1) => _)(2)`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      dynamically_constrained_identity: a => (f: :a ~> :a) => :f(:a)
+      :dynamically_constrained_identity(a)(_a => a) ~ a
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      dynamically_constrained_identity: a => (f: :a ~> :a) => :f(:a)
+      :dynamically_constrained_identity(a)(_a => oops)
+      //                                         ^ not \`a\`
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -1,6 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import option, { type Option } from '@matt.kantor/option'
-import type { Bug, ElaborationError } from '../../errors.js'
+import type { ElaborationError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import {
   applyKeyPathToSemanticGraph,
@@ -387,10 +387,10 @@ const inferTypeImplementation = (
 const getFunctionParameterType = (
   expression: FunctionExpression,
   contextOfFunction: ExpressionContext,
-): Either<Bug, Type> =>
+): Either<ElaborationError, Type> =>
   option.match(getParameterTypeAnnotation(expression), {
     some: annotation =>
-      either.map(literalTypeFromSemanticGraph(annotation), annotationType => {
+      either.map(inferType(annotation, contextOfFunction), annotationType => {
         const parameterName = getParameterName(expression)
         // `_` (`ignoredKey`) is the name for an ignored parameter (and is what
         // the parser emits for `~>` syntax sugar). Genericization is skipped


### PR DESCRIPTION
Previously only `literalTypeFromSemanticGraph` was used, which limited expressiveness.