### PR TITLE
Fix bugs due to not reusing type parameters during genericization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -293,17 +293,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/type-utils": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -316,7 +316,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.0",
+        "@typescript-eslint/parser": "^8.60.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -332,17 +332,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -358,14 +358,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.0",
-        "@typescript-eslint/types": "^8.60.0",
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -380,14 +380,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0"
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -398,9 +398,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -415,15 +415,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -440,9 +440,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -454,16 +454,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.0",
-        "@typescript-eslint/tsconfig-utils": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -482,16 +482,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0"
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -506,13 +506,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/types": "8.60.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -653,7 +653,7 @@
         "@eslint/config-array": "^0.23.5",
         "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -1174,9 +1174,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1210,9 +1210,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1268,16 +1268,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
-      "integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
+      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.0",
-        "@typescript-eslint/parser": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0"
+        "@typescript-eslint/eslint-plugin": "8.60.1",
+        "@typescript-eslint/parser": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1154,4 +1154,14 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      lookup_within: (object: { a: :something.type }) => :object.a
+      :lookup_within(@runtime { _ => { a: true } }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -71,14 +71,21 @@ export const resolveParameterTypes = (
     )
 
     if (option.isSome(enclosingFunction)) {
+      const enclosingFunctionLocation = currentLocation.slice(0, -2)
+      // Skip the function whose parameter annotation we're inside. Computing
+      // its parameter type requires this very inference (and would infinitely
+      // recurse without this guard).
+      const isInsideOwnAnnotation =
+        context.location[enclosingFunctionLocation.length] === '1' &&
+        context.location[enclosingFunctionLocation.length + 1] === 'parameter'
       const parameterName = getParameterName(enclosingFunction.value)
-      if (!parameterTypes.has(parameterName)) {
+      if (!isInsideOwnAnnotation && !parameterTypes.has(parameterName)) {
         const parameterTypeResult = getFunctionParameterType(
           enclosingFunction.value,
           {
             keywordHandlers: context.keywordHandlers,
             program: context.program,
-            location: currentLocation.slice(0, -2),
+            location: enclosingFunctionLocation,
             mutableInferenceCache: context.mutableInferenceCache,
           },
         )

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -37,6 +37,7 @@ import {
 } from './type-formats.js'
 import {
   applyKeyPathToType,
+  functionParameterKey,
   genericizeFunctionParameterAnnotation,
   getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
@@ -447,99 +448,130 @@ const inferTypeImplementation = (
 const getFunctionParameterType = (
   expression: FunctionExpression,
   contextOfFunction: ExpressionContext,
-): Either<ElaborationError, Type> =>
-  option.match(getParameterTypeAnnotation(expression), {
-    some: annotation =>
-      either.map(
-        // Type annotation lookups happen from the function's scope rather than
-        // their own location (a property within the `@function`).
-        // TODO: Consider separating out the cache key prefix from the
-        // `context.location` somehow so that I can say "lookups start from X,
-        // cache key paths are rooted at Y".
-        inferType(annotation, {
-          ...contextOfFunction,
-          mutableInferenceCache: new Map(),
-        }),
-        annotationType => {
-          const parameterName = getParameterName(expression)
-          // `_` (`ignoredKey`) is the name for an ignored parameter (and is what
-          // the parser emits for `~>` syntax sugar). Genericization is skipped
-          // in this case so `a ~> b` and `(_: a) => b` can be used to describe
-          // concrete function types rather than generic ones.
-          return parameterName === ignoredKey ? annotationType : (
-              genericizeFunctionParameterAnnotation(
-                parameterName,
-                annotationType,
-              )
-            )
-        },
-      ),
-    none: _ => {
-      const contextualType = option.flatMap(
-        enclosingExpressionFromPropertyOfExpressionArgument(contextOfFunction),
-        (enclosingExpression): Option<Type> => {
-          if (
-            isKeywordExpressionWithArgument('@runtime', enclosingExpression)
-          ) {
-            return option.makeSome(types.runtimeContext)
-          }
-
-          const positionInEnclosingExpression =
-            contextOfFunction.location[contextOfFunction.location.length - 1]
-          const applyExpressionResult = readApplyExpression(enclosingExpression)
-          if (
-            either.isRight(applyExpressionResult) &&
-            positionInEnclosingExpression === 'argument'
-          ) {
-            const contextOfEnclosingExpression: ExpressionContext = {
-              program: contextOfFunction.program,
-              keywordHandlers: contextOfFunction.keywordHandlers,
-              location: contextOfFunction.location.slice(0, -2),
-              mutableInferenceCache: contextOfFunction.mutableInferenceCache,
-            }
-            const contextuallyAppliedFunctionType = inferType(
-              applyExpressionResult.value[1].function,
-              {
-                ...contextOfEnclosingExpression,
-                location: [
-                  ...contextOfEnclosingExpression.location,
-                  '1',
-                  'function',
-                ],
-              },
-            )
-
-            // If the applied function's signature is `(a ~> b) ~> c`, the
-            // function passed to it should have its parameter typed as `a`.
-            if (
-              either.isRight(contextuallyAppliedFunctionType) &&
-              contextuallyAppliedFunctionType.value.kind === 'function' &&
-              contextuallyAppliedFunctionType.value.signature.parameter.kind ===
-                'function'
-            ) {
-              return option.makeSome(
-                contextuallyAppliedFunctionType.value.signature.parameter
-                  .signature.parameter,
-              )
-            }
-          }
-
-          return option.none
-        },
-      )
-
-      return option.match(contextualType, {
-        some: either.makeRight,
-        none: _ =>
-          either.makeRight(
-            genericizeFunctionParameterAnnotation(
-              getParameterName(expression),
-              types.something,
-            ),
+): Either<ElaborationError, Type> => {
+  // `genericizeFunctionParameterAnnotation` mints fresh type parameters, but
+  // type parameters are identified by an internal `symbol`. To keep identities
+  // consistent, cache parameter types here.
+  const parameterCacheKey = stringifyTypeKeyPathForEndUser([
+    ...contextOfFunction.location,
+    functionParameterKey,
+  ])
+  const cachedParameterType =
+    contextOfFunction.mutableInferenceCache.get(parameterCacheKey)
+  if (cachedParameterType !== undefined) {
+    return either.makeRight(cachedParameterType)
+  } else {
+    return either.map(
+      option.match(getParameterTypeAnnotation(expression), {
+        some: annotation =>
+          either.map(
+            // Type annotation lookups happen from the function's scope rather than
+            // their own location (a property within the `@function`).
+            // TODO: Consider separating out the cache key prefix from the
+            // `context.location` somehow so that I can say "lookups start from X,
+            // cache key paths are rooted at Y".
+            inferType(annotation, {
+              ...contextOfFunction,
+              mutableInferenceCache: new Map(),
+            }),
+            annotationType => {
+              const parameterName = getParameterName(expression)
+              // `_` (`ignoredKey`) is the name for an ignored parameter (and is what
+              // the parser emits for `~>` syntax sugar). Genericization is skipped
+              // in this case so `a ~> b` and `(_: a) => b` can be used to describe
+              // concrete function types rather than generic ones.
+              return parameterName === ignoredKey ? annotationType : (
+                  genericizeFunctionParameterAnnotation(
+                    parameterName,
+                    annotationType,
+                  )
+                )
+            },
           ),
-      })
-    },
-  })
+        none: _ => {
+          const contextualType = option.flatMap(
+            enclosingExpressionFromPropertyOfExpressionArgument(
+              contextOfFunction,
+            ),
+            (enclosingExpression): Option<Type> => {
+              if (
+                isKeywordExpressionWithArgument('@runtime', enclosingExpression)
+              ) {
+                return option.makeSome(types.runtimeContext)
+              }
+
+              const positionInEnclosingExpression =
+                contextOfFunction.location[
+                  contextOfFunction.location.length - 1
+                ]
+              const applyExpressionResult =
+                readApplyExpression(enclosingExpression)
+              if (
+                either.isRight(applyExpressionResult) &&
+                positionInEnclosingExpression === 'argument'
+              ) {
+                const contextOfEnclosingExpression: ExpressionContext = {
+                  program: contextOfFunction.program,
+                  keywordHandlers: contextOfFunction.keywordHandlers,
+                  location: contextOfFunction.location.slice(0, -2),
+                  mutableInferenceCache:
+                    contextOfFunction.mutableInferenceCache,
+                }
+                const contextuallyAppliedFunctionType = inferType(
+                  applyExpressionResult.value[1].function,
+                  {
+                    ...contextOfEnclosingExpression,
+                    location: [
+                      ...contextOfEnclosingExpression.location,
+                      '1',
+                      'function',
+                    ],
+                  },
+                )
+
+                // If the applied function's signature is `(a ~> b) ~> c`, the
+                // function passed to it should have its parameter typed as `a`.
+                if (
+                  either.isRight(contextuallyAppliedFunctionType) &&
+                  contextuallyAppliedFunctionType.value.kind === 'function' &&
+                  contextuallyAppliedFunctionType.value.signature.parameter
+                    .kind === 'function'
+                ) {
+                  return option.makeSome(
+                    contextuallyAppliedFunctionType.value.signature.parameter
+                      .signature.parameter,
+                  )
+                }
+              }
+
+              return option.none
+            },
+          )
+
+          return option.match(contextualType, {
+            some: either.makeRight,
+            none: _ =>
+              either.makeRight(
+                genericizeFunctionParameterAnnotation(
+                  getParameterName(expression),
+                  types.something,
+                ),
+              ),
+          })
+        },
+      }),
+      parameterType => {
+        // Side effect: cache the parameter type so its type-parameter
+        // identities remain stable.
+        contextOfFunction.mutableInferenceCache.set(
+          parameterCacheKey,
+          parameterType,
+        )
+        return parameterType
+      },
+    )
+  }
+}
 
 const enclosingExpressionFromPropertyOfExpressionArgument = ({
   program,


### PR DESCRIPTION
Type parameters have an internal `symbol` representing their identity. Minting fresh type parameters for the same annotation meant there were unrelated (but same-named) type parameters from the type system's point of view, causing certain programs to falsely be rejected by static analysis.

This problem has been fixed in this changeset by adding genericized function parameter types to the inference cache.

This diff is much better when ignoring whitespace.