### PR TITLE
Forbid multiple same-named holes in functions

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1062,4 +1062,12 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `(config: { x: ?a, y: ?a }) => :config`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'invalidExpression')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -24,6 +24,7 @@ import {
 } from '../../../semantics.js'
 import {
   collectHolesByName,
+  findDuplicateHoleNames,
   makeHoleExpression,
 } from '../../../semantics/expressions/hole-expression.js'
 import { makeTypeParameter } from '../../../semantics/type-system/type-formats.js'
@@ -33,31 +34,52 @@ export const functionKeywordHandler: KeywordHandler = (
   context: ExpressionContext,
 ): Either<ElaborationError, FunctionNode> =>
   either.flatMap(readFunctionExpression(expression), functionExpression =>
-    either.flatMap(inferType(expression, context), inferredType => {
-      if (inferredType.kind !== 'function') {
-        return either.makeLeft({
-          kind: 'bug',
-          message:
-            'inferred type of function expression was not a function type',
-        })
-      } else {
-        return either.makeRight(
-          makeFunctionNode(
-            inferredType.signature,
-            () => either.makeRight(functionExpression),
-            option.makeSome(getParameterName(functionExpression)),
-            argument =>
-              apply(
-                functionExpression,
-                inferredType.signature,
-                argument,
-                context,
-              ),
-          ),
-        )
-      }
-    }),
+    either.flatMap(checkForDuplicateHoles(functionExpression), _ =>
+      either.flatMap(inferType(expression, context), inferredType => {
+        if (inferredType.kind !== 'function') {
+          return either.makeLeft({
+            kind: 'bug',
+            message:
+              'inferred type of function expression was not a function type',
+          })
+        } else {
+          return either.makeRight(
+            makeFunctionNode(
+              inferredType.signature,
+              () => either.makeRight(functionExpression),
+              option.makeSome(getParameterName(functionExpression)),
+              argument =>
+                apply(
+                  functionExpression,
+                  inferredType.signature,
+                  argument,
+                  context,
+                ),
+            ),
+          )
+        }
+      }),
+    ),
   )
+
+const checkForDuplicateHoles = (
+  expression: FunctionExpression,
+): Either<ElaborationError, undefined> =>
+  option.match(getParameterTypeAnnotation(expression), {
+    none: () => either.makeRight(undefined),
+    some: annotation => {
+      const duplicates = findDuplicateHoleNames(annotation)
+      if (duplicates.size === 0) {
+        return either.makeRight(undefined)
+      } else {
+        const [first] = duplicates
+        return either.makeLeft({
+          kind: 'invalidExpression',
+          message: `hole \`?${first ?? ''}\` is declared more than once in the same scope`,
+        })
+      }
+    },
+  })
 
 const apply = (
   expression: FunctionExpression,

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -20,6 +20,7 @@ export {
 } from './semantics/expressions/check-expression.js'
 export {
   asSemanticGraph,
+  ignoredKey,
   stringifyKeyForEndUser,
 } from './semantics/expressions/expression-utilities.js'
 export {
@@ -40,7 +41,6 @@ export {
   type IndexExpression,
 } from './semantics/expressions/index-expression.js'
 export {
-  ignoredKey,
   keyPathToLookupExpression,
   lookup,
   makeLookupExpression,

--- a/src/language/semantics/expressions/expression-utilities.ts
+++ b/src/language/semantics/expressions/expression-utilities.ts
@@ -19,6 +19,12 @@ import {
   type SemanticGraph,
 } from '../semantic-graph.js'
 
+/**
+ * This name is used for ignored parameters/properties and can't be directly
+ * looked-up.
+ */
+export const ignoredKey = '_'
+
 export const asSemanticGraph = (
   value: SemanticGraph | Molecule,
 ): SemanticGraph =>

--- a/src/language/semantics/expressions/hole-expression.ts
+++ b/src/language/semantics/expressions/hole-expression.ts
@@ -15,7 +15,10 @@ import {
   isTypeParameter,
   makeTypeParameter,
 } from '../type-system/type-formats.js'
-import { readArgumentsFromExpression } from './expression-utilities.js'
+import {
+  ignoredKey,
+  readArgumentsFromExpression,
+} from './expression-utilities.js'
 
 export type HoleExpression = ObjectNode & {
   readonly 0: '@hole'
@@ -125,6 +128,9 @@ export const getHoleTypeParameter = (node: HoleExpression): TypeParameter =>
 
 /**
  * Walk an annotation, returning a `Map` from hole names to their expressions.
+ *
+ * Duplicates (after the first occurrence per name) are silently dropped. Use
+ * `findDuplicateHoleNames` to detect them.
  */
 export const collectHolesByName = (
   annotation: SemanticGraph,
@@ -157,4 +163,49 @@ export const collectHolesByName = (
     }
   }
   return collect(new Map(), annotation)
+}
+
+/**
+ * Walk an annotation, returning the set of hole names that appear more than
+ * once. Anonymous holes are skipped.
+ */
+export const findDuplicateHoleNames = (
+  annotation: SemanticGraph,
+): ReadonlySet<Atom> => {
+  // TODO: Consider less-imperative/more-functional approaches for this.
+  const seen = new Set<Atom>()
+  const duplicates = new Set<Atom>()
+  const visit = (node: SemanticGraph): void => {
+    const holeExpressionResult = readHoleExpression(node)
+    if (
+      either.isRight(holeExpressionResult) &&
+      typeParameterKey in holeExpressionResult.value
+    ) {
+      const node = holeExpressionResult.value
+      const name = node[1]['name']
+      // Side effect: add `name` to `seen` or `duplicates`.
+      if (
+        seen.has(name) &&
+        // Allow multiple anonymous holes in an annotation.
+        name !== ignoredKey
+      ) {
+        duplicates.add(name)
+      } else {
+        seen.add(name)
+      }
+    } else {
+      if (isFunctionNode(node)) {
+        const serialized = node.serialize()
+        if (either.isRight(serialized)) {
+          visit(serialized.value)
+        }
+      } else if (isObjectNode(node)) {
+        for (const value of Object.values(node)) {
+          visit(value)
+        }
+      }
+    }
+  }
+  visit(annotation)
+  return duplicates
 }

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -21,6 +21,7 @@ import {
   type SemanticGraph,
 } from '../semantic-graph.js'
 import {
+  ignoredKey,
   readArgumentsFromExpression,
   stringifyKeyForEndUser,
 } from './expression-utilities.js'
@@ -38,12 +39,6 @@ export type LookupExpression = ObjectNode & {
     readonly key: Atom
   }
 }
-
-/**
- * This name is used for ignored parameters/properties and can't be directly
- * looked-up.
- */
-export const ignoredKey = '_'
 
 export const readLookupExpression = (
   node: SemanticGraph,


### PR DESCRIPTION
Functions like `(a: { x: ?a, y: ?a }) => …` now emit static analysis errors.

It was only possible to reference the first hole of a given name, so there's no reason to intentionally write code like this. Multiple anonymous holes are still allowed.

The diff gets a lot better if you ignore whitespace.