### PR TITLE
Add `@hole` keyword for introducing type parameters

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -995,4 +995,41 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      f: (x: @hole { name: t, constraint: { assignableTo: :something.type } })
+        => :x
+      :f(42) ~ 42
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      apply: a => (f: :a ~> @hole {
+        name: b
+        constraint: { assignableTo: :something.type }
+      }) => :f(:a)
+      ab: :apply(a)(:atom.append(b))
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      apply2: a =>
+        (f: :a ~> @hole { name: b, constraint: { assignableTo: :something.type } })
+          => (g: :b ~> @hole { name: c, constraint: { assignableTo: :something.type } })
+            => :g(:f(:a))
+      :apply2(42)(_n => true)(_b => x) ~ x
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1032,4 +1032,17 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      pipe: (f:
+        @hole { name: a, constraint: { assignableTo: :something.type } } ~>
+          @hole { name: b, constraint: { assignableTo: :something.type } }
+      ) => (a: :a) => :f(:a)
+      ab: :pipe(:atom.append(b))(a)
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -1,10 +1,12 @@
 import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
+import type { Atom } from '../../../parsing.js'
 import {
   elaborateWithContext,
   getParameterName,
   getParameterTypeAnnotation,
+  getTypesForTypeParameters,
   ignoredKey,
   inferType,
   makeFunctionNode,
@@ -18,8 +20,13 @@ import {
   type FunctionNode,
   type KeywordHandler,
   type SemanticGraph,
+  type Type,
 } from '../../../semantics.js'
-import { collectHolesByName } from '../../../semantics/expressions/hole-expression.js'
+import {
+  collectHolesByName,
+  makeHoleExpression,
+} from '../../../semantics/expressions/hole-expression.js'
+import { makeTypeParameter } from '../../../semantics/type-system/type-formats.js'
 
 export const functionKeywordHandler: KeywordHandler = (
   expression: Expression,
@@ -80,6 +87,28 @@ const apply = (
     {
       none: _ => ({}),
       some: annotation => {
+        // Specialize each hole's type parameter using the inferred type of the
+        // argument, so references like `:a` in the body see the concrete type
+        // rather than the original unconstrained type parameter.
+        const specializationsByTypeParameterName = either.match(
+          inferType(argument, context),
+          {
+            left: _ => new Map<Atom, Type>(),
+            right: argumentType =>
+              new Map(
+                [
+                  ...getTypesForTypeParameters({
+                    parameterType: signature.parameter,
+                    argumentType,
+                  }),
+                ].map(([typeParameter, specialization]) => [
+                  typeParameter.name,
+                  specialization,
+                ]),
+              ),
+          },
+        )
+
         const holeBindings: Record<string, SemanticGraph> = {}
         for (const [name, hole] of collectHolesByName(annotation)) {
           if (
@@ -88,7 +117,15 @@ const apply = (
             name !== returnKey &&
             name !== ignoredKey
           ) {
-            holeBindings[name] = hole
+            const specializedType = specializationsByTypeParameterName.get(name)
+            holeBindings[name] =
+              specializedType === undefined ? hole : (
+                makeHoleExpression(
+                  name,
+                  hole[1].constraint,
+                  makeTypeParameter(name, { assignableTo: specializedType }),
+                )
+              )
           }
         }
         return holeBindings

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -4,6 +4,8 @@ import type { ElaborationError } from '../../../errors.js'
 import {
   elaborateWithContext,
   getParameterName,
+  getParameterTypeAnnotation,
+  ignoredKey,
   inferType,
   makeFunctionNode,
   makeObjectNode,
@@ -17,6 +19,7 @@ import {
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
+import { collectHolesByName } from '../../../semantics/expressions/hole-expression.js'
 
 export const functionKeywordHandler: KeywordHandler = (
   expression: Expression,
@@ -72,6 +75,27 @@ const apply = (
       'return with a different key to avoid collision with a stupidly-named parameter'
     : 'return'
 
+  const holeBindings: Record<string, SemanticGraph> = option.match(
+    getParameterTypeAnnotation(expression),
+    {
+      none: _ => ({}),
+      some: annotation => {
+        const holeBindings: Record<string, SemanticGraph> = {}
+        for (const [name, hole] of collectHolesByName(annotation)) {
+          if (
+            name !== parameterName &&
+            name !== ownKey &&
+            name !== returnKey &&
+            name !== ignoredKey
+          ) {
+            holeBindings[name] = hole
+          }
+        }
+        return holeBindings
+      },
+    },
+  )
+
   const result = either.flatMap(serialize(body), serializedBody =>
     either.flatMap(
       updateValueAtKeyPathInSemanticGraph(
@@ -88,6 +112,9 @@ const apply = (
             ),
             // Put the argument in scope.
             [parameterName]: argument,
+            // Put any `@hole`s from the parameter annotation in scope so type
+            // parameters can be referenced.
+            ...holeBindings,
             // Use the serialized form so the body in the program matches what
             // gets re-elaborated.
             [returnKey]: serializedBody,

--- a/src/language/compiling/semantics/keyword-handlers/hole-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/hole-handler.test.ts
@@ -1,0 +1,100 @@
+import either from '@matt.kantor/either'
+import assert from 'node:assert'
+import { types } from '../../../semantics.js'
+import { isKeywordExpressionWithArgument } from '../../../semantics/expression.js'
+import {
+  getHoleTypeParameter,
+  readHoleExpression,
+} from '../../../semantics/expressions/hole-expression.js'
+import { isObjectNode } from '../../../semantics/object-node.js'
+import { elaborationSuite } from '../test-utilities.test.js'
+
+const somethingTypeAsObject = {
+  0: '@index',
+  1: {
+    object: {
+      0: '@lookup',
+      1: { key: 'something' },
+    },
+    query: { 0: 'type' },
+  },
+}
+
+elaborationSuite('@hole', [
+  [
+    {
+      0: '@hole',
+      1: {
+        name: 'a',
+        constraint: { assignableTo: somethingTypeAsObject },
+      },
+    },
+    result => {
+      assert(either.isRight(result))
+      const node = result.value
+      const holeExpressionResult = readHoleExpression(node)
+      assert(either.isRight(holeExpressionResult))
+      const parameter = getHoleTypeParameter(holeExpressionResult.value)
+      assert.deepEqual(parameter.name, 'a')
+      assert.deepEqual(parameter.constraint.assignableTo, types.something)
+    },
+  ],
+
+  [
+    {
+      pair: {
+        0: '@union',
+        1: {
+          0: {
+            0: '@hole',
+            1: {
+              name: 'same',
+              constraint: {
+                assignableTo: somethingTypeAsObject,
+              },
+            },
+          },
+          1: {
+            0: '@hole',
+            1: {
+              name: 'same',
+              constraint: {
+                assignableTo: somethingTypeAsObject,
+              },
+            },
+          },
+        },
+      },
+    },
+    result => {
+      assert(either.isRight(result))
+      const node = result.value
+      assert(isObjectNode(node))
+      const pair = node['pair']
+      assert(pair)
+      assert(isKeywordExpressionWithArgument('@union', pair))
+      assert(isObjectNode(pair[1]))
+
+      const first = pair[1]['0']
+      const second = pair[1]['1']
+      assert(first)
+      assert(second)
+      const firstHoleExpressionResult = readHoleExpression(first)
+      assert(either.isRight(firstHoleExpressionResult))
+      const secondHoleExpressionResult = readHoleExpression(second)
+      assert(either.isRight(secondHoleExpressionResult))
+
+      // They have unique identities despite sharing a name.
+      const firstTypeParameter = getHoleTypeParameter(
+        firstHoleExpressionResult.value,
+      )
+      const secondTypeParameter = getHoleTypeParameter(
+        secondHoleExpressionResult.value,
+      )
+      assert.notDeepStrictEqual(
+        firstTypeParameter.identity,
+        secondTypeParameter.identity,
+      )
+    },
+  ],
+])

--- a/src/language/compiling/semantics/keyword-handlers/hole-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/hole-handler.ts
@@ -1,0 +1,15 @@
+import either, { type Either } from '@matt.kantor/either'
+import { type ElaborationError } from '../../../errors.js'
+import {
+  type Expression,
+  type ExpressionContext,
+  type KeywordHandler,
+  type SemanticGraph,
+} from '../../../semantics.js'
+
+export const holeKeywordHandler: KeywordHandler = (
+  expression: Expression,
+  _context: ExpressionContext,
+): Either<ElaborationError, SemanticGraph> =>
+  // This is currently only used in types and doesn't need transformation here.
+  either.makeRight(expression)

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -97,6 +97,7 @@ export const ifKeywordHandler: KeywordHandler = (
                       context.keywordHandlers['@apply'],
                     ),
                     '@function': doNotElaborate,
+                    '@hole': doNotElaborate,
                     '@if': doNotElaborate,
                     '@panic': doNotElaborate,
                     '@runtime': doNotElaborate,

--- a/src/language/compiling/semantics/keywords.ts
+++ b/src/language/compiling/semantics/keywords.ts
@@ -2,6 +2,7 @@ import { type KeywordHandlers } from '../../semantics.js'
 import { applyKeywordHandler } from './keyword-handlers/apply-handler.js'
 import { checkKeywordHandler } from './keyword-handlers/check-handler.js'
 import { functionKeywordHandler } from './keyword-handlers/function-handler.js'
+import { holeKeywordHandler } from './keyword-handlers/hole-handler.js'
 import { ifKeywordHandler } from './keyword-handlers/if-handler.js'
 import { indexKeywordHandler } from './keyword-handlers/index-handler.js'
 import { lookupKeywordHandler } from './keyword-handlers/lookup-handler.js'
@@ -25,6 +26,11 @@ export const keywordHandlers: KeywordHandlers = {
    * Creates a function.
    */
   '@function': functionKeywordHandler,
+
+  /**
+   * Introduces a type parameter.
+   */
+  '@hole': holeKeywordHandler,
 
   /**
    * Conditionally evaluates one of two expressions based on a boolean value.

--- a/src/language/semantics/expressions/hole-expression.ts
+++ b/src/language/semantics/expressions/hole-expression.ts
@@ -1,0 +1,160 @@
+import either, { type Either } from '@matt.kantor/either'
+import type { ElaborationError } from '../../errors.js'
+import type { Atom } from '../../parsing.js'
+import { isKeywordExpressionWithArgument } from '../expression.js'
+import { isFunctionNode } from '../function-node.js'
+import {
+  isObjectNode,
+  makeObjectNode,
+  type ObjectNode,
+} from '../object-node.js'
+import type { SemanticGraph } from '../semantic-graph.js'
+import { literalTypeFromSemanticGraph } from '../type-system.js'
+import type { TypeParameter } from '../type-system/type-formats.js'
+import {
+  isTypeParameter,
+  makeTypeParameter,
+} from '../type-system/type-formats.js'
+import { readArgumentsFromExpression } from './expression-utilities.js'
+
+export type HoleExpression = ObjectNode & {
+  readonly 0: '@hole'
+  readonly 1: ObjectNode & {
+    readonly name: Atom
+    readonly constraint: ObjectNode & {
+      readonly assignableTo: SemanticGraph
+    }
+  }
+
+  // This is stashed on the node so that repeated reads (e.g. successive
+  // type-inference passes) return a parameter with stable identity.
+  readonly [typeParameterKey]: TypeParameter
+}
+const typeParameterKey = Symbol('typeParameter')
+
+/**
+ * Mints a new type parameter for the node if one doesn't already exist.
+ */
+export const readHoleExpression = (
+  node: SemanticGraph,
+): Either<ElaborationError, HoleExpression> =>
+  isKeywordExpressionWithArgument('@hole', node) ?
+    either.flatMap(
+      readArgumentsFromExpression(node, ['name', 'constraint']),
+      ([name, constraint]) => {
+        if (typeof name !== 'string') {
+          return either.makeLeft<ElaborationError>({
+            kind: 'invalidExpression',
+            message: '`@hole` name must be an atom',
+          })
+        } else if (!isObjectNode(constraint)) {
+          return either.makeLeft({
+            kind: 'invalidExpression',
+            message: '`@hole` constraint must be an object',
+          })
+        } else if (
+          typeParameterKey in node &&
+          (typeof node[typeParameterKey] !== 'object' ||
+            typeof node[typeParameterKey] === null)
+        ) {
+          return either.makeLeft({
+            kind: 'bug',
+            message:
+              '`@hole` had an existing type parameter that was not actually a type parameter',
+          })
+        } else {
+          const assignableToNode = constraint['assignableTo']
+          if (assignableToNode === undefined) {
+            return either.makeLeft({
+              kind: 'invalidExpression',
+              message:
+                '`@hole` constraint must contain an `assignableTo` property',
+            })
+          } else {
+            const typeParameter =
+              (
+                typeParameterKey in node &&
+                isTypeParameter(node[typeParameterKey])
+              ) ?
+                node[typeParameterKey]
+              : undefined
+            return either.map(
+              literalTypeFromSemanticGraph(assignableToNode),
+              assignableTo => {
+                const node = makeObjectNode({
+                  0: '@hole',
+                  1: makeObjectNode({
+                    name,
+                    constraint: makeObjectNode({
+                      assignableTo: assignableToNode,
+                    }),
+                  }),
+                })
+                return Object.assign(node, {
+                  [typeParameterKey]:
+                    typeParameter === undefined ?
+                      makeTypeParameter(name, { assignableTo })
+                    : typeParameter,
+                })
+              },
+            )
+          }
+        }
+      },
+    )
+  : either.makeLeft({
+      kind: 'invalidExpression',
+      message: 'not a `@hole` expression',
+    })
+
+export const makeHoleExpression = (
+  name: Atom,
+  constraint: HoleExpression[1]['constraint'],
+  parameter: TypeParameter,
+): HoleExpression =>
+  Object.assign(
+    makeObjectNode({
+      0: '@hole',
+      1: makeObjectNode({ name, constraint }),
+    }),
+    { [typeParameterKey]: parameter },
+  )
+
+export const getHoleTypeParameter = (node: HoleExpression): TypeParameter =>
+  node[typeParameterKey]
+
+/**
+ * Walk an annotation, returning a `Map` from hole names to their expressions.
+ */
+export const collectHolesByName = (
+  annotation: SemanticGraph,
+): ReadonlyMap<Atom, HoleExpression> => {
+  const collect = (
+    accumulator: Map<Atom, HoleExpression>,
+    node: SemanticGraph,
+  ): Map<Atom, HoleExpression> => {
+    const holeExpressionResult = readHoleExpression(node)
+    if (
+      either.isRight(holeExpressionResult) &&
+      typeParameterKey in holeExpressionResult.value
+    ) {
+      const node = holeExpressionResult.value
+      const name = node[1]['name']
+      if (!accumulator.has(name)) {
+        // Side effect: remember the hole.
+        accumulator.set(name, node)
+      }
+      return accumulator
+    } else if (isFunctionNode(node)) {
+      return either.match(node.serialize(), {
+        right: serialized => collect(accumulator, serialized),
+        left: _ => accumulator,
+      })
+    } else if (!isObjectNode(node)) {
+      return accumulator
+    } else {
+      return Object.values(node).reduce(collect, accumulator)
+    }
+  }
+  return collect(new Map(), annotation)
+}

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -26,8 +26,10 @@ import {
 } from './expression-utilities.js'
 import {
   getParameterName,
+  getParameterTypeAnnotation,
   readFunctionExpression,
 } from './function-expression.js'
+import { collectHolesByName } from './hole-expression.js'
 import { makeIndexExpression } from './index-expression.js'
 
 export type LookupExpression = ObjectNode & {
@@ -152,11 +154,18 @@ export const lookup = ({
         some: parentExpression => {
           const parentFunctionResult = readFunctionExpression(parentExpression)
           // If enclosed in a `@function` expression, allow looking up the
-          // parameter.
-          if (
+          // parameter plus `@hole`s introduced by parameter annotations.
+          const isParameterMatch =
             either.isRight(parentFunctionResult) &&
-            getParameterName(parentFunctionResult.value) === key
-          ) {
+            (getParameterName(parentFunctionResult.value) === key ||
+              option.match(
+                getParameterTypeAnnotation(parentFunctionResult.value),
+                {
+                  none: () => false,
+                  some: annotation => collectHolesByName(annotation).has(key),
+                },
+              ))
+          if (isParameterMatch) {
             // Keep an unelaborated `@lookup` around for resolution when the
             // `@function` is called.
             return {

--- a/src/language/semantics/keyword.ts
+++ b/src/language/semantics/keyword.ts
@@ -1,9 +1,11 @@
-export const isExemptFromElaboration = (input: Keyword) => input === '@union'
+export const isExemptFromElaboration = (input: Keyword) =>
+  input === '@hole' || input === '@union'
 
 export const isKeyword = (input: string) =>
   input === '@apply' ||
   input === '@check' ||
   input === '@function' ||
+  input === '@hole' ||
   input === '@if' ||
   input === '@index' ||
   input === '@lookup' ||

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -1,7 +1,7 @@
 export * as types from './type-system/prelude-types.js'
 export { showType } from './type-system/show-type.js'
 export { isAssignable } from './type-system/subtyping.js'
-export type { Type } from './type-system/type-formats.js'
+export { makeTypeParameter, type Type } from './type-system/type-formats.js'
 export {
   inferType,
   resolveParameterTypes,

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -147,6 +147,37 @@ export const makeTypeParameter = (
   constraint,
 })
 
+export const isTypeParameter = (value: unknown): value is TypeParameter => {
+  // This doesn't exhaustively validate (it doesn't look inside `constraint`),
+  // but something very weird would have to be going on for this to have a false
+  // positive.
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    typeof value.name === 'string' &&
+    'kind' in value &&
+    value.kind === 'parameter' &&
+    'constraint' in value &&
+    typeof value['constraint'] === 'object' &&
+    value['constraint'] !== null &&
+    'identity' in value &&
+    typeof value.identity === 'symbol'
+  ) {
+    const newValue = {
+      name: value.name,
+      kind: value.kind,
+      constraint: value.constraint,
+      identity: value.identity,
+    } satisfies Omit<TypeParameter, 'constraint'> & {
+      constraint: Omit<TypeParameter['constraint'], 'assignableTo'>
+    }
+    return true
+  } else {
+    return false
+  }
+}
+
 export type UnionType = {
   readonly name: string
   readonly kind: 'union'

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -3,6 +3,10 @@ import type { Writable } from '../../../utility-types.js'
 import type { Bug } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
+import {
+  getHoleTypeParameter,
+  readHoleExpression,
+} from '../expressions/hole-expression.js'
 import { type SemanticGraph } from '../semantic-graph.js'
 import { types } from '../type-system.js'
 import { typesBySymbol } from './prelude-types.js'
@@ -722,6 +726,15 @@ export const literalTypeFromSemanticGraph = (
               : [memberType],
             ),
           ),
+      )
+    } else if (isKeywordExpressionWithArgument('@hole', node)) {
+      return either.mapLeft(
+        either.map(readHoleExpression(node), getHoleTypeParameter),
+        error => ({
+          kind: 'bug',
+          message: '`@hole` expression was invalid',
+          cause: error,
+        }),
       )
     } else {
       // `node` is an object type.


### PR DESCRIPTION
`@hole`s are slots for type arguments to fill in. Their expressions are stamped with a `TypeParameter` which contains a unique symbol identifying the parameter. `literalTypeFromSemanticGraph` has been taught how to extract this parameter. `@hole`s can be looked up just like properties and function parameters.