### PR TITLE
Support indexing into object-constrained type parameters

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1229,4 +1229,14 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `{
+      lookup_within: (object: (?o: { a: :something.type })) => :object.a
+      :lookup_within(@runtime { _ => { a: true } }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -22,6 +22,7 @@ import {
   makeTypeParameter,
   makeUnionType,
   matchTypeFormat,
+  type IndexedAccessType,
   type ObjectType,
   type Type,
   type TypeParameter,
@@ -97,25 +98,7 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
   } else if (typeof firstKey === 'object') {
     switch (firstKey.kind) {
       case 'parameter':
-        return remainingKeyPath.reduce(
-          (type, key) => {
-            if (typeof key === 'symbol') {
-              // TODO: Seems like this should either be allowed
-              // (`IndexedAccessType['key']` could be typed as
-              // `TypeKeyPath[number]`?) or handled better (this function could
-              // return an `Either`).
-              throw new Error(
-                'Type key path contained a symbol following a parameter. This is a bug!',
-              )
-            } else {
-              return makeIndexedAccessType(
-                type,
-                typeof key === 'string' ? makeUnionType([key]) : key,
-              )
-            }
-          },
-          makeIndexedAccessType(type, firstKey),
-        )
+        return nestedIndexedAccess(type, [firstKey, ...remainingKeyPath])
       case 'union':
         return makeUnionType(
           // Flatten to avoid nested unions.
@@ -180,9 +163,21 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
       opaque: _type => types.nothing,
       parameter: type => {
         if (typeof firstKey === 'string') {
-          // Type parameters do not have properties.
-          // TODO: Though perhaps I should drill into the constraint here?
-          return types.nothing
+          // Indexing into a type parameter yields a stuck (object-neutral)
+          // indexed access, kept dependent on the parameter so it can be reduced
+          // once the parameter is instantiated. This is only done when the key
+          // path is valid for the parameter's constraint; otherwise the property
+          // genuinely doesn't exist.
+          const typeAtKeyPathInConstraint = applyKeyPathToType(
+            type.constraint.assignableTo,
+            keyPath,
+          )
+          return (
+              typeAtKeyPathInConstraint.kind === 'union' &&
+                typeAtKeyPathInConstraint.members.size === 0
+            ) ?
+              types.nothing
+            : nestedIndexedAccess(type, [firstKey, ...remainingKeyPath])
         } else {
           switch (firstKey) {
             case typeParameterAssignableToConstraintKey:
@@ -995,6 +990,40 @@ const asUnionWithLiteralAtomMembers = (
   return !isAtomUnion ?
       option.none
     : option.makeSome(makeUnionType(atomMembers))
+}
+
+const indexedAccessFromTypeKeyPathEntry = (
+  object: Type,
+  key: TypeKeyPath[number],
+): IndexedAccessType => {
+  if (typeof key === 'symbol') {
+    // TODO: Seems like this should either be allowed
+    // (`IndexedAccessType['key']` could be typed as `TypeKeyPath[number]`?) or
+    // handled better (this function could return an `Either`).
+    throw new Error(
+      'Type key path contained a symbol following a parameter. This is a bug!',
+    )
+  } else {
+    return makeIndexedAccessType(
+      object,
+      typeof key === 'string' ? makeUnionType([key]) : key,
+    )
+  }
+}
+
+/**
+ * Build a left-nested `IndexedAccessType` projecting `keyPath` out of `object`.
+ */
+const nestedIndexedAccess = (
+  object: Type,
+  keyPath: readonly [TypeKeyPath[number], ...TypeKeyPath],
+): IndexedAccessType => {
+  const [firstKey, ...remainingKeyPath] = keyPath
+  const firstIndexedAccess = indexedAccessFromTypeKeyPathEntry(object, firstKey)
+  return remainingKeyPath.reduce(
+    indexedAccessFromTypeKeyPathEntry,
+    firstIndexedAccess,
+  )
 }
 
 const stringifyKeyPathComponentForEndUser = (

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -504,7 +504,9 @@ export const getTypesForTypeParameters = ({
 
       opaque: _ => new Map(),
 
-      // TODO: Can function parameter types contain stuck indexed access types?
+      // TODO: I don't think this case is solvable when the `IndexedAccessType`
+      // is stuck on its key (e.g. `(?a: :b.:c)`), but when the key is concrete
+      // I could perhaps use it to drill into the argument type. Is that sound?
       indexedAccess: _ => new Map(),
 
       parameter: parameterType =>


### PR DESCRIPTION
Consider this function:

```plz
(object: (?o: { a: :something.type })) => :object.a
```

Its body indexes into a type parameter constrained to a type which definitely has a property named `a` and therefore should be allowed. However, `@index`'s static analysis was rejecting it.

It's now accepted and inferred as an `IndexedAccessType`, keeping the projection dependent on the type parameter so it can be reduced when the parameter is instantiated at a call site.