### PR TITLE
Eliminate names in type formats other than `TypeParameter`

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.test.ts
@@ -31,7 +31,6 @@ elaborationSuite('@function', [
         elaboratedFunction.value.signature.parameter.kind,
         'parameter',
       )
-      assert.deepEqual(elaboratedFunction.value.signature.parameter.name, 'x')
       assert.deepEqual(
         elaboratedFunction.value.signature.return,
         elaboratedFunction.value.signature.parameter,

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -14,7 +14,7 @@ export const atom = {
     ['atom', 'append'],
     {
       parameter: types.atom,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.atom,
         return: types.atom,
       }),
@@ -48,7 +48,7 @@ export const atom = {
     ['atom', 'equals'],
     {
       parameter: types.atom,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.atom,
         return: types.boolean,
       }),
@@ -98,7 +98,7 @@ export const atom = {
     ['atom', 'prepend'],
     {
       parameter: types.atom,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.atom,
         return: types.atom,
       }),

--- a/src/language/semantics/stdlib/boolean.ts
+++ b/src/language/semantics/stdlib/boolean.ts
@@ -68,7 +68,7 @@ export const boolean = {
     ['boolean', 'and'],
     {
       parameter: types.boolean,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.boolean,
         return: types.boolean,
       }),
@@ -103,7 +103,7 @@ export const boolean = {
     ['boolean', 'or'],
     {
       parameter: types.boolean,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.boolean,
         return: types.boolean,
       }),

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -54,8 +54,8 @@ export const globalFunctions = {
     ['apply'],
     {
       parameter: A,
-      return: makeFunctionType('', {
-        parameter: makeFunctionType('', { parameter: A, return: B }),
+      return: makeFunctionType({
+        parameter: makeFunctionType({ parameter: A, return: B }),
         return: B,
       }),
     },
@@ -78,7 +78,7 @@ export const globalFunctions = {
     ['assume'],
     {
       parameter: A,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.something,
         return: A,
       }),
@@ -111,16 +111,16 @@ export const globalFunctions = {
   flow: preludeFunctionArity3(
     ['flow'],
     {
-      parameter: makeFunctionType('', {
+      parameter: makeFunctionType({
         parameter: B,
         return: C,
       }),
-      return: makeFunctionType('', {
-        parameter: makeFunctionType('', {
+      return: makeFunctionType({
+        parameter: makeFunctionType({
           parameter: A,
           return: B,
         }),
-        return: makeFunctionType('', {
+        return: makeFunctionType({
           parameter: A,
           return: C,
         }),
@@ -167,8 +167,8 @@ export const globalFunctions = {
       //  - The final return type should be a union or all the return types from
       //    the first parameter.
       parameter: types.object,
-      return: makeFunctionType('', {
-        parameter: makeObjectType('', {
+      return: makeFunctionType({
+        parameter: makeObjectType({
           tag: types.atom,
           value: types.something,
         }),

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -14,7 +14,7 @@ export const integer = {
     ['integer', 'add'],
     {
       parameter: types.integer,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.integer,
         return: types.integer,
       }),
@@ -22,7 +22,7 @@ export const integer = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.integer.isAssignableFrom(makeUnionType('', [number2]))
+        !types.integer.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -32,7 +32,7 @@ export const integer = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.integer.isAssignableFrom(makeUnionType('', [number1]))
+            !types.integer.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',
@@ -57,7 +57,7 @@ export const integer = {
     ['integer', 'equals'],
     {
       parameter: types.integer,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.integer,
         return: types.boolean,
       }),
@@ -65,7 +65,7 @@ export const integer = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.integer.isAssignableFrom(makeUnionType('', [number2]))
+        !types.integer.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -75,7 +75,7 @@ export const integer = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.integer.isAssignableFrom(makeUnionType('', [number1]))
+            !types.integer.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',
@@ -101,7 +101,6 @@ export const integer = {
         (
           typeof argument === 'string' &&
             types.integer.isAssignableFrom({
-              name: '',
               kind: 'union',
               members: new Set([argument]),
             })
@@ -122,7 +121,6 @@ export const integer = {
         (
           typeof argument === 'string' &&
             types.integer.isAssignableFrom({
-              name: '',
               kind: 'union',
               members: new Set([argument]),
             })
@@ -142,7 +140,7 @@ export const integer = {
     ['integer', 'is_greater_than'],
     {
       parameter: types.integer,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.integer,
         return: types.boolean,
       }),
@@ -150,7 +148,7 @@ export const integer = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.integer.isAssignableFrom(makeUnionType('', [number2]))
+        !types.integer.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -160,7 +158,7 @@ export const integer = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.integer.isAssignableFrom(makeUnionType('', [number1]))
+            !types.integer.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',
@@ -179,7 +177,7 @@ export const integer = {
     ['integer', 'is_less_than'],
     {
       parameter: types.integer,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.integer,
         return: types.boolean,
       }),
@@ -187,7 +185,7 @@ export const integer = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.integer.isAssignableFrom(makeUnionType('', [number2]))
+        !types.integer.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -197,7 +195,7 @@ export const integer = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.integer.isAssignableFrom(makeUnionType('', [number1]))
+            !types.integer.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',
@@ -216,7 +214,7 @@ export const integer = {
     ['integer', 'multiply'],
     {
       parameter: types.integer,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.integer,
         return: types.integer,
       }),
@@ -224,7 +222,7 @@ export const integer = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.integer.isAssignableFrom(makeUnionType('', [number2]))
+        !types.integer.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -234,7 +232,7 @@ export const integer = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.integer.isAssignableFrom(makeUnionType('', [number1]))
+            !types.integer.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',
@@ -253,7 +251,7 @@ export const integer = {
     ['integer', 'subtract'],
     {
       parameter: types.integer,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.integer,
         return: types.integer,
       }),
@@ -261,7 +259,7 @@ export const integer = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.integer.isAssignableFrom(makeUnionType('', [number2]))
+        !types.integer.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -271,7 +269,7 @@ export const integer = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.integer.isAssignableFrom(makeUnionType('', [number1]))
+            !types.integer.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',

--- a/src/language/semantics/stdlib/natural-number.ts
+++ b/src/language/semantics/stdlib/natural-number.ts
@@ -21,7 +21,6 @@ export const natural_number = {
         (
           typeof argument === 'string' &&
             types.naturalNumber.isAssignableFrom({
-              name: '',
               kind: 'union',
               members: new Set([argument]),
             })
@@ -42,7 +41,6 @@ export const natural_number = {
         (
           typeof argument === 'string' &&
             types.naturalNumber.isAssignableFrom({
-              name: '',
               kind: 'union',
               members: new Set([argument]),
             })
@@ -62,7 +60,7 @@ export const natural_number = {
     ['natural_number', 'modulo'],
     {
       parameter: types.naturalNumber,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.naturalNumber,
         return: types.naturalNumber,
       }),
@@ -70,7 +68,7 @@ export const natural_number = {
     number2 => {
       if (
         typeof number2 !== 'string' ||
-        !types.naturalNumber.isAssignableFrom(makeUnionType('', [number2]))
+        !types.naturalNumber.isAssignableFrom(makeUnionType([number2]))
       ) {
         return either.makeLeft({
           kind: 'typeMismatch',
@@ -80,7 +78,7 @@ export const natural_number = {
         return either.makeRight(number1 => {
           if (
             typeof number1 !== 'string' ||
-            !types.naturalNumber.isAssignableFrom(makeUnionType('', [number1]))
+            !types.naturalNumber.isAssignableFrom(makeUnionType([number1]))
           ) {
             return either.makeLeft({
               kind: 'typeMismatch',

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -19,7 +19,7 @@ export const object = {
     {
       // TODO
       parameter: types.atom,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.object,
         return: types.option(types.something),
       }),
@@ -81,7 +81,7 @@ export const object = {
     {
       // TODO
       parameter: types.atom,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.something,
         return: types.object,
       }),
@@ -105,7 +105,7 @@ export const object = {
     {
       // TODO
       parameter: types.object,
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.object,
         return: types.object,
       }),

--- a/src/language/semantics/stdlib/option.ts
+++ b/src/language/semantics/stdlib/option.ts
@@ -69,8 +69,8 @@ export const option = {
   map: preludeFunctionArity2(
     ['option', 'map'],
     {
-      parameter: makeFunctionType('', { parameter: A, return: B }),
-      return: makeFunctionType('', {
+      parameter: makeFunctionType({ parameter: A, return: B }),
+      return: makeFunctionType({
         parameter: types.option(A),
         return: types.option(B),
       }),
@@ -109,11 +109,11 @@ export const option = {
   flat_map: preludeFunctionArity2(
     ['option', 'flat_map'],
     {
-      parameter: makeFunctionType('', {
+      parameter: makeFunctionType({
         parameter: A,
         return: types.option(B),
       }),
-      return: makeFunctionType('', {
+      return: makeFunctionType({
         parameter: types.option(A),
         return: types.option(B),
       }),

--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -10,12 +10,12 @@ import {
   type UnionType,
 } from './type-formats.js'
 
-export const nothing = makeUnionType('nothing', []) // the bottom type
+export const nothing = makeUnionType([]) // the bottom type
 
 // `null` unfortunately can't be a variable name
-export const nullType = makeUnionType('null', ['null'])
+export const nullType = makeUnionType(['null'])
 
-export const boolean = makeUnionType('boolean', ['false', 'true'])
+export const boolean = makeUnionType(['false', 'true'])
 
 // The current type hierarchy for opaque types is:
 //  - atom
@@ -23,14 +23,14 @@ export const boolean = makeUnionType('boolean', ['false', 'true'])
 //      - natural_number
 
 export const atomTypeSymbol = Symbol('atom')
-export const atom = makeOpaqueType('atom', atomTypeSymbol, {
+export const atom = makeOpaqueType(atomTypeSymbol, {
   isAssignableFromLiteralType: (_literalType: string) => true,
   nearestOpaqueAssignableFrom: () => optionAdt.makeSome(integer),
   nearestOpaqueAssignableTo: () => optionAdt.none,
 })
 
 export const integerTypeSymbol = Symbol('integer')
-export const integer = makeOpaqueType('integer', integerTypeSymbol, {
+export const integer = makeOpaqueType(integerTypeSymbol, {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|-?[1-9](?:[0-9])*)+$/.test(literalType),
   nearestOpaqueAssignableFrom: () => optionAdt.makeSome(naturalNumber),
@@ -38,18 +38,14 @@ export const integer = makeOpaqueType('integer', integerTypeSymbol, {
 })
 
 export const naturalNumberTypeSymbol = Symbol('natural_number')
-export const naturalNumber = makeOpaqueType(
-  'natural_number',
-  naturalNumberTypeSymbol,
-  {
-    isAssignableFromLiteralType: literalType =>
-      /^(?:0|[1-9](?:[0-9])*)+$/.test(literalType),
-    nearestOpaqueAssignableFrom: () => optionAdt.none,
-    nearestOpaqueAssignableTo: () => optionAdt.makeSome(integer),
-  },
-)
+export const naturalNumber = makeOpaqueType(naturalNumberTypeSymbol, {
+  isAssignableFromLiteralType: literalType =>
+    /^(?:0|[1-9](?:[0-9])*)+$/.test(literalType),
+  nearestOpaqueAssignableFrom: () => optionAdt.none,
+  nearestOpaqueAssignableTo: () => optionAdt.makeSome(integer),
+})
 
-export const object = makeObjectType('object', {})
+export const object = makeObjectType({})
 
 // `functionType` and `something` reference each other directly, so we need to
 // do a dance:
@@ -59,14 +55,14 @@ export const functionType: FunctionType = {} as FunctionType
 export const something: UnionType = {} as UnionType // the top type
 Object.assign(
   functionType,
-  makeFunctionType('function', {
+  makeFunctionType({
     parameter: nothing,
     return: something,
   }) satisfies FunctionType,
 )
 Object.assign(
   something,
-  makeUnionType('something', [functionType, atom, object]) satisfies UnionType,
+  makeUnionType([functionType, atom, object]) satisfies UnionType,
 )
 
 // Despite not being opaque, `something` gets a type symbol to avoid
@@ -81,26 +77,26 @@ export const typesBySymbol = {
 }
 
 export const option = (value: Type) =>
-  makeUnionType('', [
-    makeObjectType('some', {
-      tag: makeUnionType('', ['some']),
+  makeUnionType([
+    makeObjectType({
+      tag: makeUnionType(['some']),
       value,
     }),
-    makeObjectType('none', {
-      tag: makeUnionType('', ['none']),
-      value: makeObjectType('', {}),
+    makeObjectType({
+      tag: makeUnionType(['none']),
+      value: makeObjectType({}),
     }),
   ])
 
 const A = makeTypeParameter('a', { assignableTo: something })
 
-export const runtimeContext = makeObjectType('runtime_context', {
-  arguments: makeObjectType('', {
-    lookup: makeFunctionType('', { parameter: atom, return: option(atom) }),
+export const runtimeContext = makeObjectType({
+  arguments: makeObjectType({
+    lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
   }),
-  environment: makeObjectType('', {
-    lookup: makeFunctionType('', { parameter: atom, return: option(atom) }),
+  environment: makeObjectType({
+    lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
   }),
-  log: makeFunctionType('', { parameter: A, return: A }),
-  program: makeObjectType('', { start_time: atom }),
+  log: makeFunctionType({ parameter: A, return: A }),
+  program: makeObjectType({ start_time: atom }),
 })

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -38,32 +38,31 @@ const extendsAnyAtom = makeTypeParameter('z', {
   assignableTo: atom,
 })
 const extendsSpecificAtom = makeTypeParameter('y', {
-  assignableTo: makeUnionType('', ['a']),
+  assignableTo: makeUnionType(['a']),
 })
 const extendsUnionOfAtoms = makeTypeParameter('x', {
-  assignableTo: makeUnionType('', ['a', 'b']),
+  assignableTo: makeUnionType(['a', 'b']),
 })
 const extendsA = makeTypeParameter('w', {
   assignableTo: A,
 })
 const extendsFunctionFromAtomToValue = makeTypeParameter('i', {
-  assignableTo: makeFunctionType('', { parameter: atom, return: something }),
+  assignableTo: makeFunctionType({ parameter: atom, return: something }),
 })
 const extendsFunctionFromValueToAtom = makeTypeParameter('v', {
-  assignableTo: makeFunctionType('', { parameter: something, return: atom }),
+  assignableTo: makeFunctionType({ parameter: something, return: atom }),
 })
 const extendsExtendsAnyAtom = makeTypeParameter('u', {
   assignableTo: extendsAnyAtom,
 })
 
 const indexedAccessBoolean = makeIndexedAccessType(
-  '',
-  makeObjectType('', {
-    a: makeUnionType('', ['true']),
-    b: makeUnionType('', ['false']),
+  makeObjectType({
+    a: makeUnionType(['true']),
+    b: makeUnionType(['false']),
   }),
   makeTypeParameter('key', {
-    assignableTo: makeUnionType('', ['a', 'b']),
+    assignableTo: makeUnionType(['a', 'b']),
   }),
 )
 
@@ -72,17 +71,17 @@ testCases(
   type => `simplifying type \`${stringifyTypeForEndUser(type)}\``,
 )('simplifying union types', [
   [
-    makeUnionType('', [
+    makeUnionType([
       'a',
       atom,
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
       }),
-      makeObjectType('', {
-        a: makeUnionType('', ['b']),
+      makeObjectType({
+        a: makeUnionType(['b']),
       }),
-      makeObjectType('', {
-        a: makeUnionType('', ['c']),
+      makeObjectType({
+        a: makeUnionType(['c']),
       }),
     ]),
     ':atom.type | { a: a | b | c }',
@@ -91,8 +90,8 @@ testCases(
 typeAssignabilitySuite('prelude types (assignable)', [
   [
     [
-      makeFunctionType('', { parameter: something, return: something }),
-      makeFunctionType('', { parameter: something, return: something }),
+      makeFunctionType({ parameter: something, return: something }),
+      makeFunctionType({ parameter: something, return: something }),
     ],
     true,
   ],
@@ -135,8 +134,8 @@ typeAssignabilitySuite('indexed-access types (assignable)', [
 ])
 
 typeAssignabilitySuite('indexed-access types (not assignable)', [
-  [[indexedAccessBoolean, makeUnionType('', ['true'])], false],
-  [[makeUnionType('', ['true']), indexedAccessBoolean], false],
+  [[indexedAccessBoolean, makeUnionType(['true'])], false],
+  [[makeUnionType(['true']), indexedAccessBoolean], false],
 
   // Despite being `true` or `false` at runtime, `indexedAccessBoolean` can't
   // have `boolean` assigned to it as it's *specifically* either `true` or
@@ -200,27 +199,27 @@ typeAssignabilitySuite('prelude types (not assignable)', [
 ])
 
 typeAssignabilitySuite('custom types (assignable)', [
-  [[makeUnionType('', ['a']), makeUnionType('', ['a', 'b'])], true],
-  [[makeUnionType('', ['a']), atom], true],
-  [[makeUnionType('', ['a', 'b']), atom], true],
-  [[makeUnionType('', ['a']), makeUnionType('', [atom, 'b'])], true],
-  [[makeUnionType('', ['1']), naturalNumber], true],
-  [[makeUnionType('', ['0', '1']), naturalNumber], true],
+  [[makeUnionType(['a']), makeUnionType(['a', 'b'])], true],
+  [[makeUnionType(['a']), atom], true],
+  [[makeUnionType(['a', 'b']), atom], true],
+  [[makeUnionType(['a']), makeUnionType([atom, 'b'])], true],
+  [[makeUnionType(['1']), naturalNumber], true],
+  [[makeUnionType(['0', '1']), naturalNumber], true],
   [
     [
-      makeUnionType('', ['9876543210']),
-      makeUnionType('', [naturalNumber, 'not a number']),
+      makeUnionType(['9876543210']),
+      makeUnionType([naturalNumber, 'not a number']),
     ],
     true,
   ],
-  [[makeUnionType('', ['0', '-1']), integer], true],
+  [[makeUnionType(['0', '-1']), integer], true],
   [
     [
-      makeObjectType('', {
-        a: makeUnionType('', ['a']),
+      makeObjectType({
+        a: makeUnionType(['a']),
         b: object,
       }),
-      makeObjectType('', {
+      makeObjectType({
         a: atom,
         b: object,
       }),
@@ -229,12 +228,12 @@ typeAssignabilitySuite('custom types (assignable)', [
   ],
   [
     [
-      makeObjectType('', {
-        a: makeUnionType('', ['a']),
-        b: makeObjectType('', { c: boolean }),
+      makeObjectType({
+        a: makeUnionType(['a']),
+        b: makeObjectType({ c: boolean }),
         c: nullType,
       }),
-      makeObjectType('', {
+      makeObjectType({
         a: atom,
         b: object,
       }),
@@ -243,12 +242,12 @@ typeAssignabilitySuite('custom types (assignable)', [
   ],
   [
     [
-      makeObjectType('', {
-        a: makeUnionType('', ['a']),
+      makeObjectType({
+        a: makeUnionType(['a']),
       }),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
       ]),
     ],
@@ -256,13 +255,13 @@ typeAssignabilitySuite('custom types (assignable)', [
   ],
   [
     [
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
       ]),
-      makeObjectType('', {
-        a: makeUnionType('', ['a']),
+      makeObjectType({
+        a: makeUnionType(['a']),
       }),
     ],
     true,
@@ -270,16 +269,16 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a } | { a: b }` is assignable to `{ a: a | b }`
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
         }),
       ]),
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
       }),
     ],
     true,
@@ -287,16 +286,16 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a } | { a: b }` is assignable to `{ a: a | b | c }`
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
         }),
       ]),
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b', 'c']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b', 'c']),
       }),
     ],
     true,
@@ -304,19 +303,19 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a, b: a } | { a: b, b: b }` is assignable to `{ a: a | b, b: a | b }`
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
-          b: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
+          b: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
-          b: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['b']),
         }),
       ]),
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
-        b: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['a', 'b']),
       }),
     ],
     true,
@@ -324,18 +323,18 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a } | { a: b } | c` is assignable to `{ a: a | b } | c`
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
         }),
         'c',
       ]),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a', 'b']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a', 'b']),
         }),
         'c',
       ]),
@@ -345,15 +344,15 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b }` is assignable to `{ a: a } | { a: b }`
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
       }),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
         }),
       ]),
     ],
@@ -362,18 +361,18 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b }` is assignable to `{ a: a } | { a: b } | { a: c }`
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
       }),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['c']),
+        makeObjectType({
+          a: makeUnionType(['c']),
         }),
       ]),
     ],
@@ -382,18 +381,18 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: { a: a | b } }` is assignable to `{ a: { a: a } | { a: b } }`
-      makeObjectType('', {
-        a: makeObjectType('', {
-          a: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeObjectType({
+          a: makeUnionType(['a', 'b']),
         }),
       }),
-      makeObjectType('', {
-        a: makeUnionType('', [
-          makeObjectType('', {
-            a: makeUnionType('', ['a']),
+      makeObjectType({
+        a: makeUnionType([
+          makeObjectType({
+            a: makeUnionType(['a']),
           }),
-          makeObjectType('', {
-            a: makeUnionType('', ['b']),
+          makeObjectType({
+            a: makeUnionType(['b']),
           }),
         ]),
       }),
@@ -403,15 +402,15 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a } | { a: b, b: c }` is assignable to `{ a: a | b }`
-      makeUnionType('', [
-        makeObjectType('', { a: makeUnionType('', ['a']) }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
-          b: makeUnionType('', ['c']),
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['a']) }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['c']),
         }),
       ]),
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
       }),
     ],
     true,
@@ -419,18 +418,18 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b } | c` is assignable to `{ a: a } | { a: b } | c`
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a', 'b']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a', 'b']),
         }),
         'c',
       ]),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
         }),
         'c',
       ]),
@@ -440,15 +439,15 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b } | { b: a | b }` is assignable to `{ a: a } | { a: b } | { b: a } | { b: b }`
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
-        b: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['a', 'b']),
       }),
-      makeUnionType('', [
-        makeObjectType('', { a: makeUnionType('', ['a']) }),
-        makeObjectType('', { a: makeUnionType('', ['b']) }),
-        makeObjectType('', { b: makeUnionType('', ['a']) }),
-        makeObjectType('', { b: makeUnionType('', ['b']) }),
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['a']) }),
+        makeObjectType({ a: makeUnionType(['b']) }),
+        makeObjectType({ b: makeUnionType(['a']) }),
+        makeObjectType({ b: makeUnionType(['b']) }),
       ]),
     ],
     true,
@@ -456,18 +455,18 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a } | { a: b } | { b: a } | { b: b }` is assignable to `{ a: a | b } | { b: a | b }`
-      makeUnionType('', [
-        makeObjectType('', { a: makeUnionType('', ['a']) }),
-        makeObjectType('', { a: makeUnionType('', ['b']) }),
-        makeObjectType('', { b: makeUnionType('', ['a']) }),
-        makeObjectType('', { b: makeUnionType('', ['b']) }),
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['a']) }),
+        makeObjectType({ a: makeUnionType(['b']) }),
+        makeObjectType({ b: makeUnionType(['a']) }),
+        makeObjectType({ b: makeUnionType(['b']) }),
       ]),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a', 'b']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a', 'b']),
         }),
-        makeObjectType('', {
-          b: makeUnionType('', ['a', 'b']),
+        makeObjectType({
+          b: makeUnionType(['a', 'b']),
         }),
       ]),
     ],
@@ -475,88 +474,88 @@ typeAssignabilitySuite('custom types (assignable)', [
   ],
   [
     [
-      makeFunctionType('', { parameter: something, return: something }),
-      makeFunctionType('', { parameter: something, return: something }),
+      makeFunctionType({ parameter: something, return: something }),
+      makeFunctionType({ parameter: something, return: something }),
     ],
     true,
   ],
   [
     [
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a']),
-        return: makeUnionType('', ['a']),
+      makeFunctionType({
+        parameter: makeUnionType(['a']),
+        return: makeUnionType(['a']),
       }),
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a']),
-        return: makeUnionType('', ['a']),
-      }),
-    ],
-    true,
-  ],
-  [
-    [
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a', 'b', 'c']),
-        return: makeUnionType('', ['d', 'e']),
-      }),
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a', 'b']),
-        return: makeUnionType('', ['d', 'e', 'f']),
+      makeFunctionType({
+        parameter: makeUnionType(['a']),
+        return: makeUnionType(['a']),
       }),
     ],
     true,
   ],
   [
     [
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a']),
-        return: makeUnionType('', ['a']),
+      makeFunctionType({
+        parameter: makeUnionType(['a', 'b', 'c']),
+        return: makeUnionType(['d', 'e']),
       }),
-      makeFunctionType('', { parameter: nothing, return: something }),
+      makeFunctionType({
+        parameter: makeUnionType(['a', 'b']),
+        return: makeUnionType(['d', 'e', 'f']),
+      }),
     ],
     true,
   ],
   [
     [
-      makeFunctionType('', { parameter: something, return: nothing }),
-      makeFunctionType('', { parameter: nothing, return: something }),
+      makeFunctionType({
+        parameter: makeUnionType(['a']),
+        return: makeUnionType(['a']),
+      }),
+      makeFunctionType({ parameter: nothing, return: something }),
+    ],
+    true,
+  ],
+  [
+    [
+      makeFunctionType({ parameter: something, return: nothing }),
+      makeFunctionType({ parameter: nothing, return: something }),
     ],
     true,
   ],
   [
     [
       // `:atom.type ~> a | :atom.type ~> b` is assignable to `a ~> a | b`
-      makeUnionType('', [
-        makeFunctionType('', {
+      makeUnionType([
+        makeFunctionType({
           parameter: atom,
-          return: makeUnionType('', ['a']),
+          return: makeUnionType(['a']),
         }),
-        makeFunctionType('', {
+        makeFunctionType({
           parameter: atom,
-          return: makeUnionType('', ['b']),
+          return: makeUnionType(['b']),
         }),
       ]),
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a']),
-        return: makeUnionType('', ['a', 'b']),
+      makeFunctionType({
+        parameter: makeUnionType(['a']),
+        return: makeUnionType(['a', 'b']),
       }),
     ],
     true,
   ],
   [
     [
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a']),
-        return: makeUnionType('', ['a']),
+      makeFunctionType({
+        parameter: makeUnionType(['a']),
+        return: makeUnionType(['a']),
       }),
-      makeUnionType('', [
-        makeFunctionType('', {
-          parameter: makeUnionType('', ['a']),
-          return: makeUnionType('', ['a']),
+      makeUnionType([
+        makeFunctionType({
+          parameter: makeUnionType(['a']),
+          return: makeUnionType(['a']),
         }),
-        makeFunctionType('', {
-          parameter: makeUnionType('', ['b']),
-          return: makeUnionType('', ['b']),
+        makeFunctionType({
+          parameter: makeUnionType(['b']),
+          return: makeUnionType(['b']),
         }),
       ]),
     ],
@@ -567,15 +566,15 @@ typeAssignabilitySuite('custom types (assignable)', [
   // [
   //   [
   //     // `{ a: a | b, b: c }` is assignable to `{ a: a } | { a: b, b: c }`
-  //     makeObjectType('', {
-  //       a: makeUnionType('', ['a', 'b']),
-  //       b: makeUnionType('', ['c']),
+  //     makeObjectType({
+  //       a: makeUnionType(['a', 'b']),
+  //       b: makeUnionType(['c']),
   //     }),
-  //     makeUnionType('', [
-  //       makeObjectType('', { a: makeUnionType('', ['a']) }),
-  //       makeObjectType('', {
-  //         a: makeUnionType('', ['b']),
-  //         b: makeUnionType('', ['c']),
+  //     makeUnionType([
+  //       makeObjectType({ a: makeUnionType(['a']) }),
+  //       makeObjectType({
+  //         a: makeUnionType(['b']),
+  //         b: makeUnionType(['c']),
   //       }),
   //     ]),
   //   ],
@@ -584,19 +583,16 @@ typeAssignabilitySuite('custom types (assignable)', [
 ])
 
 typeAssignabilitySuite('custom types (not assignable)', [
-  [
-    [makeUnionType('', ['a', 'b', 'c']), makeUnionType('', ['b', 'c', 'd'])],
-    false,
-  ],
-  [[makeUnionType('', ['-1']), naturalNumber], false],
-  [[makeUnionType('', ['-0']), integer], false],
+  [[makeUnionType(['a', 'b', 'c']), makeUnionType(['b', 'c', 'd'])], false],
+  [[makeUnionType(['-1']), naturalNumber], false],
+  [[makeUnionType(['-0']), integer], false],
   [
     [
-      makeObjectType('', {
+      makeObjectType({
         a: atom,
         b: object,
       }),
-      makeObjectType('', {
+      makeObjectType({
         a: atom,
         b: object,
         c: boolean, // required property in target not present in source
@@ -607,18 +603,18 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // `{ a: a | b, b: a | b }` is not assignable to `{ a: a, b: a } | { a: b, b: b }`
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
-        b: makeUnionType('', ['a', 'b']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['a', 'b']),
       }),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
-          b: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
+          b: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
-          b: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['b']),
         }),
       ]),
     ],
@@ -627,18 +623,18 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // `{ a: a, b: b }` is not assignable to `{ a: a, b: z } | { b: b, a: z }`
-      makeObjectType('', {
-        a: makeUnionType('', ['a']),
-        b: makeUnionType('', ['b']),
+      makeObjectType({
+        a: makeUnionType(['a']),
+        b: makeUnionType(['b']),
       }),
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
-          b: makeUnionType('', ['z']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
+          b: makeUnionType(['z']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['z']),
-          b: makeUnionType('', ['b']),
+        makeObjectType({
+          a: makeUnionType(['z']),
+          b: makeUnionType(['b']),
         }),
       ]),
     ],
@@ -647,61 +643,61 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // `{ a: a } | { a: b, b: c }` is not assignable to `{ a: a | b, b: c }`
-      makeUnionType('', [
-        makeObjectType('', {
-          a: makeUnionType('', ['a']),
+      makeUnionType([
+        makeObjectType({
+          a: makeUnionType(['a']),
         }),
-        makeObjectType('', {
-          a: makeUnionType('', ['b']),
-          b: makeUnionType('', ['c']),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['c']),
         }),
       ]),
-      makeObjectType('', {
-        a: makeUnionType('', ['a', 'b']),
-        b: makeUnionType('', ['c']),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['c']),
       }),
     ],
     false,
   ],
   [
     [
-      makeFunctionType('', { parameter: atom, return: atom }),
-      makeFunctionType('', { parameter: object, return: object }),
+      makeFunctionType({ parameter: atom, return: atom }),
+      makeFunctionType({ parameter: object, return: object }),
     ],
     false,
   ],
   [
     [
-      makeFunctionType('', { parameter: atom, return: object }),
-      makeFunctionType('', { parameter: object, return: object }),
+      makeFunctionType({ parameter: atom, return: object }),
+      makeFunctionType({ parameter: object, return: object }),
     ],
     false,
   ],
   [
     [
-      makeFunctionType('', { parameter: object, return: atom }),
-      makeFunctionType('', { parameter: object, return: object }),
+      makeFunctionType({ parameter: object, return: atom }),
+      makeFunctionType({ parameter: object, return: object }),
     ],
     false,
   ],
   [
     [
-      makeFunctionType('', { parameter: atom, return: atom }),
-      makeFunctionType('', { parameter: something, return: something }),
+      makeFunctionType({ parameter: atom, return: atom }),
+      makeFunctionType({ parameter: something, return: something }),
     ],
     false,
   ],
   [
     [
-      makeFunctionType('', { parameter: something, return: something }),
-      makeFunctionType('', { parameter: atom, return: atom }),
+      makeFunctionType({ parameter: something, return: something }),
+      makeFunctionType({ parameter: atom, return: atom }),
     ],
     false,
   ],
   [
     [
-      makeFunctionType('', { parameter: nothing, return: something }),
-      makeFunctionType('', { parameter: something, return: nothing }),
+      makeFunctionType({ parameter: nothing, return: something }),
+      makeFunctionType({ parameter: something, return: nothing }),
     ],
     false,
   ],
@@ -709,19 +705,19 @@ typeAssignabilitySuite('custom types (not assignable)', [
     [
       // `(a ~> a) | (b ~> b)` is not assignable to `(a | b) ~> (a | b)`
       // (a value of the former may only be able to handle `a` as an argument)
-      makeUnionType('', [
-        makeFunctionType('', {
-          parameter: makeUnionType('', ['a']),
-          return: makeUnionType('', ['a']),
+      makeUnionType([
+        makeFunctionType({
+          parameter: makeUnionType(['a']),
+          return: makeUnionType(['a']),
         }),
-        makeFunctionType('', {
-          parameter: makeUnionType('', ['b']),
-          return: makeUnionType('', ['b']),
+        makeFunctionType({
+          parameter: makeUnionType(['b']),
+          return: makeUnionType(['b']),
         }),
       ]),
-      makeFunctionType('', {
-        parameter: makeUnionType('', ['a', 'b']),
-        return: makeUnionType('', ['a', 'b']),
+      makeFunctionType({
+        parameter: makeUnionType(['a', 'b']),
+        return: makeUnionType(['a', 'b']),
       }),
     ],
     false,
@@ -732,11 +728,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `?a ~> :a` is assignable to itself
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
         return: A,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: B,
         return: B,
       }),
@@ -746,11 +742,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `?a ~> :a` is assignable to `(?a: :atom.type) ~> a`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
         return: A,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
       }),
@@ -760,11 +756,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `?a ~> :a` is assignable to `:atom.type ~> :atom.type`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
         return: A,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: atom,
         return: atom,
       }),
@@ -774,11 +770,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `(?a: :atom.type) ~> :a` is assignable to `:atom.type ~> :something.type`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: atom,
         return: something,
       }),
@@ -788,11 +784,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> :something.type`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType('', { a: extendsAnyAtom }),
+        return: makeObjectType({ a: extendsAnyAtom }),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: atom,
         return: something,
       }),
@@ -802,16 +798,16 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `?a ~> { a: :a, b: :atom.type }` is assignable to `(?a: :atom.type) ~> { a: a }`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
-        return: makeObjectType('', {
+        return: makeObjectType({
           a: A,
           b: atom,
         }),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType('', { a: extendsAnyAtom }),
+        return: makeObjectType({ a: extendsAnyAtom }),
       }),
     ],
     true,
@@ -819,13 +815,13 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> { a: :atom.type }`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType('', { a: extendsAnyAtom }),
+        return: makeObjectType({ a: extendsAnyAtom }),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: atom,
-        return: makeObjectType('', { a: atom }),
+        return: makeObjectType({ a: atom }),
       }),
     ],
     true,
@@ -833,14 +829,14 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `{ a: ?a } ~> :a` is assignable to `{ a: (?a: :atom.type) } ~> :a`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: A,
         }),
         return: A,
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: extendsAnyAtom,
         }),
         return: extendsAnyAtom,
@@ -851,19 +847,19 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `{ a: a } ~> { b: a }` is assignable to `{ a: (?a: :atom.type) } ~> { b: a }`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: A,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           b: A,
         }),
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: extendsAnyAtom,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           b: extendsAnyAtom,
         }),
       }),
@@ -873,13 +869,13 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `((?a: :atom.type) | {}) ~> (:a | z)` is assignable to `(?a: (a | b)) ~> (:a | y | z)`
-      makeFunctionType('', {
-        parameter: makeUnionType('', [extendsAnyAtom, object]),
-        return: makeUnionType('', [extendsAnyAtom, 'z']),
+      makeFunctionType({
+        parameter: makeUnionType([extendsAnyAtom, object]),
+        return: makeUnionType([extendsAnyAtom, 'z']),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsUnionOfAtoms,
-        return: makeUnionType('', [extendsUnionOfAtoms, 'y', 'z']),
+        return: makeUnionType([extendsUnionOfAtoms, 'y', 'z']),
       }),
     ],
     true,
@@ -887,11 +883,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `(?a: (:atom.type ~> :something.type)) ~> :a` is assignable to `(?b: (:something.type ~> :atom.type)) ~> :b`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsFunctionFromAtomToValue,
         return: extendsFunctionFromAtomToValue,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsFunctionFromValueToAtom,
         return: extendsFunctionFromValueToAtom,
       }),
@@ -902,16 +898,16 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `(?a: (:atom.type ~> :something.type)) ~> :a` is assignable to `(:something.type ~> :something.type) ~> (:something.type ~> :something.type)`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsFunctionFromAtomToValue,
         return: extendsFunctionFromAtomToValue,
       }),
-      makeFunctionType('', {
-        parameter: makeFunctionType('', {
+      makeFunctionType({
+        parameter: makeFunctionType({
           parameter: something,
           return: something,
         }),
-        return: makeFunctionType('', {
+        return: makeFunctionType({
           parameter: something,
           return: something,
         }),
@@ -922,16 +918,16 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `?a ~> { 0: :a, 1: :a }` is assignable to `(?a: :atom.type) ~> { 0: :a, 1: :atom.type }`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: A,
           1: A,
         }),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: extendsAnyAtom,
           1: atom,
         }),
@@ -942,22 +938,22 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: A,
           1: B,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: B,
           1: A,
         }),
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: C,
           1: D,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: D,
           1: C,
         }),
@@ -968,22 +964,22 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: (?a: :atom.type), 1: (?b: a) } ~> { 0: :b, 1: ?a }`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: A,
           1: B,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: B,
           1: A,
         }),
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: extendsAnyAtom,
           1: extendsSpecificAtom,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: extendsSpecificAtom,
           1: extendsAnyAtom,
         }),
@@ -994,22 +990,22 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: ?b, 1: ?a }` is assignable to `{ 0: ?a, 1: (?b: :a) } ~> { 0: :b, 1: :a }`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: B,
           1: C,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: C,
           1: B,
         }),
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: A,
           1: extendsA,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: extendsA,
           1: A,
         }),
@@ -1020,27 +1016,27 @@ typeAssignabilitySuite('generic function types (assignable)', [
   [
     [
       // `{ a: ?a, b: ?b, c: :atom.type | :b } ~> { b: :a, a: :b, c: :a }` is assignable to `{ a: (?a: :atom.type), b: (?b: :a), c: :b } ~> { b: :a, a: :b | :a, c: :atom.type }`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: A,
           b: B,
-          c: makeUnionType('', [atom, B]),
+          c: makeUnionType([atom, B]),
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           b: A,
           a: B,
           c: A,
         }),
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: extendsAnyAtom,
           b: extendsExtendsAnyAtom,
           c: extendsExtendsAnyAtom,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           b: extendsAnyAtom,
-          a: makeUnionType('', [extendsAnyAtom, extendsExtendsAnyAtom]),
+          a: makeUnionType([extendsAnyAtom, extendsExtendsAnyAtom]),
           c: atom,
         }),
       }),
@@ -1053,11 +1049,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `(?a: :atom.type) ~> :a` is not assignable to `:object.type ~> :object.type`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: object,
         return: object,
       }),
@@ -1067,11 +1063,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `(?a: a) ~> :a` is not assignable to `:atom.type ~> :atom.type`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsSpecificAtom,
         return: extendsSpecificAtom,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: atom,
         return: atom,
       }),
@@ -1081,11 +1077,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `(?a: :atom.type) ~> :a` is not assignable to `?a ~> :a`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
         return: A,
       }),
@@ -1095,11 +1091,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `?a ~> :a` is not assignable to `:something.type ~> :atom.type`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
         return: A,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: something,
         return: atom,
       }),
@@ -1109,13 +1105,13 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `?a ~> { a: :a }` is not assignable to `?a ~> { b: :a }`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
-        return: makeObjectType('', { a: A }),
+        return: makeObjectType({ a: A }),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
-        return: makeObjectType('', { b: A }),
+        return: makeObjectType({ b: A }),
       }),
     ],
     false,
@@ -1123,11 +1119,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `((?a: :atom.type) | {}) ~> (:a | z)` is not assignable to `(?a: :atom.type) ~> :a`
-      makeFunctionType('', {
-        parameter: makeUnionType('', [extendsAnyAtom, object]),
-        return: makeUnionType('', [extendsAnyAtom, 'z']),
+      makeFunctionType({
+        parameter: makeUnionType([extendsAnyAtom, object]),
+        return: makeUnionType([extendsAnyAtom, 'z']),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsAnyAtom,
         return: extendsAnyAtom,
       }),
@@ -1137,22 +1133,22 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `{ 0: ?a, 1: (?b: :a) } ~> { 0: :b, 1: :a }` is not assignable to `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: A,
           1: extendsA,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: extendsA,
           1: A,
         }),
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           0: A,
           1: B,
         }),
-        return: makeObjectType('', {
+        return: makeObjectType({
           0: B,
           1: A,
         }),
@@ -1163,11 +1159,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `(?a: (:something.type ~> :atom.type)) ~> :a` is not assignable to `((?b: :atom.type) ~> :something.type) ~> :b`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsFunctionFromValueToAtom,
         return: extendsFunctionFromValueToAtom,
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: extendsFunctionFromAtomToValue,
         return: extendsFunctionFromAtomToValue,
       }),
@@ -1177,12 +1173,12 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `?a ~> :a` is not assignable to `(:something.type ~> :something.type) ~> :atom.type
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
         return: A,
       }),
-      makeFunctionType('', {
-        parameter: makeFunctionType('', {
+      makeFunctionType({
+        parameter: makeFunctionType({
           parameter: something,
           return: something,
         }),
@@ -1194,14 +1190,14 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `{ a: ?a } ~> :a` is not assignable to `{ b: ?a } ~> :a`
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           a: A,
         }),
         return: A,
       }),
-      makeFunctionType('', {
-        parameter: makeObjectType('', {
+      makeFunctionType({
+        parameter: makeObjectType({
           b: A,
         }),
         return: A,
@@ -1212,15 +1208,15 @@ typeAssignabilitySuite('generic function types (not assignable)', [
   [
     [
       // `?a ~> { a: :a }` is not assignable to `?a ~> { b: :a }`
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
-        return: makeObjectType('', {
+        return: makeObjectType({
           a: A,
         }),
       }),
-      makeFunctionType('', {
+      makeFunctionType({
         parameter: A,
-        return: makeObjectType('', {
+        return: makeObjectType({
           b: A,
         }),
       }),
@@ -1231,34 +1227,34 @@ typeAssignabilitySuite('generic function types (not assignable)', [
 
 typeAssignabilitySuite('union to type parameter (assignable)', [
   // `?a | :nothing.type` is assignable to `?a`
-  [[makeUnionType('', [A]), A], true],
+  [[makeUnionType([A]), A], true],
   // `?a | :a` is assignable to `?a`
-  [[makeUnionType('', [A, A]), A], true],
+  [[makeUnionType([A, A]), A], true],
   // `?a | :nothing.type` is assignable to `?a | :a`
-  [[makeUnionType('', [A]), makeUnionType('', [A, A])], true],
+  [[makeUnionType([A]), makeUnionType([A, A])], true],
   // `?a | :a` is assignable to `?a | :a`
-  [[makeUnionType('', [A, A]), makeUnionType('', [A, A])], true],
+  [[makeUnionType([A, A]), makeUnionType([A, A])], true],
   // `?a | :nothing.type` is assignable to `?a | ?b`
-  [[makeUnionType('', [A]), makeUnionType('', [A, B])], true],
+  [[makeUnionType([A]), makeUnionType([A, B])], true],
   // `(?a: :atom.type) | :nothing.type` is assignable to `(?a: :atom.type)`
-  [[makeUnionType('', [extendsAnyAtom]), extendsAnyAtom], true],
+  [[makeUnionType([extendsAnyAtom]), extendsAnyAtom], true],
 ])
 
 typeAssignabilitySuite('union to type parameter (not assignable)', [
   // `1 | :nothing.type` is not assignable to `?a`
-  [[makeUnionType('', ['1']), A], false],
+  [[makeUnionType(['1']), A], false],
   // `1 | :nothing.type` is not assignable to `?a: :atom.type`
-  [[makeUnionType('', ['1']), extendsAnyAtom], false],
+  [[makeUnionType(['1']), extendsAnyAtom], false],
   // `a | :nothing.type` is not assignable to `?a: a`
-  [[makeUnionType('', ['a']), extendsSpecificAtom], false],
+  [[makeUnionType(['a']), extendsSpecificAtom], false],
   // `:atom.type | :nothing.type` is not assignable to `?a`
-  [[makeUnionType('', [atom]), A], false],
+  [[makeUnionType([atom]), A], false],
   // `:object.type | :nothing.type` is not assignable to `?a`
-  [[makeUnionType('', [object]), A], false],
+  [[makeUnionType([object]), A], false],
   // `?b | :nothing.type` is not assignable to `?a`
-  [[makeUnionType('', [B]), A], false],
+  [[makeUnionType([B]), A], false],
   // `?a | hello` is not assignable to `?a`
-  [[makeUnionType('', [A, 'hello']), A], false],
+  [[makeUnionType([A, 'hello']), A], false],
   // `?a | ?b` is not assignable to `?a`
-  [[makeUnionType('', [A, B]), A], false],
+  [[makeUnionType([A, B]), A], false],
 ])

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -23,9 +23,9 @@ export const isAssignable = ({
   readonly target: Type | Atom
 }): boolean => {
   const source =
-    typeof rawSource === 'string' ? makeUnionType('', [rawSource]) : rawSource
+    typeof rawSource === 'string' ? makeUnionType([rawSource]) : rawSource
   const target =
-    typeof rawTarget === 'string' ? makeUnionType('', [rawTarget]) : rawTarget
+    typeof rawTarget === 'string' ? makeUnionType([rawTarget]) : rawTarget
 
   return (
     source === target || // in this case there's no reason to spend time checking structural assignability
@@ -215,7 +215,7 @@ export const isAssignable = ({
                         target: targetMember,
                         source:
                           typeof sourceMember !== 'string' ? sourceMember : (
-                            makeUnionType(sourceMember, [sourceMember])
+                            makeUnionType([sourceMember])
                           ),
                       })
                     ) {
@@ -360,12 +360,12 @@ export const simplifyUnionType = (typeToSimplify: UnionType): UnionType => {
           )
         })
         const propertyTypeAsUnion = excludeRedundantUnionTypeMembers(
-          makeUnionType('', typesForThisProperty),
+          makeUnionType(typesForThisProperty),
         )
         return [key, propertyTypeAsUnion] as const
       }),
     )
-    const mergedObjectType = makeObjectType('', mergedObjectTypeChildren)
+    const mergedObjectType = makeObjectType(mergedObjectTypeChildren)
 
     // Remove all `typesToMerge` from `canonicalizedTargetMembers`.
     for (const typeWhichHasBeenMerged of typesToMerge) {
@@ -376,7 +376,6 @@ export const simplifyUnionType = (typeToSimplify: UnionType): UnionType => {
 
   return excludeRedundantUnionTypeMembers({
     kind: 'union',
-    name: typeToSimplify.name,
     members: canonicalizedTargetMembers,
   })
 }
@@ -384,7 +383,6 @@ export const simplifyUnionType = (typeToSimplify: UnionType): UnionType => {
 const excludeRedundantUnionTypeMembers = (type: UnionType) => {
   const membersAsArray = [...type.members]
   return makeUnionType(
-    type.name,
     membersAsArray.filter(
       (possiblyRedundantMember, index) =>
         // If `possiblyRedundantMember` is assignable to any other member,

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -4,7 +4,6 @@ import type { Atom } from '../../parsing.js'
 import type { TypeSymbol } from '../semantic-graph.js'
 
 export type FunctionType = {
-  readonly name: string
   readonly kind: 'function'
   readonly signature: {
     readonly parameter: Type
@@ -13,12 +12,10 @@ export type FunctionType = {
 }
 
 export const makeFunctionType = <Signature extends FunctionType['signature']>(
-  name: string,
   signature: Signature,
 ): FunctionType & {
   readonly signature: Signature
 } => ({
-  name,
   kind: 'function',
   signature,
 })
@@ -28,40 +25,33 @@ export const makeFunctionType = <Signature extends FunctionType['signature']>(
  * can't be fully resolved because its key/condition contains a type parameter.
  */
 export type IndexedAccessType = {
-  readonly name: string
   readonly kind: 'indexedAccess'
   readonly object: Type
   readonly key: Type
 }
 
 export const makeIndexedAccessType = (
-  name: string,
   object: Type,
   key: Type,
 ): IndexedAccessType => ({
-  name,
   kind: 'indexedAccess',
   object,
   key,
 })
 
 export type ObjectType = {
-  readonly name: string
   readonly kind: 'object'
   readonly children: Readonly<Record<Atom, Type>>
 }
 
 export const makeObjectType = <Children extends Readonly<Record<Atom, Type>>>(
-  name: string,
   children: Children,
 ): ObjectType & { readonly children: Children } => ({
-  name,
   kind: 'object',
   children,
 })
 
 export type OpaqueType = {
-  readonly name: string
   readonly symbol: TypeSymbol
   readonly kind: 'opaque'
   readonly isAssignableFrom: (source: Type) => boolean
@@ -69,7 +59,6 @@ export type OpaqueType = {
 }
 
 export const makeOpaqueType = (
-  name: string,
   symbol: TypeSymbol,
   subtyping: {
     readonly isAssignableFromLiteralType: (literalType: string) => boolean
@@ -89,7 +78,6 @@ export const makeOpaqueType = (
   ),
 ): OpaqueType => {
   const self: OpaqueType = {
-    name,
     symbol,
     kind: 'opaque',
     isAssignableFrom: source =>
@@ -203,7 +191,6 @@ export const isTypeParameter = (value: unknown): value is TypeParameter => {
 }
 
 export type UnionType = {
-  readonly name: string
   readonly kind: 'union'
   readonly members: ReadonlySet<
     Atom | Exclude<Type, UnionType> // unions are always flat
@@ -218,10 +205,8 @@ type SpecificUnionType<Member extends Atom | Exclude<Type, UnionType>> = Omit<
 }
 
 export const makeUnionType = <Member extends Atom | Exclude<Type, UnionType>>(
-  name: string,
   members: readonly Member[],
 ): SpecificUnionType<Member> => ({
-  name,
   kind: 'union',
   members: new Set(members),
 })

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -185,7 +185,7 @@ const inferTypeImplementation = (
               descendantContext(['1', 'body']),
             ),
             returnType =>
-              makeFunctionType('', {
+              makeFunctionType({
                 parameter: parameterType,
                 return: returnType,
               }),
@@ -403,8 +403,7 @@ const inferTypeImplementation = (
             return either.flatMap(inferThen(), thenType =>
               either.map(inferElse(), elseType =>
                 makeIndexedAccessType(
-                  '',
-                  makeObjectType('', { false: elseType, true: thenType }),
+                  makeObjectType({ false: elseType, true: thenType }),
                   conditionType,
                 ),
               ),
@@ -414,10 +413,7 @@ const inferTypeImplementation = (
               type.kind === 'union' ? [...type.members] : [type]
             return either.flatMap(inferThen(), thenType =>
               either.map(inferElse(), elseType =>
-                makeUnionType('', [
-                  ...membersOf(thenType),
-                  ...membersOf(elseType),
-                ]),
+                makeUnionType([...membersOf(thenType), ...membersOf(elseType)]),
               ),
             )
           }
@@ -449,7 +445,7 @@ const inferTypeImplementation = (
             ),
           ),
         ),
-        entries => makeObjectType('', Object.fromEntries(entries)),
+        entries => makeObjectType(Object.fromEntries(entries)),
       ),
     )
   } else {

--- a/src/language/semantics/type-system/type-utilities.test.ts
+++ b/src/language/semantics/type-system/type-utilities.test.ts
@@ -46,45 +46,42 @@ applyKeyPathSuite('applyKeyPathToType with empty key path', [
   [[nothing, []], stringifyTypeForEndUser(nothing)],
   [[something, []], stringifyTypeForEndUser(something)],
   [
-    [makeObjectType('', { a: atom }), []],
-    stringifyTypeForEndUser(makeObjectType('', { a: atom })),
+    [makeObjectType({ a: atom }), []],
+    stringifyTypeForEndUser(makeObjectType({ a: atom })),
   ],
   [
-    [makeFunctionType('', { parameter: atom, return: something }), []],
+    [makeFunctionType({ parameter: atom, return: something }), []],
     stringifyTypeForEndUser(
-      makeFunctionType('', { parameter: atom, return: something }),
+      makeFunctionType({ parameter: atom, return: something }),
     ),
   ],
 ])
 
 applyKeyPathSuite('applyKeyPathToType with object types', [
   [
-    [makeObjectType('', { a: atom, b: integer }), ['a']],
+    [makeObjectType({ a: atom, b: integer }), ['a']],
     stringifyTypeForEndUser(atom),
   ],
   [
-    [makeObjectType('', { a: atom, b: integer }), ['b']],
+    [makeObjectType({ a: atom, b: integer }), ['b']],
     stringifyTypeForEndUser(integer),
   ],
-  [[makeObjectType('', { a: atom }), ['z']], stringifyTypeForEndUser(nothing)],
+  [[makeObjectType({ a: atom }), ['z']], stringifyTypeForEndUser(nothing)],
   [
     [
-      makeObjectType('', {
-        a: makeObjectType('', { b: makeUnionType('', ['hello']) }),
+      makeObjectType({
+        a: makeObjectType({ b: makeUnionType(['hello']) }),
       }),
       ['a', 'b'],
     ],
-    stringifyTypeForEndUser(makeUnionType('', ['hello'])),
+    stringifyTypeForEndUser(makeUnionType(['hello'])),
   ],
-  [
-    [makeObjectType('', { a: atom }), ['a', 'b']],
-    stringifyTypeForEndUser(nothing),
-  ],
+  [[makeObjectType({ a: atom }), ['a', 'b']], stringifyTypeForEndUser(nothing)],
 ])
 
 applyKeyPathSuite('applyKeyPathToType with non-object types', [
   [
-    [makeFunctionType('', { parameter: atom, return: something }), ['a']],
+    [makeFunctionType({ parameter: atom, return: something }), ['a']],
     stringifyTypeForEndUser(nothing),
   ],
   [[atom, ['a']], stringifyTypeForEndUser(nothing)],
@@ -95,39 +92,33 @@ applyKeyPathSuite('applyKeyPathToType with non-object types', [
 applyKeyPathSuite('applyKeyPathToType with union types', [
   [
     [
-      makeUnionType('', [
-        makeObjectType('', { a: makeUnionType('', ['x']) }),
-        makeObjectType('', { a: makeUnionType('', ['y']) }),
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['x']) }),
+        makeObjectType({ a: makeUnionType(['y']) }),
       ]),
       ['a'],
     ],
-    stringifyTypeForEndUser(makeUnionType('', ['x', 'y'])),
+    stringifyTypeForEndUser(makeUnionType(['x', 'y'])),
   ],
   [
     [
-      makeUnionType('', [
-        makeObjectType('', { a: makeUnionType('', ['x']) }),
-        'some_atom',
-      ]),
+      makeUnionType([makeObjectType({ a: makeUnionType(['x']) }), 'some_atom']),
       ['a'],
     ],
-    stringifyTypeForEndUser(makeUnionType('', ['x'])),
+    stringifyTypeForEndUser(makeUnionType(['x'])),
   ],
   [
     [
-      makeUnionType('', [
-        makeObjectType('', { b: atom }),
-        makeObjectType('', { c: atom }),
-      ]),
+      makeUnionType([makeObjectType({ b: atom }), makeObjectType({ c: atom })]),
       ['a'],
     ],
     stringifyTypeForEndUser(nothing),
   ],
   [
     [
-      makeUnionType('', [
-        makeObjectType('', { a: integer }),
-        makeFunctionType('', { parameter: atom, return: atom }),
+      makeUnionType([
+        makeObjectType({ a: integer }),
+        makeFunctionType({ parameter: atom, return: atom }),
       ]),
       ['a'],
     ],
@@ -151,12 +142,20 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [[something, atom], new Map()],
 
-  [[makeObjectType('', { a: A }), atom], new Map()],
+  [[makeObjectType({ a: A }), atom], new Map()],
+
+  [
+    [makeObjectType({ a: A, b: B }), makeObjectType({ a: atom, b: integer })],
+    new Map([
+      [A, atom],
+      [B, integer],
+    ]),
+  ],
 
   [
     [
-      makeObjectType('', { a: A, b: B }),
-      makeObjectType('', { a: atom, b: integer }),
+      makeFunctionType({ parameter: A, return: B }),
+      makeFunctionType({ parameter: atom, return: integer }),
     ],
     new Map([
       [A, atom],
@@ -166,19 +165,8 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [
     [
-      makeFunctionType('', { parameter: A, return: B }),
-      makeFunctionType('', { parameter: atom, return: integer }),
-    ],
-    new Map([
-      [A, atom],
-      [B, integer],
-    ]),
-  ],
-
-  [
-    [
-      makeFunctionType('', { parameter: A, return: A }),
-      makeFunctionType('', { parameter: atom, return: integer }),
+      makeFunctionType({ parameter: A, return: A }),
+      makeFunctionType({ parameter: atom, return: integer }),
     ],
     // The first occurrence should be used in situations like this. In real code
     // this will likely result in a type error later.
@@ -186,10 +174,7 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
   ],
 
   [
-    [
-      makeObjectType('', { a: A, b: A }),
-      makeObjectType('', { a: atom, b: integer }),
-    ],
+    [makeObjectType({ a: A, b: A }), makeObjectType({ a: atom, b: integer })],
     // The first occurrence should be used in situations like this. In real code
     // this will likely result in a type error later.
     new Map([[A, atom]]),
@@ -197,35 +182,33 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [[extendsAnyAtom, object], new Map()],
 
-  [[makeUnionType('', [A, atom]), object], new Map([[A, object]])],
+  [[makeUnionType([A, atom]), object], new Map([[A, object]])],
 
-  [[makeUnionType('', [A, atom]), something], new Map([[A, something]])],
+  [[makeUnionType([A, atom]), something], new Map([[A, something]])],
 
-  [[makeUnionType('', [A, atom]), atom], new Map([[A, atom]])],
+  [[makeUnionType([A, atom]), atom], new Map([[A, atom]])],
 
   [
-    [makeUnionType('', [A, object]), makeUnionType('', ['specific atom'])],
-    new Map([[A, makeUnionType('', ['specific atom'])]]),
+    [makeUnionType([A, object]), makeUnionType(['specific atom'])],
+    new Map([[A, makeUnionType(['specific atom'])]]),
   ],
 
   [
     [
-      makeUnionType('', [extendsAnyAtom, object]),
-      makeUnionType('', ['specific atom', object]),
+      makeUnionType([extendsAnyAtom, object]),
+      makeUnionType(['specific atom', object]),
     ],
-    new Map([
-      [extendsAnyAtom, makeUnionType('specific atom', ['specific atom'])],
-    ]),
+    new Map([[extendsAnyAtom, makeUnionType(['specific atom'])]]),
   ],
 
-  [[makeUnionType('', [extendsAnyAtom, object]), object], new Map()],
+  [[makeUnionType([extendsAnyAtom, object]), object], new Map()],
 
   [[option(A), option(naturalNumber)], new Map([[A, naturalNumber]])],
 
   [
     [
-      makeFunctionType('', { parameter: A, return: option(B) }),
-      makeFunctionType('', {
+      makeFunctionType({ parameter: A, return: option(B) }),
+      makeFunctionType({
         parameter: atom,
         return: option(naturalNumber),
       }),
@@ -258,14 +241,14 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
 
   [['a', integer], '(?a: :integer.type)'],
 
-  [['a', makeUnionType('', ['foo', 'bar'])], '(?a: foo | bar)'],
+  [['a', makeUnionType(['foo', 'bar'])], '(?a: foo | bar)'],
 
   [['a', something], '?a'],
 
   [
     [
       'x',
-      makeObjectType('', {
+      makeObjectType({
         a: integer,
         b: atom,
       }),
@@ -276,8 +259,8 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType('', {
-        a: makeObjectType('', { b: atom }),
+      makeObjectType({
+        a: makeObjectType({ b: atom }),
       }),
     ],
     '{ a: { b: (?"x.a.b": :atom.type) } }',
@@ -286,19 +269,19 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType('', {
-        callback: makeFunctionType('', { parameter: atom, return: integer }),
+      makeObjectType({
+        callback: makeFunctionType({ parameter: atom, return: integer }),
       }),
     ],
     '{ callback: (?"x.callback.#parameter": :atom.type) ~> (?"x.callback.#return": :integer.type) }',
   ],
 
-  [['empty', makeObjectType('', {})], '{}'],
+  [['empty', makeObjectType({})], '{}'],
 
-  [['identity', makeFunctionType('', { parameter: A, return: A })], '?a ~> :a'],
+  [['identity', makeFunctionType({ parameter: A, return: A })], '?a ~> :a'],
 
   [
-    ['wrap', makeObjectType('', { value: A })],
+    ['wrap', makeObjectType({ value: A })],
     `{ value: ${stringifyTypeForEndUser(A)} }`,
   ],
 ])

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -109,17 +109,15 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
               )
             } else {
               return makeIndexedAccessType(
-                '',
                 type,
-                typeof key === 'string' ? makeUnionType('', [key]) : key,
+                typeof key === 'string' ? makeUnionType([key]) : key,
               )
             }
           },
-          makeIndexedAccessType('', type, firstKey),
+          makeIndexedAccessType(type, firstKey),
         )
       case 'union':
         return makeUnionType(
-          '',
           // Flatten to avoid nested unions.
           [...firstKey.members].flatMap(firstKeyMember => {
             const typeForThisPossibility = applyKeyPathToType(type, [
@@ -143,7 +141,7 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
         } else {
           switch (firstKey) {
             case functionParameterKey:
-              return makeFunctionType(type.name, {
+              return makeFunctionType({
                 parameter: applyKeyPathToType(
                   type.signature.parameter,
                   remainingKeyPath,
@@ -151,7 +149,7 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
                 return: type.signature.return,
               })
             case functionReturnKey:
-              return makeFunctionType(type.name, {
+              return makeFunctionType({
                 parameter: type.signature.parameter,
                 return: applyKeyPathToType(
                   type.signature.return,
@@ -204,7 +202,6 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
       },
       union: type => {
         return makeUnionType(
-          type.name,
           [...type.members].flatMap(member => {
             if (typeof member === 'string') {
               return []
@@ -249,7 +246,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
 ): Type =>
   matchTypeFormat(type, {
     function: (type): Type =>
-      makeFunctionType(type.name, {
+      makeFunctionType({
         parameter: genericizeFunctionParameterAnnotationAtKeyPath(
           parameterName,
           type.signature.parameter,
@@ -263,7 +260,6 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
       }),
     object: type =>
       makeObjectType(
-        type.name,
         Object.fromEntries(
           Object.entries(type.children).map(
             ([key, child]) =>
@@ -341,7 +337,7 @@ const containedTypeParametersImplementation = (
               stringifyTypeKeyPathForEndUser(root),
               {
                 keyPath: root,
-                typeParameters: makeUnionType('', [type]),
+                typeParameters: makeUnionType([type]),
               },
             ],
           ]),
@@ -535,9 +531,7 @@ export const getTypesForTypeParameters = ({
             // of `(A <: atom) | object` and an `argumentType` of `atom |
             // object`, `A` should be inferred as `atom`.
             [...argumentType.members].flatMap((member): readonly Type[] =>
-              typeof member === 'string' ?
-                [makeUnionType(member, [member])]
-              : [member],
+              typeof member === 'string' ? [makeUnionType([member])] : [member],
             )
           : []),
         ] as const
@@ -592,7 +586,7 @@ export const supplyTypeArgument = (
   } else {
     return matchTypeFormat(type, {
       function: type =>
-        makeFunctionType(type.name, {
+        makeFunctionType({
           parameter: supplyTypeArgument(
             type.signature.parameter,
             typeParameter,
@@ -613,7 +607,7 @@ export const supplyTypeArgument = (
             typeArgument,
           )
         }
-        return makeObjectType(type.name, substitutedChildren)
+        return makeObjectType(substitutedChildren)
       },
       indexedAccess: type =>
         either.match(
@@ -636,7 +630,6 @@ export const supplyTypeArgument = (
         type.identity === typeParameter.identity ? typeArgument : type,
       union: type =>
         makeUnionType(
-          type.name,
           [...type.members].flatMap(member => {
             if (typeof member === 'string') {
               return member
@@ -684,7 +677,6 @@ export const updateTypeAtKeyPathIfValid = (
     // If the key path is empty, this is the type to operate on.
     if (type.kind === 'union') {
       return makeUnionType(
-        type.name,
         [...type.members].flatMap(member => {
           if (typeof member === 'string') {
             return member
@@ -706,7 +698,7 @@ export const updateTypeAtKeyPathIfValid = (
       function: type => {
         switch (firstKey) {
           case functionParameterKey:
-            return makeFunctionType(type.name, {
+            return makeFunctionType({
               parameter: updateTypeAtKeyPathIfValid(
                 type.signature.parameter,
                 remainingKeyPath,
@@ -715,7 +707,7 @@ export const updateTypeAtKeyPathIfValid = (
               return: type.signature.return,
             })
           case functionReturnKey:
-            return makeFunctionType(type.name, {
+            return makeFunctionType({
               return: updateTypeAtKeyPathIfValid(
                 type.signature.return,
                 remainingKeyPath,
@@ -734,7 +726,7 @@ export const updateTypeAtKeyPathIfValid = (
           if (next === undefined) {
             return type
           } else {
-            return makeObjectType(type.name, {
+            return makeObjectType({
               ...type.children,
               [firstKey]: updateTypeAtKeyPathIfValid(
                 next,
@@ -764,7 +756,6 @@ export const updateTypeAtKeyPathIfValid = (
       },
       union: type =>
         makeUnionType(
-          type.name,
           [...type.members].flatMap(member => {
             if (typeof member === 'string') {
               return []
@@ -791,7 +782,6 @@ export const literalTypeFromSemanticGraph = (
 ): Either<Bug, Type> => {
   if (typeof node === 'string') {
     return either.makeRight({
-      name: '',
       kind: 'union',
       members: new Set([node]),
     })
@@ -806,7 +796,6 @@ export const literalTypeFromSemanticGraph = (
     }
   } else if (typeof node === 'function') {
     return either.makeRight({
-      name: '',
       kind: 'function',
       signature: node.signature,
     })
@@ -821,7 +810,6 @@ export const literalTypeFromSemanticGraph = (
         ),
         memberTypes =>
           makeUnionType(
-            '',
             memberTypes.flatMap(memberType =>
               memberType.kind === 'union' ?
                 [...memberType.members]
@@ -849,7 +837,7 @@ export const literalTypeFromSemanticGraph = (
             ]),
           ),
         ),
-        entries => makeObjectType('', Object.fromEntries(entries)),
+        entries => makeObjectType(Object.fromEntries(entries)),
       )
     }
   }
@@ -869,7 +857,7 @@ const mergeTypeParametersByKeyPath = (
       // Merge all type(s) at this key path into a (simplified) union.
       const supposedTypeParametersAsArray = [
         ...simplifyUnionType(
-          makeUnionType(typeParameters.name, [
+          makeUnionType([
             ...typeParameters.members,
             ...valueFromB.typeParameters.members,
           ]),
@@ -889,10 +877,7 @@ const mergeTypeParametersByKeyPath = (
 
       result.set(key, {
         keyPath,
-        typeParameters: makeUnionType(
-          typeParameters.name,
-          supposedTypeParametersAsArray,
-        ),
+        typeParameters: makeUnionType(supposedTypeParametersAsArray),
       })
     }
   }
@@ -960,7 +945,7 @@ const atomKeyPathComponentFromType = (
                 ...type.constraint,
                 assignableTo:
                   typeof validAssignableTo === 'string' ?
-                    makeUnionType('', [validAssignableTo])
+                    makeUnionType([validAssignableTo])
                   : validAssignableTo,
               },
             }),
@@ -1009,7 +994,7 @@ const asUnionWithLiteralAtomMembers = (
 
   return !isAtomUnion ?
       option.none
-    : option.makeSome(makeUnionType(simplifiedType.name, atomMembers))
+    : option.makeSome(makeUnionType(atomMembers))
 }
 
 const stringifyKeyPathComponentForEndUser = (


### PR DESCRIPTION
Ever since [`showType` was reimplemented](https://github.com/mkantor/please-lang-prototype/pull/177) I haven't really been using these type names, and they weren't aligned with anything people could actually talk about from Please.

I may in the future want to be cleverer about how types are referred to in error messages & such (e.g. using lookup syntax instead of showing the full structural type when that makes sense), but this `.name` property wouldn't be the right foundation for that.