### PR TITLE
Allow dynamic index keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ You can index into the properties of looked-up values:
 }
 ```
 
+Index keys may be computed dynamically[^2]:
+
+```plz
+{
+  a: { 2: "Hello, World!" }
+  :a.(1 + 1) // "Hello, World!"
+}
+```
+
 Lookups are lexically scoped:
 
 ```plz
@@ -453,3 +462,6 @@ it approaches them over time.
     Every Please program is an
     [arborescence](<https://en.wikipedia.org/wiki/Arborescence_(graph_theory)>)
     with edges labeled by property keys.
+
+[^2]:
+    Dynamic keys are checked. `{ 2: "Hello, World!" }.(1 + 41)` is a type error.

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -112,6 +112,15 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
       '0 (not greater than one) 1 (not greater than one) 2 (greater than one) ',
     ),
   ],
+  [
+    // TODO: Move to the regular end-to-end suite once there's unparser support.
+    `{
+      key1: b
+      get_key2: _ => false
+      {a:{b:{1:{2:{true:{false:{🎉:"it works"}}}}}}}.a.:key1.(1).(1 + 1).(:boolean.not(false)).(:get_key2(_)).(@runtime { _ => 🎉 })
+    }.0`,
+    success('it works'),
+  ],
 ])
 
 testCases(endToEnd, code => code)('end-to-end tests', [

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -112,15 +112,6 @@ testCases(parseAndCompileAndRun, code => code)('runtime-derived values', [
       '0 (not greater than one) 1 (not greater than one) 2 (greater than one) ',
     ),
   ],
-  [
-    // TODO: Move to the regular end-to-end suite once there's unparser support.
-    `{
-      key1: b
-      get_key2: _ => false
-      {a:{b:{1:{2:{true:{false:{🎉:"it works"}}}}}}}.a.:key1.(1).(1 + 1).(:boolean.not(false)).(:get_key2(_)).(@runtime { _ => 🎉 })
-    }.0`,
-    success('it works'),
-  ],
 ])
 
 testCases(endToEnd, code => code)('end-to-end tests', [
@@ -885,4 +876,12 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   // `_` can still be used as part of an `@index` query:
   [`{ _: a }._`, success('a')],
+  [
+    `{
+      key1: b
+      get_key2: _ => false
+      {a:{b:{1:{2:{true:{false:{🎉:"it works"}}}}}}}.a.:key1.(1).(1 + 1).(:boolean.not(false)).(:get_key2(_)).(@runtime { _ => 🎉 })
+    }.0`,
+    success('it works'),
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1089,4 +1089,27 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{ obj: { a: 1, b: 2 }, get: (key: a | b) => :obj.:key ~ (1 | 2) }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ obj: { a: 1, b: 2 }, get: (key: a | b) => :obj.(:key) ~ 1 }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ x: { a: 1 }, y: :x.({}) }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -2,24 +2,26 @@ import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
-  applyKeyPathToSemanticGraph,
   applyKeyPathToType,
   containsAnyUnelaboratedNodes,
   inferType,
-  keyPathFromObjectNode,
   readIndexExpression,
   showType,
-  stringifyKeyPathForEndUser,
   type Expression,
   type ExpressionContext,
-  type KeyPath,
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
+import { applyTypeKeyPathToSemanticGraph } from '../../../semantics/semantic-graph.js'
+import {
+  stringifyTypeKeyPathForEndUser,
+  typeKeyPathFromObjectNode,
+  type TypeKeyPath,
+} from '../../../semantics/type-system.js'
 
 const checkKeyPathExistsInType = (
   object: SemanticGraph,
-  keyPath: KeyPath,
+  keyPath: TypeKeyPath,
   context: ExpressionContext,
 ): Either<ElaborationError, undefined> =>
   either.flatMap(
@@ -34,7 +36,7 @@ const checkKeyPathExistsInType = (
         ) ?
           either.makeLeft({
             kind: 'typeMismatch',
-            message: `property \`${stringifyKeyPathForEndUser(
+            message: `property \`${stringifyTypeKeyPathForEndUser(
               keyPath,
             )}\` does not exist on type \`${showType(objectType)}\``,
           })
@@ -50,21 +52,36 @@ export const indexKeywordHandler: KeywordHandler = (
     const {
       1: { object, query },
     } = indexExpression
-    return either.flatMap(keyPathFromObjectNode(query), keyPath =>
-      either.flatMap(checkKeyPathExistsInType(object, keyPath, context), _ =>
-        containsAnyUnelaboratedNodes(object) ?
-          // The object isn't ready, so keep the @index unelaborated.
-          either.makeRight(indexExpression)
-        : option.match(applyKeyPathToSemanticGraph(object, keyPath), {
-            none: () =>
-              either.makeLeft({
-                kind: 'typeMismatch',
-                message: `property \`${stringifyKeyPathForEndUser(
-                  keyPath,
-                )}\` not found`,
-              }),
-            some: either.makeRight,
-          }),
+    return either.flatMap(
+      typeKeyPathFromObjectNode(
+        query,
+        { ...context, location: [...context.location, '1', 'query'] },
+        inferType,
       ),
+      typeKeyPath => {
+        return either.flatMap(
+          checkKeyPathExistsInType(object, typeKeyPath, context),
+          _ =>
+            (
+              containsAnyUnelaboratedNodes(object) ||
+              containsAnyUnelaboratedNodes(query)
+            ) ?
+              // The object isn't ready, so keep the @index unelaborated.
+              either.makeRight(indexExpression)
+            : option.match(
+                applyTypeKeyPathToSemanticGraph(object, typeKeyPath),
+                {
+                  none: () =>
+                    either.makeLeft({
+                      kind: 'typeMismatch',
+                      message: `property \`${stringifyTypeKeyPathForEndUser(
+                        typeKeyPath,
+                      )}\` not found`,
+                    }),
+                  some: either.makeRight,
+                },
+              ),
+        )
+      },
     )
   })

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -664,5 +664,62 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
           '{\n  "f": {\n    "0": "@function",\n    "1": {\n      "parameter": {\n        "x": {\n          "0": "@hole",\n          "1": {\n            "name": "b",\n            "constraint": {\n              "assignableTo": {\n                "0": "@index",\n                "1": {\n                  "object": {\n                    "0": "@lookup",\n                    "1": {\n                      "key": "atom"\n                    }\n                  },\n                  "query": {\n                    "0": "type"\n                  }\n                }\n              }\n            }\n          }\n        }\n      },\n      "body": {\n        "0": "@lookup",\n        "1": {\n          "0": "x"\n        }\n      }\n    }\n  }\n}\n',
       },
     ],
+
+    [
+      {
+        key: 'a',
+        x: { a: 'found' },
+        test: {
+          0: '@index',
+          1: {
+            object: { 0: '@lookup', 1: { key: 'x' } },
+            query: { 0: { 0: '@lookup', 1: { key: 'key' } } },
+          },
+        },
+      },
+      {
+        inlinePlz: '{ key: a, x: { a: found }, test: :x.:key }',
+        sugarFreeInlinePlz:
+          '{ key: a, x: { a: found }, test: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: x } }, query: { 0: { 0: "@lookup", 1: { key: key } } } } } }',
+        prettyPlz:
+          '{\n  key: a\n  x: {\n    a: found\n  }\n  test: :x.:key\n}\n',
+        sugarFreePrettyPlz:
+          '{\n  key: a\n  x: {\n    a: found\n  }\n  test: {\n    0: "@index"\n    1: {\n      object: {\n        0: "@lookup"\n        1: {\n          key: x\n        }\n      }\n      query: {\n        0: {\n          0: "@lookup"\n          1: {\n            key: key\n          }\n        }\n      }\n    }\n  }\n}\n',
+        prettyJson:
+          '{\n  "key": "a",\n  "x": {\n    "a": "found"\n  },\n  "test": {\n    "0": "@index",\n    "1": {\n      "object": {\n        "0": "@lookup",\n        "1": {\n          "key": "x"\n        }\n      },\n      "query": {\n        "0": {\n          "0": "@lookup",\n          "1": {\n            "key": "key"\n          }\n        }\n      }\n    }\n  }\n}\n',
+      },
+    ],
+
+    [
+      {
+        x: { a: 'found' },
+        test: {
+          0: '@index',
+          1: {
+            object: { 0: '@lookup', 1: { key: 'x' } },
+            query: {
+              0: {
+                0: '@apply',
+                1: {
+                  function: { 0: '@lookup', 1: { key: 'identity' } },
+                  argument: 'a',
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        inlinePlz: '{ x: { a: found }, test: :x.(:identity(a)) }',
+        sugarFreeInlinePlz:
+          '{ x: { a: found }, test: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: x } }, query: { 0: { 0: "@apply", 1: { function: { 0: "@lookup", 1: { key: identity } }, argument: a } } } } } }',
+        prettyPlz:
+          '{\n  x: {\n    a: found\n  }\n  test: :x.(:identity(a))\n}\n',
+        sugarFreePrettyPlz:
+          '{\n  x: {\n    a: found\n  }\n  test: {\n    0: "@index"\n    1: {\n      object: {\n        0: "@lookup"\n        1: {\n          key: x\n        }\n      }\n      query: {\n        0: {\n          0: "@apply"\n          1: {\n            function: {\n              0: "@lookup"\n              1: {\n                key: identity\n              }\n            }\n            argument: a\n          }\n        }\n      }\n    }\n  }\n}\n',
+        prettyJson:
+          '{\n  "x": {\n    "a": "found"\n  },\n  "test": {\n    "0": "@index",\n    "1": {\n      "object": {\n        "0": "@lookup",\n        "1": {\n          "key": "x"\n        }\n      },\n      "query": {\n        "0": {\n          "0": "@apply",\n          "1": {\n            "function": {\n              "0": "@lookup",\n              "1": {\n                "key": "identity"\n              }\n            },\n            "argument": "a"\n          }\n        }\n      }\n    }\n  }\n}\n',
+      },
+    ],
   ],
 )

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -11,7 +11,7 @@ import {
 } from '@matt.kantor/parsing'
 import * as orderedRecord from '../../ordered-record.js'
 import { type OrderedRecord } from '../../ordered-record.js'
-import { arrayToMolecule, ignoredKey, type KeyPath } from '../semantics.js'
+import { arrayToMolecule, ignoredKey } from '../semantics.js'
 import {
   atom,
   atomWithAdditionalQuotationRequirements,
@@ -250,13 +250,33 @@ const propertyDelimiter = oneOf([
 
 const argument = surroundedByParentheses(lazy(() => expression))
 
+const dottedKeyPathKey = oneOf([
+  // (a)
+  // (1 + 1)
+  // (:a.b.c)
+  // (:f(x)(y))
+  surroundedByParentheses(lazy(() => expression)),
+
+  // :a
+  map(sequence([colon, atomRequiringDotQuotation]), ([_colon, key]) =>
+    molecule([
+      ['0', '@lookup'],
+      ['1', molecule([['key', key]])],
+    ]),
+  ),
+
+  // 1
+  // "a.b"
+  atomRequiringDotQuotation,
+])
+
 const compactDottedKeyPathComponent = map(
-  sequence([dot, atomRequiringDotQuotation]),
+  sequence([dot, dottedKeyPathKey]),
   ([_dot, key]) => key,
 )
 
 const dottedKeyPathComponent = map(
-  sequence([optionalTrivia, dot, optionalTrivia, atomRequiringDotQuotation]),
+  sequence([optionalTrivia, dot, optionalTrivia, dottedKeyPathKey]),
   ([_trivia1, _dot, _trivia2, key]) => key,
 )
 
@@ -308,7 +328,7 @@ type TrailingIndexOrArgument =
     }
   | {
       readonly kind: 'index'
-      readonly query: KeyPath
+      readonly query: readonly (Molecule | Atom)[]
     }
 
 const dottedKeyPath = oneOrMore(dottedKeyPathComponent)

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -11,7 +11,7 @@ import {
 } from '@matt.kantor/parsing'
 import * as orderedRecord from '../../ordered-record.js'
 import { type OrderedRecord } from '../../ordered-record.js'
-import { ignoredKey, keyPathToMolecule, type KeyPath } from '../semantics.js'
+import { arrayToMolecule, ignoredKey, type KeyPath } from '../semantics.js'
 import {
   atom,
   atomWithAdditionalQuotationRequirements,
@@ -86,7 +86,7 @@ const trailingIndexesAndArgumentsToExpression = (
             '1',
             molecule([
               ['object', expression],
-              ['query', keyPathToMolecule(indexOrArgument.query)],
+              ['query', arrayToMolecule(indexOrArgument.query)],
             ]),
           ],
         ])

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -73,8 +73,8 @@ export {
 } from './semantics/function-node.js'
 export { isSemanticGraph } from './semantics/is-semantic-graph.js'
 export {
+  arrayToMolecule,
   keyPathFromObjectNode,
-  keyPathToMolecule,
   stringifyKeyPathForEndUser,
   type KeyPath,
 } from './semantics/key-path.js'

--- a/src/language/semantics/expressions/index-expression.ts
+++ b/src/language/semantics/expressions/index-expression.ts
@@ -1,7 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../errors.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
-import { keyPathFromObjectNode } from '../key-path.js'
 import {
   isObjectNode,
   makeObjectNode,
@@ -24,18 +23,13 @@ export const readIndexExpression = (
   isKeywordExpressionWithArgument('@index', node) ?
     either.flatMap(
       readArgumentsFromExpression(node, ['object', 'query']),
-      ([object, query]) => {
-        if (!isObjectNode(query)) {
-          return either.makeLeft({
+      ([object, query]) =>
+        !isObjectNode(query) ?
+          either.makeLeft({
             kind: 'invalidExpression',
             message: 'query must be an object',
           })
-        } else {
-          return either.map(keyPathFromObjectNode(query), _validKeyPath =>
-            makeIndexExpression({ object, query }),
-          )
-        }
-      },
+        : either.makeRight(makeIndexExpression({ object, query })),
     )
   : either.makeLeft({
       kind: 'invalidExpression',

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -5,7 +5,7 @@ import type { Atom } from '../../parsing.js'
 import type { ExpressionContext } from '../expression-elaboration.js'
 import { isExpression, isKeywordExpressionWithArgument } from '../expression.js'
 import {
-  keyPathToMolecule,
+  arrayToMolecule,
   type KeyPath,
   type NonEmptyKeyPath,
 } from '../key-path.js'
@@ -75,7 +75,7 @@ export const keyPathToLookupExpression = (keyPath: NonEmptyKeyPath) => {
   } else {
     return makeIndexExpression({
       object: initialLookup,
-      query: objectNodeFromMolecule(keyPathToMolecule(indexes)),
+      query: objectNodeFromMolecule(arrayToMolecule(indexes)),
     })
   }
 }

--- a/src/language/semantics/key-path.ts
+++ b/src/language/semantics/key-path.ts
@@ -9,12 +9,14 @@ export type KeyPath = readonly Atom[]
 export type NonEmptyKeyPath = readonly [Atom, ...KeyPath]
 
 export const stringifyKeyPathForEndUser = (keyPath: KeyPath): string =>
-  either.match(unparse(keyPathToMolecule(keyPath), inlinePlz), {
+  either.match(unparse(arrayToMolecule(keyPath), inlinePlz), {
     right: stringifiedOutput => stringifiedOutput,
     left: error => `(unserializable key path: ${error.message})`,
   })
 
-export const keyPathToMolecule = (keyPath: KeyPath): Molecule =>
+export const arrayToMolecule = (
+  keyPath: readonly (Molecule | Atom)[],
+): Molecule =>
   orderedRecord.make(keyPath.map((key, index) => [String(index), key]))
 
 export const keyPathFromObjectNode = (

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -5,13 +5,14 @@ import type {
   InvalidExpressionError,
   UnserializableValueError,
 } from '../errors.js'
-import type { Atom, Molecule } from '../parsing.js'
+import type { Atom, Molecule, SyntaxTree } from '../parsing.js'
 import {
   ignoredKey,
   makeFunctionExpression,
   makeIndexExpression,
   makeLookupExpression,
   makeUnionExpression,
+  readFunctionExpression,
   types,
   type Type,
 } from '../semantics.js'
@@ -31,6 +32,12 @@ import {
   type ObjectNode,
 } from './object-node.js'
 import { nodeTag } from './semantic-graph-node-tag.js'
+import {
+  functionParameterKey,
+  functionReturnKey,
+  typeParameterAssignableToConstraintKey,
+  type TypeKeyPath,
+} from './type-system.js'
 import {
   atomTypeSymbol,
   integerTypeSymbol,
@@ -68,6 +75,92 @@ export const applyKeyPathToSemanticGraph = (
             isSemanticGraph(next) ? next : syntaxTreeToSemanticGraph(next),
             remainingKeyPath,
           )
+        }
+      },
+    })
+  }
+}
+
+export const applyTypeKeyPathToSemanticGraph = (
+  node: SemanticGraph,
+  keyPath: TypeKeyPath,
+): Option<SemanticGraph> => {
+  const [firstKey, ...remainingKeyPath] = keyPath
+  if (firstKey === undefined) {
+    // If the key path is empty, this is the type we're looking for.
+    return option.makeSome(node)
+  } else if (typeof firstKey === 'object') {
+    return option.map(
+      option.sequence(
+        [...firstKey.members].map(firstKeyMember =>
+          applyTypeKeyPathToSemanticGraph(node, [
+            firstKeyMember,
+            ...remainingKeyPath,
+          ]),
+        ),
+      ),
+      foundNodes =>
+        makeUnionExpression(
+          objectNodeFromOrderedEntries(
+            foundNodes.map((node, index) => [String(index), node]),
+          ),
+        ),
+    )
+  } else {
+    return matchSemanticGraph(node, {
+      // If it's an `Atom` or `TypeSymbol` but we have a non-empty path, we
+      // whiffed.
+      atom: _ => option.none,
+      typeSymbol: _ => option.none,
+
+      function: node => {
+        if (
+          firstKey === functionParameterKey ||
+          firstKey === functionReturnKey
+        ) {
+          return either.match(
+            either.flatMap(node.serialize(), readFunctionExpression),
+            {
+              left: _ => option.none,
+              right: serializedFunction => {
+                // TODO: Determine whether this is useful, expunge if not.
+                switch (firstKey) {
+                  case functionParameterKey:
+                    return option.makeSome(serializedFunction[1].parameter)
+                  case functionReturnKey:
+                    return option.makeSome(serializedFunction[1].body)
+                }
+              },
+            },
+          )
+        } else {
+          return option.none
+        }
+      },
+
+      object: node => {
+        if (typeof firstKey === 'string') {
+          // Exhaustiveness checks:
+          firstKey satisfies string
+          node satisfies ObjectNode
+
+          const next = node[firstKey]
+          if (next === undefined) {
+            return option.none
+          } else {
+            return applyTypeKeyPathToSemanticGraph(
+              isSemanticGraph(next) ? next : syntaxTreeToSemanticGraph(next),
+              remainingKeyPath,
+            )
+          }
+        } else {
+          switch (firstKey) {
+            // None of the following can be applied to object nodes:
+            case functionParameterKey:
+            case functionReturnKey:
+            case typeParameterAssignableToConstraintKey:
+              return option.none
+          }
         }
       },
     })
@@ -184,16 +277,24 @@ export const serialize = (
     withPhantomData<Serialized>(),
   )
 
+export const stringifySyntaxTreeForEndUser = (
+  tree: SyntaxTree,
+  notation: Notation = inlinePlz,
+): string =>
+  either.unwrapOrElse(
+    unparse(tree, notation),
+    error => `(unserializable value: ${error.message})`,
+  )
+
 export const stringifySemanticGraphForEndUser = (
   graph: SemanticGraph,
   notation: Notation = inlinePlz,
 ): string =>
-  either.match(
-    either.flatMap(serialize(graph), output => unparse(output, notation)),
-    {
-      right: stringifiedOutput => stringifiedOutput,
-      left: error => `(unserializable value: ${error.message})`,
-    },
+  either.unwrapOrElse(
+    either.map(serialize(graph), syntaxTree =>
+      stringifySyntaxTreeForEndUser(syntaxTree, notation),
+    ),
+    error => `(unserializable value: ${error.message})`,
   )
 
 export const typeToSemanticGraph = (

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -8,9 +8,15 @@ export {
 export {
   applyKeyPathToType,
   containedTypeParameters,
+  functionParameterKey,
+  functionReturnKey,
   getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
   replaceAllTypeParametersWithTheirConstraints,
+  stringifyTypeKeyPathForEndUser,
   supplyTypeArgument,
   supplyTypeArguments,
+  typeKeyPathFromObjectNode,
+  typeParameterAssignableToConstraintKey,
+  type TypeKeyPath,
 } from './type-system/type-utilities.js'

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -11,7 +11,6 @@ import {
   isExpression,
   isFunctionNode,
   isObjectNode,
-  keyPathFromObjectNode,
   lookup,
   readApplyExpression,
   readFunctionExpression,
@@ -43,6 +42,7 @@ import {
   literalTypeFromSemanticGraph,
   stringifyTypeKeyPathForEndUser,
   supplyTypeArguments,
+  typeKeyPathFromObjectNode,
 } from './type-utilities.js'
 
 /**
@@ -236,7 +236,17 @@ const inferTypeImplementation = (
         ),
         objectType =>
           either.map(
-            keyPathFromObjectNode(indexExpressionResult.value[1].query),
+            typeKeyPathFromObjectNode(
+              indexExpressionResult.value[1].query,
+              descendantContext(['1', 'query']),
+              (node, context) =>
+                inferTypeImplementation(
+                  node,
+                  parameterTypes,
+                  lookingUpKeys,
+                  context,
+                ),
+            ),
             keyPath => applyKeyPathToType(objectType, keyPath),
           ),
       ),

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -41,7 +41,7 @@ import {
   genericizeFunctionParameterAnnotation,
   getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
-  stringifyKeyPath,
+  stringifyTypeKeyPathForEndUser,
   supplyTypeArguments,
 } from './type-utilities.js'
 
@@ -118,7 +118,7 @@ const inferTypeImplementation = (
   lookingUpKeys: ReadonlySet<Atom>,
   context: ExpressionContext,
 ): Either<ElaborationError, Type> => {
-  const cacheKey = stringifyKeyPath(context.location)
+  const cacheKey = stringifyTypeKeyPathForEndUser(context.location)
   const cached = context.mutableInferenceCache.get(cacheKey)
   if (cached !== undefined) {
     return either.makeRight(cached)

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -2,6 +2,7 @@ import either, { type Either } from '@matt.kantor/either'
 import type { Writable } from '../../../utility-types.js'
 import type { Bug } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
+import { quoteAtomIfNecessary } from '../../unparsing/plz-utilities.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
 import {
   getHoleTypeParameter,
@@ -236,23 +237,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
 const synthesizeTypeParameterName = (
   parameterName: Atom,
   keyPath: TypeKeyPath,
-): string =>
-  keyPath.reduce<string>((name, key) => {
-    // TODO: Consider surfacing this in plz syntax (allowing programmatic access
-    // of un-elaborated function parameters/returns and type parameter
-    // constraints).
-    if (key === functionParameter) {
-      return `${name}.#parameter`
-    } else if (key === functionReturn) {
-      return `${name}.#return`
-    } else if (key === typeParameterAssignableToConstraint) {
-      return `${name}.#constraint`
-    } else if (typeof key === 'object') {
-      return `${name}.#${[...key.members].join('|')}`
-    } else {
-      return `${name}.${key}`
-    }
-  }, parameterName)
+): string => parameterName.concat(stringifyTypeKeyPathForEndUser(keyPath))
 
 export const containedTypeParameters = (type: Type): TypeParametersByKeyPath =>
   containedTypeParametersImplementation(type, [])
@@ -292,7 +277,7 @@ const containedTypeParametersImplementation = (
           ]),
           new Map([
             [
-              stringifyKeyPath(root),
+              stringifyTypeKeyPathForEndUser(root),
               {
                 keyPath: root,
                 typeParameters: makeUnionType('', [type]),
@@ -826,16 +811,41 @@ const mergeTypeParametersByKeyPath = (
   return result
 }
 
-// The string format is not meant for human consumption. The only guarantee is
-// that every distinct key path produces a unique string.
-export const stringifyKeyPath = (keyPath: TypeKeyPath): string =>
-  keyPath.reduce((stringifiedKeyPath: string, key) => {
-    const stringifiedKey =
-      typeof key === 'symbol' ? key.description : JSON.stringify(key)
-    if (stringifiedKey === undefined) {
-      throw new Error(
-        'Symbol in key path does not have a description. This is a bug!',
-      )
+export const stringifyTypeKeyPathForEndUser = (keyPath: TypeKeyPath): string =>
+  // TODO: Would be nice to use unparser machinery here.
+  keyPath.reduce(
+    (stringifiedTypeKeyPath: string, key) =>
+      stringifiedTypeKeyPath.concat(
+        '.',
+        stringifyKeyPathComponentForEndUser(key),
+      ),
+    '',
+  )
+
+const stringifyKeyPathComponentForEndUser = (
+  component: TypeKeyPath[number],
+): string => {
+  if (typeof component === 'string') {
+    return quoteAtomIfNecessary(component)
+  } else if (typeof component === 'object') {
+    return '('.concat(
+      [...component.members]
+        .sort()
+        .map(stringifyKeyPathComponentForEndUser)
+        .join(' | '),
+      ')',
+    )
+  } else {
+    switch (component) {
+      // TODO: Consider surfacing this in plz syntax (allowing programmatic
+      // access of un-elaborated function parameters/returns and type parameter
+      // constraints).
+      case functionParameter:
+        return '#parameter'
+      case functionReturn:
+        return '#return'
+      case typeParameterAssignableToConstraint:
+        return '#constraint'
     }
-    return `${stringifiedKeyPath}.${stringifiedKey}`
-  }, '')
+  }
+}

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -24,9 +24,9 @@ import {
   type UnionType,
 } from './type-formats.js'
 
-const functionParameter = Symbol('functionParameter')
-const functionReturn = Symbol('functionReturn')
-const typeParameterAssignableToConstraint = Symbol(
+const functionParameterKey = Symbol('functionParameter')
+const functionReturnKey = Symbol('functionReturn')
+const typeParameterAssignableToConstraintKey = Symbol(
   'typeParameterAssignableToConstraint',
 )
 
@@ -38,9 +38,9 @@ type AtomKeyPathElement =
 
 export type TypeKeyPath = readonly (
   | AtomKeyPathElement
-  | typeof functionParameter
-  | typeof functionReturn
-  | typeof typeParameterAssignableToConstraint
+  | typeof functionParameterKey
+  | typeof functionReturnKey
+  | typeof typeParameterAssignableToConstraintKey
 )[]
 
 type StringifiedKeyPath = string // this could be branded if that seems useful
@@ -89,7 +89,7 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
           return types.nothing
         } else {
           switch (firstKey) {
-            case functionParameter:
+            case functionParameterKey:
               return makeFunctionType(type.name, {
                 parameter: applyKeyPathToType(
                   type.signature.parameter,
@@ -97,7 +97,7 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
                 ),
                 return: type.signature.return,
               })
-            case functionReturn:
+            case functionReturnKey:
               return makeFunctionType(type.name, {
                 parameter: type.signature.parameter,
                 return: applyKeyPathToType(
@@ -105,7 +105,7 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
                   remainingKeyPath,
                 ),
               })
-            case typeParameterAssignableToConstraint:
+            case typeParameterAssignableToConstraintKey:
               // Functions aren't type parameters.
               return types.nothing
           }
@@ -132,15 +132,15 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
           return types.nothing
         } else {
           switch (firstKey) {
-            case typeParameterAssignableToConstraint:
+            case typeParameterAssignableToConstraintKey:
               return makeTypeParameter(type.name, {
                 assignableTo: applyKeyPathToType(
                   type.constraint.assignableTo,
                   remainingKeyPath,
                 ),
               })
-            case functionParameter:
-            case functionReturn:
+            case functionParameterKey:
+            case functionReturnKey:
               // Type parameters aren't function types.
               // TODO: Though perhaps I should drill into the constraint here?
               return types.nothing
@@ -198,12 +198,12 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
         parameter: genericizeFunctionParameterAnnotationAtKeyPath(
           parameterName,
           type.signature.parameter,
-          [...keyPath, functionParameter],
+          [...keyPath, functionParameterKey],
         ),
         return: genericizeFunctionParameterAnnotationAtKeyPath(
           parameterName,
           type.signature.return,
-          [...keyPath, functionReturn],
+          [...keyPath, functionReturnKey],
         ),
       }),
     object: type =>
@@ -255,11 +255,11 @@ const containedTypeParametersImplementation = (
         mergeTypeParametersByKeyPath(
           containedTypeParametersImplementation(signature.parameter, [
             ...root,
-            functionParameter,
+            functionParameterKey,
           ]),
           containedTypeParametersImplementation(signature.return, [
             ...root,
-            functionReturn,
+            functionReturnKey,
           ]),
         ),
       object: type =>
@@ -273,7 +273,7 @@ const containedTypeParametersImplementation = (
         mergeTypeParametersByKeyPath(
           containedTypeParametersImplementation(type.constraint.assignableTo, [
             ...root,
-            typeParameterAssignableToConstraint,
+            typeParameterAssignableToConstraintKey,
           ]),
           new Map([
             [
@@ -318,12 +318,12 @@ const findKeyPathsToTypeParameterImplementation = (
           ...findKeyPathsToTypeParameterImplementation(
             signature.parameter,
             typeParameterToFind,
-            [...root, functionParameter],
+            [...root, functionParameterKey],
           ),
           ...findKeyPathsToTypeParameterImplementation(
             signature.return,
             typeParameterToFind,
-            [...root, functionReturn],
+            [...root, functionReturnKey],
           ),
         ]),
       object: type =>
@@ -345,7 +345,7 @@ const findKeyPathsToTypeParameterImplementation = (
           ...findKeyPathsToTypeParameterImplementation(
             type.constraint.assignableTo,
             typeParameterToFind,
-            [...root, typeParameterAssignableToConstraint],
+            [...root, typeParameterAssignableToConstraintKey],
           ),
           ...(type.identity === typeParameterToFind.identity ? [root] : []),
         ]),
@@ -612,7 +612,7 @@ export const updateTypeAtKeyPathIfValid = (
     return matchTypeFormat(type, {
       function: type => {
         switch (firstKey) {
-          case functionParameter:
+          case functionParameterKey:
             return makeFunctionType(type.name, {
               parameter: updateTypeAtKeyPathIfValid(
                 type.signature.parameter,
@@ -621,7 +621,7 @@ export const updateTypeAtKeyPathIfValid = (
               ),
               return: type.signature.return,
             })
-          case functionReturn:
+          case functionReturnKey:
             return makeFunctionType(type.name, {
               return: updateTypeAtKeyPathIfValid(
                 type.signature.return,
@@ -656,7 +656,7 @@ export const updateTypeAtKeyPathIfValid = (
       opaque: (type): Type => type,
       parameter: type => {
         switch (firstKey) {
-          case typeParameterAssignableToConstraint:
+          case typeParameterAssignableToConstraintKey:
             return makeTypeParameter(type.name, {
               assignableTo: updateTypeAtKeyPathIfValid(
                 type.constraint.assignableTo,
@@ -840,11 +840,11 @@ const stringifyKeyPathComponentForEndUser = (
       // TODO: Consider surfacing this in plz syntax (allowing programmatic
       // access of un-elaborated function parameters/returns and type parameter
       // constraints).
-      case functionParameter:
+      case functionParameterKey:
         return '#parameter'
-      case functionReturn:
+      case functionReturnKey:
         return '#return'
-      case typeParameterAssignableToConstraint:
+      case typeParameterAssignableToConstraintKey:
         return '#constraint'
     }
   }

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -1,13 +1,15 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { Writable } from '../../../utility-types.js'
-import type { Bug } from '../../errors.js'
+import type { Bug, ElaborationError, TypeMismatchError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import { quoteAtomIfNecessary } from '../../unparsing/plz-utilities.js'
+import type { ExpressionContext } from '../expression-elaboration.js'
 import { isKeywordExpressionWithArgument } from '../expression.js'
 import {
   getHoleTypeParameter,
   readHoleExpression,
 } from '../expressions/hole-expression.js'
+import type { ObjectNode } from '../object-node.js'
 import { type SemanticGraph } from '../semantic-graph.js'
 import { types } from '../type-system.js'
 import { typesBySymbol } from './prelude-types.js'
@@ -24,24 +26,46 @@ import {
   type UnionType,
 } from './type-formats.js'
 
-const functionParameterKey = Symbol('functionParameter')
-const functionReturnKey = Symbol('functionReturn')
-const typeParameterAssignableToConstraintKey = Symbol(
+export const functionParameterKey = Symbol('functionParameter')
+export const functionReturnKey = Symbol('functionReturn')
+export const typeParameterAssignableToConstraintKey = Symbol(
   'typeParameterAssignableToConstraint',
 )
 
-// An element selecting a property: a literal atom, or a union of literal atoms
-// (when a dynamic key could be one of several atoms).
-type AtomKeyPathElement =
+type AtomKeyPathComponent =
   | Atom
   | (Omit<UnionType, 'members'> & { readonly members: ReadonlySet<Atom> })
 
 export type TypeKeyPath = readonly (
-  | AtomKeyPathElement
+  | AtomKeyPathComponent
   | typeof functionParameterKey
   | typeof functionReturnKey
   | typeof typeParameterAssignableToConstraintKey
 )[]
+
+export const typeKeyPathFromObjectNode = (
+  node: ObjectNode,
+  context: ExpressionContext,
+  inferType: (
+    specificKey: SemanticGraph,
+    contextForSpecificKey: ExpressionContext,
+  ) => Either<ElaborationError, Type>,
+): Either<ElaborationError, TypeKeyPath> =>
+  // Each sequentially-keyed property is either a literal atom or a dynamic key
+  // whose type must be an atom or union of atoms.
+  either.sequence(
+    Object.entries(node).map(([key, component]) =>
+      typeof component === 'string' ?
+        either.makeRight(component)
+      : either.flatMap(
+          inferType(component, {
+            ...context,
+            location: [...context.location, key],
+          }),
+          atomKeyPathComponentFromType,
+        ),
+    ),
+  )
 
 type StringifiedKeyPath = string // this could be branded if that seems useful
 type UnionOfTypeParameters = Omit<UnionType, 'members'> & {
@@ -821,6 +845,37 @@ export const stringifyTypeKeyPathForEndUser = (keyPath: TypeKeyPath): string =>
       ),
     '',
   )
+
+const atomKeyPathComponentFromType = (
+  type: Type,
+): Either<TypeMismatchError, AtomKeyPathComponent> => {
+  const concreteType = replaceAllTypeParametersWithTheirConstraints(type)
+  const simplifiedType =
+    concreteType.kind === 'union' ?
+      simplifyUnionType(concreteType)
+    : concreteType
+
+  const atomMembers =
+    simplifiedType.kind === 'union' ?
+      [...simplifiedType.members].filter(member => typeof member === 'string')
+    : []
+
+  const isAtomUnion =
+    simplifiedType.kind === 'union' &&
+    atomMembers.length > 0 &&
+    atomMembers.length === simplifiedType.members.size
+  const [firstAtom, ...remainingAtoms] = atomMembers
+
+  return (
+    !isAtomUnion || firstAtom === undefined ?
+      either.makeLeft({
+        kind: 'typeMismatch',
+        message: 'dynamic index key must be an atom or a union of atoms',
+      })
+    : remainingAtoms.length === 0 ? either.makeRight(firstAtom)
+    : either.makeRight(makeUnionType(simplifiedType.name, atomMembers))
+  )
+}
 
 const stringifyKeyPathComponentForEndUser = (
   component: TypeKeyPath[number],

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -29,8 +29,14 @@ const typeParameterAssignableToConstraint = Symbol(
   'typeParameterAssignableToConstraint',
 )
 
-export type TypeKeyPath = readonly (
+// An element selecting a property: a literal atom, or a union of literal atoms
+// (when a dynamic key could be one of several atoms).
+type AtomKeyPathElement =
   | Atom
+  | (Omit<UnionType, 'members'> & { readonly members: ReadonlySet<Atom> })
+
+export type TypeKeyPath = readonly (
+  | AtomKeyPathElement
   | typeof functionParameter
   | typeof functionReturn
   | typeof typeParameterAssignableToConstraint
@@ -58,8 +64,24 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
   if (firstKey === undefined) {
     // If the key path is empty, this is the type we're looking for.
     return type
+  } else if (typeof firstKey === 'object') {
+    return makeUnionType(
+      '',
+      // Flatten to avoid nested unions.
+      [...firstKey.members].flatMap(firstKeyMember => {
+        const typeForThisPossibility = applyKeyPathToType(type, [
+          firstKeyMember,
+          ...remainingKeyPath,
+        ])
+        if (typeForThisPossibility.kind === 'union') {
+          return [...typeForThisPossibility.members]
+        } else {
+          return typeForThisPossibility
+        }
+      }),
+    )
   } else {
-    return matchTypeFormat(type, {
+    return matchTypeFormat<Type>(type, {
       function: type => {
         if (typeof firstKey === 'string') {
           // Functions do not have properties.
@@ -225,6 +247,8 @@ const synthesizeTypeParameterName = (
       return `${name}.#return`
     } else if (key === typeParameterAssignableToConstraint) {
       return `${name}.#constraint`
+    } else if (typeof key === 'object') {
+      return `${name}.#${[...key.members].join('|')}`
     } else {
       return `${name}.${key}`
     }

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -26,7 +26,6 @@ import {
   type FunctionExpression,
   type HoleExpression,
   type IndexExpression,
-  type KeyPath,
   type LookupExpression,
   type ObjectNode,
   type SemanticGraph,
@@ -441,37 +440,49 @@ const unparseSugaredIndex = (
 
 const unparseKeyPathOfSugaredIndex = (
   query: ObjectNode,
-  { semanticContext }: Context,
-) => {
-  const keyPath = Object.entries(query).reduce(
-    (accumulator: KeyPath | 'invalid', [key, value]) => {
-      if (accumulator === 'invalid') {
-        return accumulator
-      } else {
-        if (key === String(accumulator.length) && typeof value === 'string') {
-          return [...accumulator, value]
-        } else {
-          return 'invalid'
-        }
-      }
-    },
-    [],
+  { unparseAtomOrMolecule, semanticContext }: Context,
+): Either<UnserializableValueError, string> => {
+  const { dot, colon, openGroupingParenthesis, closeGroupingParenthesis } =
+    punctuation(styleText)
+  const componentResults = Object.entries(query).map(
+    ([key, value], index): Either<UnserializableValueError, string> =>
+      // Keys must be sequential ("0", "1", …) to use the dotted sugar.
+      key !== String(index) ?
+        either.makeLeft({
+          kind: 'unserializableValue',
+          message: 'invalid key path',
+        })
+        // A literal atom uses `.a`.
+      : typeof value === 'string' ?
+        either.makeRight(quoteKeyPathComponentIfNecessary(value))
+      : either.match(readLookupExpression(value), {
+          // A `@lookup` uses `.:key`.
+          right: lookup =>
+            either.makeRight(
+              colon.concat(quoteKeyPathComponentIfNecessary(lookup[1].key)),
+            ),
+          // Any other expression uses `.(…)`.
+          left: _ =>
+            either.map(
+              either.flatMap(
+                serializeIfNeeded(value),
+                unparseAtomOrMolecule('default'),
+              ),
+              unparsedExpression =>
+                openGroupingParenthesis.concat(
+                  unparsedExpression,
+                  closeGroupingParenthesis,
+                ),
+            ),
+        }),
   )
 
-  if (keyPath === 'invalid' || Object.keys(query).length !== keyPath.length) {
-    return either.makeLeft({
-      kind: 'unserializableValue',
-      message: 'invalid key path',
-    })
-  } else {
-    const { dot } = punctuation(styleText)
-    return either.makeRight(
-      styleText(
-        semanticContext === 'apply' ? applyColor : keyColor,
-        dot.concat(keyPath.map(quoteKeyPathComponentIfNecessary).join(dot)),
-      ),
-    )
-  }
+  return either.map(either.sequence(componentResults), components =>
+    styleText(
+      semanticContext === 'apply' ? applyColor : keyColor,
+      dot.concat(components.join(dot)),
+    ),
+  )
 }
 
 const unparseSugaredLookup = (


### PR DESCRIPTION
Previously key paths had to be made of literal (quoted or unquoted) atoms (e.g. `:a.b.c."d e".f`). Now the keys can be computed by arbitrary expressions, using syntax like `:a.b.(1 + 1).c`. Lookups do not need parentheses, e.g. `:a.:b.:c` works.

As before the keys in the path must provably be valid for the object they're drilling into, though now union types are supported (see tests for examples).