### PR TITLE
Fix a bunch of incorrect `ExpressionContext` locations

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -85,7 +85,7 @@ export const applyKeywordHandler: KeywordHandler = (
             // The argument isn't ready, so keep the @apply unelaborated.
             return either.makeRight(applyExpression)
           } else if (isFunctionNode(functionToApply)) {
-            const result = functionToApply(argument)
+            const result = functionToApply(argument, context)
             if (either.isLeft(result)) {
               if (result.value.kind === 'dependencyUnavailable') {
                 // Keep the @apply unelaborated.

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -22,27 +22,33 @@ const checkArgumentType = (
   parameterType: Type,
   context: ExpressionContext,
 ): Either<ElaborationError, undefined> =>
-  either.flatMap(inferType(argument, context), argumentType => {
-    // Instantiate type parameters contained in `parameterType` before the
-    // assignability check.
-    const instantiatedParameterType = supplyTypeArguments(
-      parameterType,
-      getTypesForTypeParameters({ parameterType, argumentType }),
-    )
-    return (
-        isAssignable({
-          source: argumentType,
-          target: instantiatedParameterType,
-        })
-      ) ?
-        either.makeRight(undefined)
-      : either.makeLeft({
-          kind: 'typeMismatch',
-          message: `the value \`${stringifySemanticGraphForEndUser(
-            argument,
-          )}\` (inferred to have type \`${showType(argumentType)}\`) is not assignable to the type \`${showType(parameterType)}\``,
-        })
-  })
+  either.flatMap(
+    inferType(argument, {
+      ...context,
+      location: [...context.location, '1', 'argument'],
+    }),
+    argumentType => {
+      // Instantiate type parameters contained in `parameterType` before the
+      // assignability check.
+      const instantiatedParameterType = supplyTypeArguments(
+        parameterType,
+        getTypesForTypeParameters({ parameterType, argumentType }),
+      )
+      return (
+          isAssignable({
+            source: argumentType,
+            target: instantiatedParameterType,
+          })
+        ) ?
+          either.makeRight(undefined)
+        : either.makeLeft({
+            kind: 'typeMismatch',
+            message: `the value \`${stringifySemanticGraphForEndUser(
+              argument,
+            )}\` (inferred to have type \`${showType(argumentType)}\`) is not assignable to the type \`${showType(parameterType)}\``,
+          })
+    },
+  )
 
 export const applyKeywordHandler: KeywordHandler = (
   expression: Expression,
@@ -55,7 +61,10 @@ export const applyKeywordHandler: KeywordHandler = (
       const argument = applyExpression[1].argument
 
       const argumentTypeCheck = either.flatMap(
-        inferType(functionToApply, context),
+        inferType(functionToApply, {
+          ...context,
+          location: [...context.location, '1', 'function'],
+        }),
         functionType =>
           functionType.kind === 'function' ?
             checkArgumentType(

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -2,6 +2,7 @@ import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
   isAssignable,
+  isObjectNode,
   readCheckExpression,
   showType,
   stringifySemanticGraphForEndUser,
@@ -19,35 +20,49 @@ const check = ({
   value,
   type,
   context,
+  valueKey,
 }: {
   readonly value: SemanticGraph
   readonly type: SemanticGraph
   readonly context: ExpressionContext
+  readonly valueKey: string
 }): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(inferType(value, context), valueAsType =>
-    either.flatMap(literalTypeFromSemanticGraph(type), typeAsType => {
-      if (
-        isAssignable({
-          source: valueAsType,
-          target: typeAsType,
-        })
-      ) {
-        return either.makeRight(value)
-      } else {
-        return either.makeLeft({
-          kind: 'typeMismatch',
-          message: `the value \`${stringifySemanticGraphForEndUser(
-            value,
-          )}\` (inferred to have type \`${showType(valueAsType)}\`) is not assignable to the type \`${showType(typeAsType)}\``,
-        })
-      }
+  either.flatMap(
+    inferType(value, {
+      ...context,
+      location: [...context.location, '1', valueKey],
     }),
+    valueAsType =>
+      either.flatMap(literalTypeFromSemanticGraph(type), typeAsType => {
+        if (
+          isAssignable({
+            source: valueAsType,
+            target: typeAsType,
+          })
+        ) {
+          return either.makeRight(value)
+        } else {
+          return either.makeLeft({
+            kind: 'typeMismatch',
+            message: `the value \`${stringifySemanticGraphForEndUser(
+              value,
+            )}\` (inferred to have type \`${showType(valueAsType)}\`) is not assignable to the type \`${showType(typeAsType)}\``,
+          })
+        }
+      }),
   )
 
 export const checkKeywordHandler: KeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(readCheckExpression(expression), ({ 1: { value, type } }) =>
-    check({ value, type, context }),
-  )
+  either.flatMap(readCheckExpression(expression), ({ 1: { value, type } }) => {
+    // The original (un-canonicalized) expression's argument object may use
+    // either named keys (`value`/`type`) or positional ones (`0`/`1`).
+    const argument = expression[1]
+    const valueKey =
+      argument !== undefined && isObjectNode(argument) && 'value' in argument ?
+        'value'
+      : '0'
+    return check({ value, type, context, valueKey })
+  })

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -49,13 +49,11 @@ export const functionKeywordHandler: KeywordHandler = (
               inferredType.signature,
               () => either.makeRight(functionExpression),
               option.makeSome(getParameterName(functionExpression)),
-              argument =>
-                apply(
-                  functionExpression,
-                  inferredType.signature,
-                  argument,
-                  context,
-                ),
+              (argument, applySiteContext) =>
+                apply(functionExpression, inferredType.signature, argument, {
+                  functionDefinitionContext: context,
+                  applySiteContext,
+                }),
             ),
           )
         }
@@ -86,12 +84,21 @@ const apply = (
   expression: FunctionExpression,
   signature: FunctionNode['signature'],
   argument: SemanticGraph,
-  context: ExpressionContext,
+  {
+    functionDefinitionContext,
+    applySiteContext,
+  }: {
+    readonly functionDefinitionContext: ExpressionContext
+    readonly applySiteContext: ExpressionContext
+  },
 ): ReturnType<FunctionNode> => {
   const parameterName = getParameterName(expression)
   const body = expression[1].body
 
-  const ownKey = context.location[context.location.length - 1]
+  const ownKey =
+    functionDefinitionContext.location[
+      functionDefinitionContext.location.length - 1
+    ]
   if (ownKey === undefined) {
     return either.makeLeft({
       kind: 'panic',
@@ -113,7 +120,10 @@ const apply = (
         // argument, so references like `:a` in the body see the concrete type
         // rather than the original unconstrained type parameter.
         const specializationsByTypeParameterName = either.match(
-          inferType(argument, context),
+          inferType(argument, {
+            ...applySiteContext,
+            location: [...applySiteContext.location, '1', 'argument'],
+          }),
           {
             left: _ => new Map<Atom, Type>(),
             right: argumentType =>
@@ -158,8 +168,8 @@ const apply = (
   const result = either.flatMap(serialize(body), serializedBody =>
     either.flatMap(
       updateValueAtKeyPathInSemanticGraph(
-        context.program,
-        context.location,
+        functionDefinitionContext.program,
+        functionDefinitionContext.location,
         _ =>
           objectNodeFromOrderedEntries([
             // Include the function itself to allow recursion.
@@ -169,7 +179,11 @@ const apply = (
                 signature,
                 () => either.makeRight(expression),
                 option.makeSome(parameterName),
-                argument => apply(expression, signature, argument, context),
+                argument =>
+                  apply(expression, signature, argument, {
+                    functionDefinitionContext,
+                    applySiteContext,
+                  }),
               ),
             ],
             // Put the argument in scope.
@@ -184,8 +198,8 @@ const apply = (
       ),
       updatedProgram =>
         elaborateWithContext(serializedBody, {
-          keywordHandlers: context.keywordHandlers,
-          location: [...context.location, returnKey],
+          keywordHandlers: functionDefinitionContext.keywordHandlers,
+          location: [...functionDefinitionContext.location, returnKey],
           program: updatedProgram,
         }),
     ),

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -60,7 +60,13 @@ export const ifKeywordHandler: KeywordHandler = (
         } else {
           return either.flatMap(
             either.flatMap(
-              inferType(elaboratedCondition, context),
+              inferType(elaboratedCondition, {
+                ...context,
+                location: [
+                  ...context.location,
+                  ...subexpressionKeyPaths.condition,
+                ],
+              }),
               conditionType =>
                 (
                   isAssignable({
@@ -104,9 +110,13 @@ export const ifKeywordHandler: KeywordHandler = (
 
                 const elaborateNestedIfLookups = (
                   branch: SemanticGraph,
+                  branchLocation: KeyPath,
                 ): Either<ElaborationError, SemanticGraph> =>
                   isExpression(branch) && branch['0'] === '@if' ?
-                    ifKeywordHandler(branch, partiallyElaboratingContext)
+                    ifKeywordHandler(branch, {
+                      ...partiallyElaboratingContext,
+                      location: branchLocation,
+                    })
                   : isExpression(branch) && branch['0'] === '@function' ?
                     either.makeRight(branch)
                   : isObjectNode(branch) ?
@@ -114,7 +124,10 @@ export const ifKeywordHandler: KeywordHandler = (
                       either.sequence(
                         orderedEntriesOfObjectNode(branch).map(([key, value]) =>
                           either.map(
-                            elaborateNestedIfLookups(value),
+                            elaborateNestedIfLookups(value, [
+                              ...branchLocation,
+                              key,
+                            ]),
                             elaboratedValue => [key, elaboratedValue] as const,
                           ),
                         ),
@@ -125,8 +138,12 @@ export const ifKeywordHandler: KeywordHandler = (
 
                 const elaborateBranch = (
                   branchKey: 'then' | 'else',
-                ): Either<ElaborationError, SemanticGraph> =>
-                  either.flatMap(
+                ): Either<ElaborationError, SemanticGraph> => {
+                  const branchLocation = [
+                    ...partiallyElaboratingContext.location,
+                    ...subexpressionKeyPaths[branchKey],
+                  ]
+                  return either.flatMap(
                     either.map(
                       evaluateSubexpression(
                         subexpressionKeyPaths[branchKey],
@@ -135,8 +152,9 @@ export const ifKeywordHandler: KeywordHandler = (
                       ),
                       asSemanticGraph,
                     ),
-                    elaborateNestedIfLookups,
+                    branch => elaborateNestedIfLookups(branch, branchLocation),
                   )
+                }
 
                 return either.map(
                   either.sequence([

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -6,6 +6,7 @@ import {
   applyKeyPathToType,
   containsAnyUnelaboratedNodes,
   inferType,
+  isObjectNode,
   keyPathFromObjectNode,
   readIndexExpression,
   showType,
@@ -21,18 +22,27 @@ const checkKeyPathExistsInType = (
   object: SemanticGraph,
   keyPath: KeyPath,
   context: ExpressionContext,
+  objectKey: string,
 ): Either<ElaborationError, undefined> =>
-  either.flatMap(inferType(object, context), objectType => {
-    const typeAtKeyPath = applyKeyPathToType(objectType, keyPath)
-    return typeAtKeyPath.kind === 'union' && typeAtKeyPath.members.size === 0 ?
-        either.makeLeft({
-          kind: 'typeMismatch',
-          message: `property \`${stringifyKeyPathForEndUser(
-            keyPath,
-          )}\` does not exist on type \`${showType(objectType)}\``,
-        })
-      : either.makeRight(undefined)
-  })
+  either.flatMap(
+    inferType(object, {
+      ...context,
+      location: [...context.location, '1', objectKey],
+    }),
+    objectType => {
+      const typeAtKeyPath = applyKeyPathToType(objectType, keyPath)
+      return (
+          typeAtKeyPath.kind === 'union' && typeAtKeyPath.members.size === 0
+        ) ?
+          either.makeLeft({
+            kind: 'typeMismatch',
+            message: `property \`${stringifyKeyPathForEndUser(
+              keyPath,
+            )}\` does not exist on type \`${showType(objectType)}\``,
+          })
+        : either.makeRight(undefined)
+    },
+  )
 
 export const indexKeywordHandler: KeywordHandler = (
   expression: Expression,
@@ -41,8 +51,19 @@ export const indexKeywordHandler: KeywordHandler = (
   either.flatMap(readIndexExpression(expression), indexExpression =>
     either.flatMap(keyPathFromObjectNode(indexExpression[1].query), keyPath => {
       const object = indexExpression[1].object
+      // The original (un-canonicalized) expression's argument object may use
+      // either named keys (`object`/`query`) or positional ones (`0`/`1`).
+      const argument = expression[1]
+      const objectKey =
+        (
+          argument !== undefined &&
+          isObjectNode(argument) &&
+          'object' in argument
+        ) ?
+          'object'
+        : '0'
       return either.flatMap(
-        checkKeyPathExistsInType(object, keyPath, context),
+        checkKeyPathExistsInType(object, keyPath, context, objectKey),
         _ =>
           containsAnyUnelaboratedNodes(object) ?
             // The object isn't ready, so keep the @index unelaborated.

--- a/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
@@ -18,14 +18,14 @@ export const lookupKeywordHandler: KeywordHandler = (
 ): Either<ElaborationError, SemanticGraph> =>
   either.flatMap(readLookupExpression(expression), ({ 1: { key } }) => {
     if (isObjectNode(context.program)) {
-      return either.flatMap(lookup({ context, key }), possibleValue =>
-        option.match(possibleValue, {
+      return either.flatMap(lookup({ context, key }), successfulLookup =>
+        option.match(successfulLookup, {
           none: () =>
             either.makeLeft({
               kind: 'invalidExpression',
               message: `property \`${stringifyKeyForEndUser(key)}\` not found`,
             }),
-          some: either.makeRight,
+          some: ({ foundValue }) => either.makeRight(foundValue),
         }),
       )
     } else {

--- a/src/language/runtime/keywords.ts
+++ b/src/language/runtime/keywords.ts
@@ -160,7 +160,7 @@ export const keywordHandlers: KeywordHandlers = {
   /**
    * Evaluates the given function, passing runtime context captured in `world`.
    */
-  '@runtime': expression =>
+  '@runtime': (expression, expressionContext) =>
     either.flatMap(
       readRuntimeExpression(expression),
       ({ 1: { function: runtimeFunction } }) => {
@@ -173,6 +173,7 @@ export const keywordHandlers: KeywordHandlers = {
         } else {
           const result = runtimeFunction(
             runtimeContext(runtimeFunction.parameterName),
+            expressionContext,
           )
           return either.mapLeft(result, error => ({
             // The runtime function panicked or had an unavailable dependency

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -89,7 +89,13 @@ export const lookup = ({
 }: {
   readonly context: ExpressionContext
   readonly key: Atom
-}): Either<ElaborationError, Option<SemanticGraph>> => {
+}): Either<
+  ElaborationError,
+  Option<{
+    readonly foundLocation: 'prelude' | KeyPath
+    readonly foundValue: SemanticGraph
+  }>
+> => {
   if (key === ignoredKey) {
     return either.makeLeft({
       kind: 'invalidExpression',
@@ -103,7 +109,12 @@ export const lookup = ({
           kind: 'invalidExpression',
           message: `property \`${stringifyKeyForEndUser(key)}\` not found`,
         })
-      : either.makeRight(option.makeSome(valueFromPrelude))
+      : either.makeRight(
+          option.makeSome({
+            foundLocation: 'prelude',
+            foundValue: valueFromPrelude,
+          }),
+        )
   } else {
     // Given the following program:
     // ```
@@ -137,6 +148,7 @@ export const lookup = ({
       | {
           readonly kind: 'found'
           readonly foundValue: SemanticGraph
+          readonly foundLocation: KeyPath
         }
       | {
           readonly kind: 'notFound'
@@ -166,6 +178,7 @@ export const lookup = ({
             return {
               kind: 'found',
               foundValue: makeLookupExpression(key),
+              foundLocation: [...pathToCurrentScope, key],
             }
           } else {
             return {
@@ -186,6 +199,7 @@ export const lookup = ({
               some: foundValue => ({
                 kind: 'found',
                 foundValue,
+                foundLocation: [...pathToCurrentScope, key],
               }),
               none: _ => ({
                 kind: 'notFound',
@@ -197,7 +211,12 @@ export const lookup = ({
     )
 
     if (result.kind === 'found') {
-      return either.makeRight(option.makeSome(result.foundValue))
+      return either.makeRight(
+        option.makeSome({
+          foundValue: result.foundValue,
+          foundLocation: result.foundLocation,
+        }),
+      )
     } else {
       // Try the parent scope.
       return lookup({

--- a/src/language/semantics/function-node.ts
+++ b/src/language/semantics/function-node.ts
@@ -9,6 +9,7 @@ import type {
   UnserializableValueError,
 } from '../errors.js'
 import type { Atom } from '../parsing.js'
+import type { ExpressionContext } from './expression-elaboration.js'
 import type { ObjectNode } from './object-node.js'
 import { nodeTag } from './semantic-graph-node-tag.js'
 import { serialize, type Output, type SemanticGraph } from './semantic-graph.js'
@@ -22,6 +23,7 @@ export type FunctionNodeCallError =
 
 export type FunctionNodeCallSignature = (
   value: SemanticGraph,
+  contextOfApplication: ExpressionContext,
 ) => Either<FunctionNodeCallError, SemanticGraph>
 
 export type FunctionNode = FunctionNodeCallSignature & {
@@ -42,12 +44,11 @@ export const makeFunctionNode = <Signature extends FunctionType['signature']>(
   signature: Signature,
   serialize: FunctionNode['serialize'],
   parameterName: Option<Atom>,
-  f: (value: SemanticGraph) => Either<FunctionNodeCallError, SemanticGraph>,
+  f: FunctionNodeCallSignature,
 ): FunctionNodeWithSignature<Signature> => {
-  const node: ((
-    value: SemanticGraph,
-  ) => Either<FunctionNodeCallError, SemanticGraph>) &
-    Writable<FunctionNodeWithSignature<Signature>> = value => f(value)
+  const node: FunctionNodeCallSignature &
+    Writable<FunctionNodeWithSignature<Signature>> = (argument, context) =>
+    f(argument, context)
   node[nodeTag] = 'function'
   node.parameterName = parameterName
   node.signature = signature

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -21,6 +21,7 @@ import {
 } from '../type-system/type-formats.js'
 import { literalTypeFromSemanticGraph } from '../type-system/type-utilities.js'
 import {
+  emptyContextForStdlibApplications,
   preludeFunctionArity1,
   preludeFunctionArity2,
   preludeFunctionArity3,
@@ -66,7 +67,7 @@ export const globalFunctions = {
             message: '`apply` expected a function',
           })
         } else {
-          return functionToApply(argument)
+          return functionToApply(argument, emptyContextForStdlibApplications)
         }
       }),
   ),
@@ -139,8 +140,15 @@ export const globalFunctions = {
               message: '`flow` expected a function',
             })
           } else {
-            return either.makeRight(argument =>
-              either.flatMap(firstFunction(argument), secondFunction),
+            return either.makeRight(firstArgument =>
+              either.flatMap(
+                firstFunction(firstArgument, emptyContextForStdlibApplications),
+                secondArgument =>
+                  secondFunction(
+                    secondArgument,
+                    emptyContextForStdlibApplications,
+                  ),
+              ),
             )
           }
         })
@@ -190,7 +198,10 @@ export const globalFunctions = {
             } else {
               return !isFunctionNode(relevantCase.value) ?
                   either.makeRight(relevantCase.value)
-                : relevantCase.value(argument.value)
+                : relevantCase.value(
+                    argument.value,
+                    emptyContextForStdlibApplications,
+                  )
             }
           }
         })

--- a/src/language/semantics/stdlib/option.ts
+++ b/src/language/semantics/stdlib/option.ts
@@ -13,6 +13,7 @@ import {
   makeTypeParameter,
 } from '../type-system/type-formats.js'
 import {
+  emptyContextForStdlibApplications,
   preludeFunctionArity1,
   preludeFunctionArity2,
 } from './stdlib-utilities.js'
@@ -90,11 +91,13 @@ export const option = {
           } else if (optionValue.tag === 'none') {
             return either.makeRight(optionValue)
           } else {
-            return either.map(transform(optionValue.value), transformedValue =>
-              objectNodeFromOrderedEntries([
-                ['tag', 'some'],
-                ['value', transformedValue],
-              ]),
+            return either.map(
+              transform(optionValue.value, emptyContextForStdlibApplications),
+              transformedValue =>
+                objectNodeFromOrderedEntries([
+                  ['tag', 'some'],
+                  ['value', transformedValue],
+                ]),
             )
           }
         })
@@ -132,7 +135,7 @@ export const option = {
             return either.makeRight(optionValue)
           } else {
             return either.flatMap(
-              transform(optionValue.value),
+              transform(optionValue.value, emptyContextForStdlibApplications),
               transformedValue => {
                 if (!nodeIsOptionLike(transformedValue)) {
                   return either.makeLeft({

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -3,6 +3,8 @@ import option from '@matt.kantor/option'
 import {
   keyPathToLookupExpression,
   makeApplyExpression,
+  objectNodeFromOrderedEntries,
+  type ExpressionContext,
 } from '../../semantics.js'
 import {
   makeFunctionNode,
@@ -30,9 +32,32 @@ const handleUnavailableDependencies =
         message: 'one or more dependencies are unavailable',
       })
     } else {
-      return f(argument)
+      return f(argument, emptyContextForStdlibApplications)
     }
   }
+
+/**
+ * Use with calls of user-defined functions from the standard library (which
+ * conceptually occur from "outside your program" and therefore do not have a
+ * meaningful `ExpressionContext`).
+ */
+export const emptyContextForStdlibApplications: ExpressionContext = {
+  keywordHandlers: {
+    '@apply': either.makeRight,
+    '@check': either.makeRight,
+    '@function': either.makeRight,
+    '@hole': either.makeRight,
+    '@if': either.makeRight,
+    '@index': either.makeRight,
+    '@lookup': either.makeRight,
+    '@panic': either.makeRight,
+    '@runtime': either.makeRight,
+    '@todo': either.makeRight,
+    '@union': either.makeRight,
+  },
+  location: [],
+  program: objectNodeFromOrderedEntries([]),
+}
 
 export const serializeOnceAppliedFunction =
   (keyPath: NonEmptyKeyPath, argument: SemanticGraph) => () =>

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -425,7 +425,14 @@ const getFunctionParameterType = (
             }
             const contextuallyAppliedFunctionType = inferType(
               applyExpressionResult.value[1].function,
-              contextOfEnclosingExpression,
+              {
+                ...contextOfEnclosingExpression,
+                location: [
+                  ...contextOfEnclosingExpression.location,
+                  '1',
+                  'function',
+                ],
+              },
             )
 
             // If the applied function's signature is `(a ~> b) ~> c`, the

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -174,14 +174,15 @@ const inferTypeImplementation = (
     } else if (!lookingUpKeys.has(key)) {
       const lookupResult = lookup({ key, context })
       if (either.isRight(lookupResult) && option.isSome(lookupResult.value)) {
+        const { foundValue, foundLocation } = lookupResult.value.value
         return inferTypeImplementation(
-          lookupResult.value.value,
+          foundValue,
           parameterTypes,
           new Set([...lookingUpKeys, key]),
-          // TODO: Possibly adjust `context.location` to point at the looked-up
-          // value? To do so, `lookup` would need to return a `KeyPath` along
-          // with the resolved value.
-          context,
+          {
+            ...context,
+            location: foundLocation === 'prelude' ? [] : foundLocation,
+          },
         )
       } else {
         // Fall back to the top type.

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -391,16 +391,24 @@ const getFunctionParameterType = (
 ): Either<ElaborationError, Type> =>
   option.match(getParameterTypeAnnotation(expression), {
     some: annotation =>
-      either.map(inferType(annotation, contextOfFunction), annotationType => {
-        const parameterName = getParameterName(expression)
-        // `_` (`ignoredKey`) is the name for an ignored parameter (and is what
-        // the parser emits for `~>` syntax sugar). Genericization is skipped
-        // in this case so `a ~> b` and `(_: a) => b` can be used to describe
-        // concrete function types rather than generic ones.
-        return parameterName === ignoredKey ? annotationType : (
-            genericizeFunctionParameterAnnotation(parameterName, annotationType)
-          )
-      }),
+      either.map(
+        // Type annotation lookups happen from the function's scope rather than
+        // their own location (a property within the `@function`).
+        inferType(annotation, contextOfFunction),
+        annotationType => {
+          const parameterName = getParameterName(expression)
+          // `_` (`ignoredKey`) is the name for an ignored parameter (and is what
+          // the parser emits for `~>` syntax sugar). Genericization is skipped
+          // in this case so `a ~> b` and `(_: a) => b` can be used to describe
+          // concrete function types rather than generic ones.
+          return parameterName === ignoredKey ? annotationType : (
+              genericizeFunctionParameterAnnotation(
+                parameterName,
+                annotationType,
+              )
+            )
+        },
+      ),
     none: _ => {
       const contextualType = option.flatMap(
         enclosingExpressionFromPropertyOfExpressionArgument(contextOfFunction),


### PR DESCRIPTION
This is easy to mess up and I have no doubt I've missed some/there will be more mistakes in the future. Longer-term I should perhaps have every node keep track of its own location.

In the meantime this seems good enough to unblock what I really want to work on: a cache for type inferences (which will be keyed by node locations, hence requiring these fixes).

The diff is easier to review if you ignore whitespace.