### PR TITLE
Implement indexed access types

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1164,4 +1164,69 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      not: (a: :boolean.type) => @if { :a, false, true }
+      :not(@runtime { _ => false }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      lookup: (key: a | b) => { a: true, b: false }.:key
+      :lookup(@runtime { _ => a }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      lookup: (key: a | b) => { a: { x: true }, b: { x: false } }.:key.x
+      :lookup(@runtime { _ => a }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      lookup: (keys: { a | b, x | y }) =>
+        { a: { x: true, y: false }, b: { x: false, y: false } }.(:keys.0).(:keys.1)
+      :lookup(@runtime { _ => { a, x } }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      not: (a: :boolean.type) => @if { :a, false, true }
+      :not(@runtime { _ => false }) ~ false
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      lookup: (key: a | b) => { a: true, b: false }.:key
+      :lookup(@runtime { _ => b }) ~ true
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -311,6 +311,13 @@ export const typeToSemanticGraph = (
         ]),
         recurseWithSameTypeParameters(type.signature.return),
       ),
+    indexedAccess: type =>
+      makeIndexExpression({
+        object: recurseWithSameTypeParameters(type.object),
+        query: objectNodeFromOrderedEntries([
+          ['0', recurseWithSameTypeParameters(type.key)],
+        ]),
+      }),
     object: type =>
       objectNodeFromOrderedEntries(
         Object.entries(type.children).map(([key, value]) => [

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -87,25 +87,36 @@ export const applyTypeKeyPathToSemanticGraph = (
 ): Option<SemanticGraph> => {
   const [firstKey, ...remainingKeyPath] = keyPath
   if (firstKey === undefined) {
-    // If the key path is empty, this is the type we're looking for.
+    // If the key path is empty, this is the node we're looking for.
     return option.makeSome(node)
   } else if (typeof firstKey === 'object') {
-    return option.map(
-      option.sequence(
-        [...firstKey.members].map(firstKeyMember =>
-          applyTypeKeyPathToSemanticGraph(node, [
-            firstKeyMember,
-            ...remainingKeyPath,
-          ]),
-        ),
-      ),
-      foundNodes =>
-        makeUnionExpression(
-          objectNodeFromOrderedEntries(
-            foundNodes.map((node, index) => [String(index), node]),
+    switch (firstKey.kind) {
+      case 'parameter':
+        // Use the constraint.
+        // TODO: Make sure this is actually sound. It's currently not exposed
+        // because the `@index` handler bails early on unelaborated queries.
+        return applyTypeKeyPathToSemanticGraph(node, [
+          firstKey.constraint.assignableTo,
+          ...remainingKeyPath,
+        ])
+      case 'union':
+        return option.map(
+          option.sequence(
+            [...firstKey.members].map(firstKeyMember =>
+              applyTypeKeyPathToSemanticGraph(node, [
+                firstKeyMember,
+                ...remainingKeyPath,
+              ]),
+            ),
           ),
-        ),
-    )
+          foundNodes =>
+            makeUnionExpression(
+              objectNodeFromOrderedEntries(
+                foundNodes.map((node, index) => [String(index), node]),
+              ),
+            ),
+        )
+    }
   } else {
     return matchSemanticGraph(node, {
       // If it's an `Atom` or `TypeSymbol` but we have a non-empty path, we

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -14,6 +14,7 @@ import {
 import { isAssignable, simplifyUnionType } from './subtyping.js'
 import {
   makeFunctionType,
+  makeIndexedAccessType,
   makeObjectType,
   makeTypeParameter,
   makeUnionType,
@@ -54,6 +55,17 @@ const extendsFunctionFromValueToAtom = makeTypeParameter('v', {
 const extendsExtendsAnyAtom = makeTypeParameter('u', {
   assignableTo: extendsAnyAtom,
 })
+
+const indexedAccessBoolean = makeIndexedAccessType(
+  '',
+  makeObjectType('', {
+    a: makeUnionType('', ['true']),
+    b: makeUnionType('', ['false']),
+  }),
+  makeTypeParameter('key', {
+    assignableTo: makeUnionType('', ['a', 'b']),
+  }),
+)
 
 testCases(
   (type: UnionType) => stringifyTypeForEndUser(simplifyUnionType(type)),
@@ -114,6 +126,22 @@ typeAssignabilitySuite('prelude types (assignable)', [
   [[atom, something], true],
   [[object, something], true],
   [[functionType, something], true],
+])
+
+typeAssignabilitySuite('indexed-access types (assignable)', [
+  [[indexedAccessBoolean, boolean], true],
+  [[indexedAccessBoolean, atom], true],
+  [[indexedAccessBoolean, something], true],
+])
+
+typeAssignabilitySuite('indexed-access types (not assignable)', [
+  [[indexedAccessBoolean, makeUnionType('', ['true'])], false],
+  [[makeUnionType('', ['true']), indexedAccessBoolean], false],
+
+  // Despite being `true` or `false` at runtime, `indexedAccessBoolean` can't
+  // have `boolean` assigned to it as it's *specifically* either `true` or
+  // `false` depending on how its type parameter is instantiated.
+  [[boolean, indexedAccessBoolean], false],
 ])
 
 typeAssignabilitySuite('prelude types (not assignable)', [

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -10,6 +10,7 @@ import {
 import {
   containedTypeParameters,
   findKeyPathsToTypeParameter,
+  replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArgument,
   updateTypeAtKeyPathIfValid,
 } from './type-utilities.js'
@@ -137,14 +138,21 @@ export const isAssignable = ({
               )
             }
           },
+          indexedAccess: _target => false,
           object: _target => false, // functions are never assignable to objects
           opaque: target => target.isAssignableFrom(source),
           parameter: _target => false, // a function type is never directly assignable to a type parameter
           union: target => isNonUnionAssignableToUnion({ source, target }),
         }),
+      indexedAccess: source =>
+        isAssignable({
+          source: replaceAllTypeParametersWithTheirConstraints(source),
+          target,
+        }),
       object: source =>
         matchTypeFormat(target, {
           function: _ => false, // objects are never assignable to functions
+          indexedAccess: _ => false,
           object: target => {
             // Make sure all properties in the target are present and valid in
             // the source (recursively). Values may have additional properties
@@ -187,6 +195,8 @@ export const isAssignable = ({
       union: source =>
         matchTypeFormat(target, {
           function: target => isUnionAssignableToNonUnion({ source, target }),
+          indexedAccess: target =>
+            isUnionAssignableToNonUnion({ source, target }),
           object: target => isUnionAssignableToNonUnion({ source, target }),
           opaque: target => isUnionAssignableToNonUnion({ source, target }),
           parameter: target => isUnionAssignableToNonUnion({ source, target }),

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -23,6 +23,28 @@ export const makeFunctionType = <Signature extends FunctionType['signature']>(
   signature,
 })
 
+/**
+ * A stuck projection (i.e. `object[key]`), produced when an `@index` or `@if`
+ * can't be fully resolved because its key/condition contains a type parameter.
+ */
+export type IndexedAccessType = {
+  readonly name: string
+  readonly kind: 'indexedAccess'
+  readonly object: Type
+  readonly key: Type
+}
+
+export const makeIndexedAccessType = (
+  name: string,
+  object: Type,
+  key: Type,
+): IndexedAccessType => ({
+  name,
+  kind: 'indexedAccess',
+  object,
+  key,
+})
+
 export type ObjectType = {
   readonly name: string
   readonly kind: 'object'
@@ -73,6 +95,9 @@ export const makeOpaqueType = (
     isAssignableFrom: source =>
       matchTypeFormat(source, {
         function: _ => false,
+        // TODO: Use the stuck index's upper bound once the cycle with
+        // `type-utilities.ts` can be avoided. Conservative (sound) for now.
+        indexedAccess: _ => false,
         object: _ => false,
         opaque: source =>
           source === self ||
@@ -99,6 +124,7 @@ export const makeOpaqueType = (
     isAssignableTo: target =>
       matchTypeFormat(target, {
         function: _ => false,
+        indexedAccess: _ => false,
         object: _ => false,
         opaque: target =>
           target === self ||
@@ -202,6 +228,7 @@ export const makeUnionType = <Member extends Atom | Exclude<Type, UnionType>>(
 
 export type Type =
   | FunctionType
+  | IndexedAccessType
   | ObjectType
   | OpaqueType
   | TypeParameter
@@ -211,6 +238,7 @@ export const matchTypeFormat = <Result>(
   type: Type,
   cases: {
     function: (type: FunctionType) => Result
+    indexedAccess: (type: IndexedAccessType) => Result
     object: (type: ObjectType) => Result
     opaque: (type: OpaqueType) => Result
     parameter: (type: TypeParameter) => Result
@@ -219,6 +247,8 @@ export const matchTypeFormat = <Result>(
 ): Result => {
   switch (type.kind) {
     case 'function':
+      return cases[type.kind](type)
+    case 'indexedAccess':
       return cases[type.kind](type)
     case 'object':
       return cases[type.kind](type)

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -43,7 +43,6 @@ import {
   genericizeFunctionParameterAnnotation,
   getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
-  reduceIndexedAccess,
   stringifyTypeKeyPathForEndUser,
   supplyTypeArguments,
   typeKeyPathFromObjectNode,
@@ -247,43 +246,19 @@ const inferTypeImplementation = (
           descendantContext(['1', 'object']),
         ),
         objectType =>
-          // Infer each query component's type. If any component depends on a
-          // type parameter, model it using stuck `IndexedAccessType`s.
-          either.flatMap(
-            either.sequence(
-              Object.entries(query).map(([key, component]) =>
+          either.map(
+            typeKeyPathFromObjectNode(
+              query,
+              descendantContext(['1', 'query']),
+              (node, context) =>
                 inferTypeImplementation(
-                  component,
+                  node,
                   parameterTypes,
                   lookingUpKeys,
-                  descendantContext(['1', 'query', key]),
+                  context,
                 ),
-              ),
             ),
-            componentTypes =>
-              (
-                componentTypes.some(
-                  componentType =>
-                    containedTypeParameters(componentType).size > 0,
-                )
-              ) ?
-                either.makeRight(
-                  componentTypes.reduce(reduceIndexedAccess, objectType),
-                )
-              : either.map(
-                  typeKeyPathFromObjectNode(
-                    query,
-                    descendantContext(['1', 'query']),
-                    (node, context) =>
-                      inferTypeImplementation(
-                        node,
-                        parameterTypes,
-                        lookingUpKeys,
-                        context,
-                      ),
-                  ),
-                  keyPath => applyKeyPathToType(objectType, keyPath),
-                ),
+            keyPath => applyKeyPathToType(objectType, keyPath),
           ),
       ),
     )

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -31,16 +31,19 @@ import {
 import * as types from './prelude-types.js'
 import {
   makeFunctionType,
+  makeIndexedAccessType,
   makeObjectType,
   makeUnionType,
   type Type,
 } from './type-formats.js'
 import {
   applyKeyPathToType,
+  containedTypeParameters,
   functionParameterKey,
   genericizeFunctionParameterAnnotation,
   getTypesForTypeParameters,
   literalTypeFromSemanticGraph,
+  reduceIndexedAccess,
   stringifyTypeKeyPathForEndUser,
   supplyTypeArguments,
   typeKeyPathFromObjectNode,
@@ -234,6 +237,7 @@ const inferTypeImplementation = (
   // @index: infer object type, look up appropriate type by key path.
   const indexExpressionResult = readIndexExpression(node)
   if (either.isRight(indexExpressionResult)) {
+    const query = indexExpressionResult.value[1].query
     return cacheOnSuccess(
       either.flatMap(
         inferTypeImplementation(
@@ -243,19 +247,43 @@ const inferTypeImplementation = (
           descendantContext(['1', 'object']),
         ),
         objectType =>
-          either.map(
-            typeKeyPathFromObjectNode(
-              indexExpressionResult.value[1].query,
-              descendantContext(['1', 'query']),
-              (node, context) =>
+          // Infer each query component's type. If any component depends on a
+          // type parameter, model it using stuck `IndexedAccessType`s.
+          either.flatMap(
+            either.sequence(
+              Object.entries(query).map(([key, component]) =>
                 inferTypeImplementation(
-                  node,
+                  component,
                   parameterTypes,
                   lookingUpKeys,
-                  context,
+                  descendantContext(['1', 'query', key]),
                 ),
+              ),
             ),
-            keyPath => applyKeyPathToType(objectType, keyPath),
+            componentTypes =>
+              (
+                componentTypes.some(
+                  componentType =>
+                    containedTypeParameters(componentType).size > 0,
+                )
+              ) ?
+                either.makeRight(
+                  componentTypes.reduce(reduceIndexedAccess, objectType),
+                )
+              : either.map(
+                  typeKeyPathFromObjectNode(
+                    query,
+                    descendantContext(['1', 'query']),
+                    (node, context) =>
+                      inferTypeImplementation(
+                        node,
+                        parameterTypes,
+                        lookingUpKeys,
+                        context,
+                      ),
+                  ),
+                  keyPath => applyKeyPathToType(objectType, keyPath),
+                ),
           ),
       ),
     )
@@ -386,6 +414,26 @@ const inferTypeImplementation = (
             return inferThen()
           } else if (isAssignable({ source: conditionType, target: 'false' })) {
             return inferElse()
+          } else if (containedTypeParameters(conditionType).size > 0) {
+            // The condition depends on a type parameter, so keep the choice
+            // unresolved as an indexed access into a boolean-keyed object.
+            // This expression:
+            // ```
+            // @if { :a, b, c }
+            // ```
+            // Is equivalent type-wise to this expression:
+            // ```
+            // { true: b, false: c }.:a
+            // ```
+            return either.flatMap(inferThen(), thenType =>
+              either.map(inferElse(), elseType =>
+                makeIndexedAccessType(
+                  '',
+                  makeObjectType('', { false: elseType, true: thenType }),
+                  conditionType,
+                ),
+              ),
+            )
           } else {
             const membersOf = (type: Type) =>
               type.kind === 'union' ? [...type.members] : [type]

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -16,6 +16,7 @@ import { typesBySymbol } from './prelude-types.js'
 import { isAssignable, simplifyUnionType } from './subtyping.js'
 import {
   makeFunctionType,
+  makeIndexedAccessType,
   makeObjectType,
   makeTypeParameter,
   makeUnionType,
@@ -148,6 +149,8 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
           return types.nothing
         }
       },
+      indexedAccess: type =>
+        applyKeyPathToType(type.object, [firstKey, ...remainingKeyPath]),
       opaque: _type => types.nothing,
       parameter: type => {
         if (typeof firstKey === 'string') {
@@ -189,6 +192,29 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
         )
       },
     })
+  }
+}
+
+/**
+ * Reduce a (possibly nested) indexed access `object[key]`. A stuck object is
+ * reduced first; projection (via `applyKeyPathToType`) happens only when the
+ * object has known structure and the key is a concrete atom or union of atoms,
+ * otherwise the access stays a stuck `IndexedAccessType`.
+ */
+export const reduceIndexedAccess = (object: Type, key: Type): Type => {
+  const reducedObject =
+    object.kind === 'indexedAccess' ?
+      reduceIndexedAccess(object.object, object.key)
+    : object
+  const keyIsConcrete = containedTypeParameters(key).size === 0
+  const objectHasKnownStructure = reducedObject.kind !== 'indexedAccess'
+  if (keyIsConcrete && objectHasKnownStructure) {
+    return either.match(atomKeyPathComponentFromType(key), {
+      left: _ => types.nothing,
+      right: component => applyKeyPathToType(reducedObject, [component]),
+    })
+  } else {
+    return makeIndexedAccessType('', reducedObject, key)
   }
 }
 
@@ -252,6 +278,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
         assignableTo: leafType,
       }),
     parameter: leafType => leafType,
+    indexedAccess: leafType => leafType,
     union: leafType =>
       makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
         assignableTo: leafType,
@@ -292,6 +319,11 @@ const containedTypeParametersImplementation = (
             containedTypeParametersImplementation(child, [...root, key]),
           )
           .reduce(mergeTypeParametersByKeyPath, new Map()),
+      indexedAccess: type =>
+        mergeTypeParametersByKeyPath(
+          containedTypeParametersImplementation(type.object, root),
+          containedTypeParametersImplementation(type.key, root),
+        ),
       opaque: _ => new Map(),
       parameter: type =>
         mergeTypeParametersByKeyPath(
@@ -363,6 +395,19 @@ const findKeyPathsToTypeParameterImplementation = (
             (accumulator, paths) => new Set([...accumulator, ...paths]),
             new Set(),
           ),
+      indexedAccess: type =>
+        new Set([
+          ...findKeyPathsToTypeParameterImplementation(
+            type.object,
+            typeParameterToFind,
+            root,
+          ),
+          ...findKeyPathsToTypeParameterImplementation(
+            type.key,
+            typeParameterToFind,
+            root,
+          ),
+        ]),
       opaque: _ => new Set(),
       parameter: type =>
         new Set([
@@ -463,6 +508,9 @@ export const getTypesForTypeParameters = ({
 
       opaque: _ => new Map(),
 
+      // TODO: Can function parameter types contain stuck indexed access types?
+      indexedAccess: _ => new Map(),
+
       parameter: parameterType =>
         (
           isAssignable({
@@ -562,6 +610,11 @@ export const supplyTypeArgument = (
         }
         return makeObjectType(type.name, substitutedChildren)
       },
+      indexedAccess: type =>
+        reduceIndexedAccess(
+          supplyTypeArgument(type.object, typeParameter, typeArgument),
+          supplyTypeArgument(type.key, typeParameter, typeArgument),
+        ),
       opaque: type => type,
       parameter: type =>
         type.identity === typeParameter.identity ? typeArgument : type,
@@ -607,7 +660,7 @@ export const supplyTypeArguments = (
 export const updateTypeAtKeyPathIfValid = (
   type: Type,
   keyPath: TypeKeyPath,
-  // TODO: `operation` should be able to update `Atom`s
+  // TODO: `operation` should be able to update `Atom`s.
   operation: (typeAtKeyPath: Exclude<Type, UnionType>) => Type,
 ): Type => {
   const [firstKey, ...remainingKeyPath] = keyPath
@@ -633,7 +686,7 @@ export const updateTypeAtKeyPathIfValid = (
       return operation(type)
     }
   } else {
-    return matchTypeFormat(type, {
+    return matchTypeFormat<Type>(type, {
       function: type => {
         switch (firstKey) {
           case functionParameterKey:
@@ -658,6 +711,7 @@ export const updateTypeAtKeyPathIfValid = (
             return type
         }
       },
+      indexedAccess: type => type,
       object: type => {
         if (typeof firstKey === 'string') {
           const next = type.children[firstKey]
@@ -677,7 +731,7 @@ export const updateTypeAtKeyPathIfValid = (
           return type
         }
       },
-      opaque: (type): Type => type,
+      opaque: type => type,
       parameter: type => {
         switch (firstKey) {
           case typeParameterAssignableToConstraintKey:

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -1,4 +1,5 @@
 import either, { type Either } from '@matt.kantor/either'
+import option, { type Option } from '@matt.kantor/option'
 import type { Writable } from '../../../utility-types.js'
 import type { Bug, ElaborationError, TypeMismatchError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
@@ -36,6 +37,9 @@ export const typeParameterAssignableToConstraintKey = Symbol(
 type AtomKeyPathComponent =
   | Atom
   | (Omit<UnionType, 'members'> & { readonly members: ReadonlySet<Atom> })
+  | (TypeParameter & {
+      readonly constraint: { readonly assignableTo: AtomKeyPathComponent }
+    })
 
 export type TypeKeyPath = readonly (
   | AtomKeyPathComponent
@@ -91,21 +95,45 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
     // If the key path is empty, this is the type we're looking for.
     return type
   } else if (typeof firstKey === 'object') {
-    return makeUnionType(
-      '',
-      // Flatten to avoid nested unions.
-      [...firstKey.members].flatMap(firstKeyMember => {
-        const typeForThisPossibility = applyKeyPathToType(type, [
-          firstKeyMember,
-          ...remainingKeyPath,
-        ])
-        if (typeForThisPossibility.kind === 'union') {
-          return [...typeForThisPossibility.members]
-        } else {
-          return typeForThisPossibility
-        }
-      }),
-    )
+    switch (firstKey.kind) {
+      case 'parameter':
+        return remainingKeyPath.reduce(
+          (type, key) => {
+            if (typeof key === 'symbol') {
+              // TODO: Seems like this should either be allowed
+              // (`IndexedAccessType['key']` could be typed as
+              // `TypeKeyPath[number]`?) or handled better (this function could
+              // return an `Either`).
+              throw new Error(
+                'Type key path contained a symbol following a parameter. This is a bug!',
+              )
+            } else {
+              return makeIndexedAccessType(
+                '',
+                type,
+                typeof key === 'string' ? makeUnionType('', [key]) : key,
+              )
+            }
+          },
+          makeIndexedAccessType('', type, firstKey),
+        )
+      case 'union':
+        return makeUnionType(
+          '',
+          // Flatten to avoid nested unions.
+          [...firstKey.members].flatMap(firstKeyMember => {
+            const typeForThisPossibility = applyKeyPathToType(type, [
+              firstKeyMember,
+              ...remainingKeyPath,
+            ])
+            if (typeForThisPossibility.kind === 'union') {
+              return [...typeForThisPossibility.members]
+            } else {
+              return typeForThisPossibility
+            }
+          }),
+        )
+    }
   } else {
     return matchTypeFormat<Type>(type, {
       function: type => {
@@ -192,29 +220,6 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
         )
       },
     })
-  }
-}
-
-/**
- * Reduce a (possibly nested) indexed access `object[key]`. A stuck object is
- * reduced first; projection (via `applyKeyPathToType`) happens only when the
- * object has known structure and the key is a concrete atom or union of atoms,
- * otherwise the access stays a stuck `IndexedAccessType`.
- */
-export const reduceIndexedAccess = (object: Type, key: Type): Type => {
-  const reducedObject =
-    object.kind === 'indexedAccess' ?
-      reduceIndexedAccess(object.object, object.key)
-    : object
-  const keyIsConcrete = containedTypeParameters(key).size === 0
-  const objectHasKnownStructure = reducedObject.kind !== 'indexedAccess'
-  if (keyIsConcrete && objectHasKnownStructure) {
-    return either.match(atomKeyPathComponentFromType(key), {
-      left: _ => types.nothing,
-      right: component => applyKeyPathToType(reducedObject, [component]),
-    })
-  } else {
-    return makeIndexedAccessType('', reducedObject, key)
   }
 }
 
@@ -611,9 +616,20 @@ export const supplyTypeArgument = (
         return makeObjectType(type.name, substitutedChildren)
       },
       indexedAccess: type =>
-        reduceIndexedAccess(
-          supplyTypeArgument(type.object, typeParameter, typeArgument),
-          supplyTypeArgument(type.key, typeParameter, typeArgument),
+        either.match(
+          atomKeyPathComponentFromType(
+            supplyTypeArgument(type.key, typeParameter, typeArgument),
+          ),
+          {
+            left: _ =>
+              // TODO: Should this trigger an error?
+              types.nothing,
+            right: key =>
+              applyKeyPathToType(
+                supplyTypeArgument(type.object, typeParameter, typeArgument),
+                [key],
+              ),
+          },
         ),
       opaque: type => type,
       parameter: type =>
@@ -902,33 +918,98 @@ export const stringifyTypeKeyPathForEndUser = (keyPath: TypeKeyPath): string =>
 
 const atomKeyPathComponentFromType = (
   type: Type,
-): Either<TypeMismatchError, AtomKeyPathComponent> => {
-  const concreteType = replaceAllTypeParametersWithTheirConstraints(type)
-  const simplifiedType =
-    concreteType.kind === 'union' ?
-      simplifyUnionType(concreteType)
-    : concreteType
-
-  const atomMembers =
-    simplifiedType.kind === 'union' ?
-      [...simplifiedType.members].filter(member => typeof member === 'string')
-    : []
-
-  const isAtomUnion =
-    simplifiedType.kind === 'union' &&
-    atomMembers.length > 0 &&
-    atomMembers.length === simplifiedType.members.size
-  const [firstAtom, ...remainingAtoms] = atomMembers
-
-  return (
-    !isAtomUnion || firstAtom === undefined ?
+): Either<TypeMismatchError, AtomKeyPathComponent> =>
+  matchTypeFormat<Either<TypeMismatchError, AtomKeyPathComponent>>(type, {
+    function: _ =>
       either.makeLeft({
         kind: 'typeMismatch',
-        message: 'dynamic index key must be an atom or a union of atoms',
-      })
-    : remainingAtoms.length === 0 ? either.makeRight(firstAtom)
-    : either.makeRight(makeUnionType(simplifiedType.name, atomMembers))
+        message: `${type.kind} types are not valid key path components`,
+      }),
+    indexedAccess: _ =>
+      either.makeLeft({
+        kind: 'typeMismatch',
+        message: `${type.kind} types are not valid key path components`,
+      }),
+    object: _ =>
+      either.makeLeft({
+        kind: 'typeMismatch',
+        message: `${type.kind} types are not valid key path components`,
+      }),
+    opaque: _ =>
+      either.makeLeft({
+        kind: 'typeMismatch',
+        message: `${type.kind} types are not valid key path components`,
+      }),
+    parameter: type => {
+      switch (type.constraint.assignableTo.kind) {
+        case 'function':
+        case 'indexedAccess':
+        case 'object':
+        case 'opaque':
+          return either.makeLeft({
+            kind: 'typeMismatch',
+            message: `type parameters constrained to ${type.constraint.assignableTo.kind} types aren't valid key path components`,
+          })
+        case 'union':
+        case 'parameter':
+          return either.map(
+            atomKeyPathComponentFromType(type.constraint.assignableTo),
+            validAssignableTo => ({
+              ...type,
+              constraint: {
+                ...type.constraint,
+                assignableTo:
+                  typeof validAssignableTo === 'string' ?
+                    makeUnionType('', [validAssignableTo])
+                  : validAssignableTo,
+              },
+            }),
+          )
+      }
+    },
+    union: type => {
+      const [firstAtom, ...remainingAtoms] = [...type.members]
+      return (
+        firstAtom === undefined ?
+          either.makeLeft({
+            kind: 'typeMismatch',
+            message: `union types are only valid key path components if they are non-empty`,
+          })
+        : remainingAtoms.length === 0 && typeof firstAtom === 'string' ?
+          // Unwrap single-member unions.
+          either.makeRight(firstAtom)
+        : option.match(asUnionWithLiteralAtomMembers(type), {
+            none: _ =>
+              either.makeLeft({
+                kind: 'typeMismatch',
+                message: `union types are only valid key path components when all their members are literal atoms`,
+              }),
+            some: either.makeRight,
+          })
+      )
+    },
+  })
+
+/**
+ * Returns a narrowed version of the `UnionType` if all of its members are
+ * literal atom types.
+ */
+const asUnionWithLiteralAtomMembers = (
+  type: UnionType,
+): Option<
+  Omit<UnionType, 'members'> & { readonly members: ReadonlySet<Atom> }
+> => {
+  const simplifiedType = simplifyUnionType(type)
+
+  const atomMembers = [...simplifiedType.members].filter(
+    member => typeof member === 'string',
   )
+
+  const isAtomUnion = atomMembers.length === simplifiedType.members.size
+
+  return !isAtomUnion ?
+      option.none
+    : option.makeSome(makeUnionType(simplifiedType.name, atomMembers))
 }
 
 const stringifyKeyPathComponentForEndUser = (
@@ -937,13 +1018,18 @@ const stringifyKeyPathComponentForEndUser = (
   if (typeof component === 'string') {
     return quoteAtomIfNecessary(component)
   } else if (typeof component === 'object') {
-    return '('.concat(
-      [...component.members]
-        .sort()
-        .map(stringifyKeyPathComponentForEndUser)
-        .join(' | '),
-      ')',
-    )
+    switch (component.kind) {
+      case 'parameter':
+        return `?${component.name}`
+      case 'union':
+        return '('.concat(
+          [...component.members]
+            .sort()
+            .map(stringifyKeyPathComponentForEndUser)
+            .join(' | '),
+          ')',
+        )
+    }
   } else {
     switch (component) {
       // TODO: Consider surfacing this in plz syntax (allowing programmatic


### PR DESCRIPTION
In many situations `@index` operations can be eagerly resolved to a specific type. However, when one of the keys dynamically references a type parameter this cannot be done (it's a "stuck projection"). Previously static analysis was unable to reason about such operations generically, but the new `IndexedAccessType` makes this possible.

`@if` expressions are able to benefit from the same plumbing (conceptually they're like using the condition to `@index` into an object with keys named `true` and `false`).

This moves Please closer to being "fully" dependently-typed. For example, given this function:

```plz
not: (a: :boolean.type) => @if { :a, false, true }
```

It's now possible to statically know that `:not(@runtime { _ => true })` is `false`.