### PR TITLE
Implement application types

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1317,4 +1317,42 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `{
+      lookup_foo: (f: ?a ~> (?b: { foo: :something.type })) => :f(true).foo
+      :lookup_foo(@runtime { _ => _ => { foo: 42 } }) ~ 42
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      lookup_foo: (f: ?a ~> (?b: { foo: :something.type })) => :f(true).foo
+      :lookup_foo(@runtime { _ => _ => { foo: 42 } }) ~ 43
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ lookup_foo: (f: ?a ~> (?b: { foo: :something.type })) => :f(true).bar }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ outer: (f: ?a ~> ?b) => ((g: :f(true)) => :g)(:f(true)) }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1293,4 +1293,28 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      apply_to_true: (f: ?a ~> ?b) => :f(true)
+      first: x => _y => :x
+      :apply_to_true(@runtime { _ => :first }) ~ (:something.type ~> true)
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      apply_to_true: (f: ?a ~> ?b) => :f(true)
+      first: x => _y => :x
+      :apply_to_true(@runtime { _ => :first }) ~ (:something.type ~> false)
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1261,4 +1261,36 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `{
+      apply_to_true: (f: (?g: :something.type ~> :something.type)) => :f(true)
+      :apply_to_true(@runtime { _ => a => :a }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      apply_to_true: (f: (?g: :something.type ~> :something.type)) => :f(true)
+      :apply_to_true(@runtime { _ => a => :a }) ~ false
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      apply_to_true: (f: (?g: :something.type ~> :something.type)) => :f(true)
+      :apply_to_true(@runtime { _ => _ => false }) ~ false
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1239,4 +1239,26 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `{
+      apply_to_true: (f: ?a ~> ?b) => :f(true)
+      :apply_to_true(@runtime { _ => a => :a }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      apply_to_true: (f: ?a ~> ?b) => :f(true)
+      :apply_to_true(@runtime { _ => a => :a }) ~ false
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -1,6 +1,8 @@
 import either, { type Either } from '@matt.kantor/either'
+import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  applicableFunctionSignature,
   containsAnyUnelaboratedNodes,
   getTypesForTypeParameters,
   inferType,
@@ -66,16 +68,15 @@ export const applyKeywordHandler: KeywordHandler = (
           location: [...context.location, '1', 'function'],
         }),
         functionType =>
-          functionType.kind === 'function' ?
-            checkArgumentType(
-              argument,
-              functionType.signature.parameter,
-              context,
-            )
-          : either.makeLeft({
-              kind: 'invalidExpression',
-              message: `only functions can be applied, but got a \`${stringifyTypeForEndUser(functionType)}\``,
-            }),
+          option.match(applicableFunctionSignature(functionType), {
+            some: signature =>
+              checkArgumentType(argument, signature.parameter, context),
+            none: _ =>
+              either.makeLeft({
+                kind: 'invalidExpression',
+                message: `only functions can be applied, but got a \`${stringifyTypeForEndUser(functionType)}\``,
+              }),
+          }),
       )
 
       return either.flatMap(

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -105,6 +105,7 @@ export {
   type SemanticGraph,
 } from './semantics/semantic-graph.js'
 export {
+  applicableFunctionSignature,
   applyKeyPathToType,
   containedTypeParameters,
   getTypesForTypeParameters,

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -8,6 +8,7 @@ import type {
 import type { Atom, Molecule, SyntaxTree } from '../parsing.js'
 import {
   ignoredKey,
+  makeApplyExpression,
   makeFunctionExpression,
   makeIndexExpression,
   makeLookupExpression,
@@ -315,6 +316,11 @@ export const typeToSemanticGraph = (
   const recurseWithSameTypeParameters = (type: Type) =>
     typeToSemanticGraph(type, alreadyIntroducedTypeParameterIdentities)
   return matchTypeFormat(type, {
+    application: type =>
+      makeApplyExpression({
+        function: recurseWithSameTypeParameters(type.function),
+        argument: recurseWithSameTypeParameters(type.argument),
+      }),
     function: type =>
       makeFunctionExpression(
         objectNodeFromOrderedEntries([

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -6,6 +6,7 @@ export {
   resolveParameterTypes,
 } from './type-system/type-inference.js'
 export {
+  applicableFunctionSignature,
   applyKeyPathToType,
   containedTypeParameters,
   functionParameterKey,

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -13,6 +13,7 @@ import {
 } from './prelude-types.js'
 import { isAssignable, simplifyUnionType } from './subtyping.js'
 import {
+  makeApplicationType,
   makeFunctionType,
   makeIndexedAccessType,
   makeObjectType,
@@ -64,6 +65,14 @@ const indexedAccessBoolean = makeIndexedAccessType(
   makeTypeParameter('key', {
     assignableTo: makeUnionType(['a', 'b']),
   }),
+)
+
+const applicationBoolean = makeApplicationType(
+  makeFunctionType({
+    parameter: makeTypeParameter('a', { assignableTo: something }),
+    return: makeTypeParameter('b', { assignableTo: boolean }),
+  }),
+  makeUnionType(['true']),
 )
 
 testCases(
@@ -141,6 +150,21 @@ typeAssignabilitySuite('indexed-access types (not assignable)', [
   // have `boolean` assigned to it as it's *specifically* either `true` or
   // `false` depending on how its type parameter is instantiated.
   [[boolean, indexedAccessBoolean], false],
+])
+
+typeAssignabilitySuite('application types (assignable)', [
+  [[applicationBoolean, boolean], true],
+  [[applicationBoolean, atom], true],
+  [[applicationBoolean, something], true],
+])
+
+typeAssignabilitySuite('application types (not assignable)', [
+  [[applicationBoolean, makeUnionType(['true'])], false],
+  [[makeUnionType(['true']), applicationBoolean], false],
+
+  // As with stuck indexed accesses, `boolean` can't be assigned to a stuck
+  // application even though the application's upper bound is `boolean`.
+  [[boolean, applicationBoolean], false],
 ])
 
 typeAssignabilitySuite('prelude types (not assignable)', [

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -67,12 +67,22 @@ const indexedAccessBoolean = makeIndexedAccessType(
   }),
 )
 
+const applicationFunctionParameter = makeTypeParameter('a', {
+  assignableTo: something,
+})
+const applicationReturnParameter = makeTypeParameter('b', {
+  assignableTo: boolean,
+})
 const applicationBoolean = makeApplicationType(
   makeFunctionType({
-    parameter: makeTypeParameter('a', { assignableTo: something }),
-    return: makeTypeParameter('b', { assignableTo: boolean }),
+    parameter: applicationFunctionParameter,
+    return: applicationReturnParameter,
   }),
   makeUnionType(['true']),
+  new Set([
+    applicationFunctionParameter.identity,
+    applicationReturnParameter.identity,
+  ]),
 )
 
 testCases(

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -84,6 +84,18 @@ const applicationBoolean = makeApplicationType(
     applicationReturnParameter.identity,
   ]),
 )
+// Same as above:
+const applicationBoolean2 = makeApplicationType(
+  makeFunctionType({
+    parameter: applicationFunctionParameter,
+    return: applicationReturnParameter,
+  }),
+  makeUnionType(['true']),
+  new Set([
+    applicationFunctionParameter.identity,
+    applicationReturnParameter.identity,
+  ]),
+)
 
 testCases(
   (type: UnionType) => stringifyTypeForEndUser(simplifyUnionType(type)),
@@ -166,6 +178,8 @@ typeAssignabilitySuite('application types (assignable)', [
   [[applicationBoolean, boolean], true],
   [[applicationBoolean, atom], true],
   [[applicationBoolean, something], true],
+  // A stuck application is assignable to an identical one.
+  [[applicationBoolean, applicationBoolean2], true],
 ])
 
 typeAssignabilitySuite('application types (not assignable)', [

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -31,10 +31,17 @@ export const isAssignable = ({
     source === target || // in this case there's no reason to spend time checking structural assignability
     matchTypeFormat(source, {
       application: source =>
-        isAssignable({
-          source: replaceAllTypeParametersWithTheirConstraints(source),
-          target,
-        }),
+        target.kind === 'application' ?
+          // Two stuck applications are assignable when their functions and
+          // arguments are mutually assignable.
+          isAssignable({ source: source.function, target: target.function }) &&
+          isAssignable({ source: target.function, target: source.function }) &&
+          isAssignable({ source: source.argument, target: target.argument }) &&
+          isAssignable({ source: target.argument, target: source.argument })
+        : isAssignable({
+            source: replaceAllTypeParametersWithTheirConstraints(source),
+            target,
+          }),
       function: source =>
         matchTypeFormat(target, {
           function: target => {

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -30,6 +30,11 @@ export const isAssignable = ({
   return (
     source === target || // in this case there's no reason to spend time checking structural assignability
     matchTypeFormat(source, {
+      application: source =>
+        isAssignable({
+          source: replaceAllTypeParametersWithTheirConstraints(source),
+          target,
+        }),
       function: source =>
         matchTypeFormat(target, {
           function: target => {
@@ -138,6 +143,7 @@ export const isAssignable = ({
               )
             }
           },
+          application: _target => false,
           indexedAccess: _target => false,
           object: _target => false, // functions are never assignable to objects
           opaque: target => target.isAssignableFrom(source),
@@ -152,6 +158,7 @@ export const isAssignable = ({
       object: source =>
         matchTypeFormat(target, {
           function: _ => false, // objects are never assignable to functions
+          application: _ => false,
           indexedAccess: _ => false,
           object: target => {
             // Make sure all properties in the target are present and valid in
@@ -195,6 +202,8 @@ export const isAssignable = ({
       union: source =>
         matchTypeFormat(target, {
           function: target => isUnionAssignableToNonUnion({ source, target }),
+          application: target =>
+            isUnionAssignableToNonUnion({ source, target }),
           indexedAccess: target =>
             isUnionAssignableToNonUnion({ source, target }),
           object: target => isUnionAssignableToNonUnion({ source, target }),

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -39,6 +39,26 @@ export const makeIndexedAccessType = (
   key,
 })
 
+/**
+ * A stuck application (i.e. `function(argument)`), produced when an `@apply`
+ * can't be fully resolved because the applied function's type depends on a type
+ * parameter belonging to an enclosing (not-yet-applied) function.
+ */
+export type ApplicationType = {
+  readonly kind: 'application'
+  readonly function: Type
+  readonly argument: Type
+}
+
+export const makeApplicationType = (
+  functionType: Type,
+  argument: Type,
+): ApplicationType => ({
+  kind: 'application',
+  function: functionType,
+  argument,
+})
+
 export type ObjectType = {
   readonly kind: 'object'
   readonly children: Readonly<Record<Atom, Type>>
@@ -82,10 +102,12 @@ export const makeOpaqueType = (
     kind: 'opaque',
     isAssignableFrom: source =>
       matchTypeFormat(source, {
-        function: _ => false,
-        // TODO: Use the stuck index's upper bound once the cycle with
-        // `type-utilities.ts` can be avoided. Conservative (sound) for now.
+        // TODO: Use the stuck type's upper bound once the cycle with
+        // `type-utilities.ts` can be avoided.
+        application: _ => false,
         indexedAccess: _ => false,
+
+        function: _ => false,
         object: _ => false,
         opaque: source =>
           source === self ||
@@ -111,6 +133,7 @@ export const makeOpaqueType = (
       }),
     isAssignableTo: target =>
       matchTypeFormat(target, {
+        application: _ => false,
         function: _ => false,
         indexedAccess: _ => false,
         object: _ => false,
@@ -145,7 +168,7 @@ export type TypeParameter = {
   readonly identity: symbol
   readonly constraint: {
     readonly assignableTo: Type
-    // readonly assignableFrom: Type // TODO: implement lower bound constraints
+    // readonly assignableFrom: Type // TODO: Implement lower bound constraints.
   }
 }
 
@@ -212,6 +235,7 @@ export const makeUnionType = <Member extends Atom | Exclude<Type, UnionType>>(
 })
 
 export type Type =
+  | ApplicationType
   | FunctionType
   | IndexedAccessType
   | ObjectType
@@ -222,6 +246,7 @@ export type Type =
 export const matchTypeFormat = <Result>(
   type: Type,
   cases: {
+    application: (type: ApplicationType) => Result
     function: (type: FunctionType) => Result
     indexedAccess: (type: IndexedAccessType) => Result
     object: (type: ObjectType) => Result
@@ -231,6 +256,8 @@ export const matchTypeFormat = <Result>(
   },
 ): Result => {
   switch (type.kind) {
+    case 'application':
+      return cases[type.kind](type)
     case 'function':
       return cases[type.kind](type)
     case 'indexedAccess':

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -41,22 +41,30 @@ export const makeIndexedAccessType = (
 
 /**
  * A stuck application (i.e. `function(argument)`), produced when an `@apply`
- * can't be fully resolved because the applied function's type depends on a type
- * parameter belonging to an enclosing (not-yet-applied) function.
+ * can't be fully resolved because the applied function's type depends on type
+ * parameters belonging to enclosing (not-yet-applied) functions.
+ *
+ * `flexibleParameters` holds the `identity`s of those type parameters. The
+ * application stays stuck while its `function` still contains any of them, and
+ * reduces once they have all been substituted away (leaving only the applied
+ * function's own rigid parameters, which may remain in the result).
  */
 export type ApplicationType = {
   readonly kind: 'application'
   readonly function: Type
   readonly argument: Type
+  readonly flexibleParameters: ReadonlySet<symbol>
 }
 
 export const makeApplicationType = (
   functionType: Type,
   argument: Type,
+  flexibleParameters: ReadonlySet<symbol>,
 ): ApplicationType => ({
   kind: 'application',
   function: functionType,
   argument,
+  flexibleParameters,
 })
 
 export type ObjectType = {

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -38,6 +38,7 @@ import {
   type Type,
 } from './type-formats.js'
 import {
+  applicableFunctionSignature,
   applyKeyPathToType,
   containedTypeParameters,
   functionParameterKey,
@@ -307,20 +308,10 @@ const inferTypeImplementation = (
       descendantContext(['1', 'function']),
     )
     if (either.isRight(inferredFunctionType)) {
-      const inferredFunctionTypeAsFunctionType =
-        inferredFunctionType.value.kind === 'function' ?
-          option.makeSome(inferredFunctionType.value)
-        : (
-          inferredFunctionType.value.kind === 'parameter' &&
-          inferredFunctionType.value.constraint.assignableTo.kind === 'function'
-        ) ?
-          option.makeSome(inferredFunctionType.value.constraint.assignableTo)
-        : option.none
+      const appliedFunctionType = inferredFunctionType.value
 
-      return option.match(inferredFunctionTypeAsFunctionType, {
-        some: functionType => {
-          const { parameter: parameterType, return: returnType } =
-            functionType.signature
+      return option.match(applicableFunctionSignature(appliedFunctionType), {
+        some: ({ parameter: parameterType, return: returnType }) => {
           const argumentTypeResult = inferTypeImplementation(
             applyExpressionResult.value[1].argument,
             parameterTypes,
@@ -338,35 +329,53 @@ const inferTypeImplementation = (
               returnType,
               typeArguments,
             )
-            // Keep the application stuck if a free type parameter (e.g. from an
-            // enclosing function's signature) would escape into the return
-            // value. The type parameter must be mentioned in the applied
-            // function's own type and mustn't have been instantiated by its
-            // argument. Such an application can only be reduced once the
-            // enclosing function is applied.
-            const boundTypeParameters = new Set(
-              [...typeArguments.keys()].map(
-                typeParameter => typeParameter.identity,
-              ),
-            )
-            const freeTypeParameters = new Set(
-              [...parameterTypes.values()].flatMap(enclosingParameterType => [
-                ...typeParameterIdentitiesWithinType(enclosingParameterType),
-              ]),
-            ).difference(boundTypeParameters)
-            const typeParametersMentionedInThisSignature =
-              typeParameterIdentitiesWithinType(functionType)
-            const applicationIsStuck = [
-              ...typeParameterIdentitiesWithinType(eagerReturnType),
-            ].some(
-              identity =>
-                typeParametersMentionedInThisSignature.has(identity) &&
-                freeTypeParameters.has(identity),
-            )
+
+            const applicationIsStuck =
+              // When the applied function is itself a bare type parameter, an
+              // eager return type would lose track of which concrete function
+              // is supplied, so the application should stay stuck until that
+              // type parameter is instantiated.
+              appliedFunctionType.kind === 'parameter' ||
+              // Also keep the application stuck if a free type parameter (e.g.
+              // from an enclosing function's signature) would escape into the
+              // return value. The type parameter must be mentioned in the
+              // applied function's own type and mustn't have been instantiated
+              // by its argument. Such an application can only be reduced once
+              // the enclosing function is applied.
+              (() => {
+                const boundTypeParameters = new Set(
+                  [...typeArguments.keys()].map(
+                    typeParameter => typeParameter.identity,
+                  ),
+                )
+                const freeTypeParameters = new Set(
+                  [...parameterTypes.values()].flatMap(
+                    enclosingParameterType => [
+                      ...typeParameterIdentitiesWithinType(
+                        enclosingParameterType,
+                      ),
+                    ],
+                  ),
+                ).difference(boundTypeParameters)
+                const typeParametersMentionedInThisSignature =
+                  typeParameterIdentitiesWithinType(appliedFunctionType)
+                const applicationIsStuckOnAFreeTypeParameter = [
+                  ...typeParameterIdentitiesWithinType(eagerReturnType),
+                ].some(
+                  identity =>
+                    typeParametersMentionedInThisSignature.has(identity) &&
+                    freeTypeParameters.has(identity),
+                )
+                return applicationIsStuckOnAFreeTypeParameter
+              })()
+
             return cacheOnSuccess(
               either.makeRight(
                 applicationIsStuck ?
-                  makeApplicationType(functionType, argumentTypeResult.value)
+                  makeApplicationType(
+                    appliedFunctionType,
+                    argumentTypeResult.value,
+                  )
                 : eagerReturnType,
               ),
             )

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -30,6 +30,7 @@ import {
 } from '../expressions/function-expression.js'
 import * as types from './prelude-types.js'
 import {
+  makeApplicationType,
   makeFunctionType,
   makeIndexedAccessType,
   makeObjectType,
@@ -46,6 +47,7 @@ import {
   stringifyTypeKeyPathForEndUser,
   supplyTypeArguments,
   typeKeyPathFromObjectNode,
+  typeParameterIdentitiesWithinType,
 } from './type-utilities.js'
 
 /**
@@ -316,9 +318,9 @@ const inferTypeImplementation = (
         : option.none
 
       return option.match(inferredFunctionTypeAsFunctionType, {
-        some: ({
-          signature: { parameter: parameterType, return: returnType },
-        }) => {
+        some: functionType => {
+          const { parameter: parameterType, return: returnType } =
+            functionType.signature
           const argumentTypeResult = inferTypeImplementation(
             applyExpressionResult.value[1].argument,
             parameterTypes,
@@ -328,15 +330,44 @@ const inferTypeImplementation = (
           if (either.isRight(argumentTypeResult)) {
             // Supply type arguments to the return type based on the inferred
             // argument type.
+            const typeArguments = getTypesForTypeParameters({
+              parameterType,
+              argumentType: argumentTypeResult.value,
+            })
+            const eagerReturnType = supplyTypeArguments(
+              returnType,
+              typeArguments,
+            )
+            // Keep the application stuck if a free type parameter (e.g. from an
+            // enclosing function's signature) would escape into the return
+            // value. The type parameter must be mentioned in the applied
+            // function's own type and mustn't have been instantiated by its
+            // argument. Such an application can only be reduced once the
+            // enclosing function is applied.
+            const boundTypeParameters = new Set(
+              [...typeArguments.keys()].map(
+                typeParameter => typeParameter.identity,
+              ),
+            )
+            const freeTypeParameters = new Set(
+              [...parameterTypes.values()].flatMap(enclosingParameterType => [
+                ...typeParameterIdentitiesWithinType(enclosingParameterType),
+              ]),
+            ).difference(boundTypeParameters)
+            const typeParametersMentionedInThisSignature =
+              typeParameterIdentitiesWithinType(functionType)
+            const applicationIsStuck = [
+              ...typeParameterIdentitiesWithinType(eagerReturnType),
+            ].some(
+              identity =>
+                typeParametersMentionedInThisSignature.has(identity) &&
+                freeTypeParameters.has(identity),
+            )
             return cacheOnSuccess(
               either.makeRight(
-                supplyTypeArguments(
-                  returnType,
-                  getTypesForTypeParameters({
-                    parameterType,
-                    argumentType: argumentTypeResult.value,
-                  }),
-                ),
+                applicationIsStuck ?
+                  makeApplicationType(functionType, argumentTypeResult.value)
+                : eagerReturnType,
               ),
             )
           } else {

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -329,7 +329,26 @@ const inferTypeImplementation = (
               returnType,
               typeArguments,
             )
-
+            const boundTypeParameters = new Set(
+              [...typeArguments.keys()].map(
+                typeParameter => typeParameter.identity,
+              ),
+            )
+            const flexibleTypeParameters = new Set(
+              [...parameterTypes.values()].flatMap(enclosingParameterType => [
+                ...typeParameterIdentitiesWithinType(enclosingParameterType),
+              ]),
+            )
+            const typeParametersMentionedInThisSignature =
+              typeParameterIdentitiesWithinType(appliedFunctionType)
+            // Flexible parameters this application requires to become unstuck,
+            // i.e. those of the applied function that an enclosing function
+            // will instantiate.
+            const flexibleParametersOfApplication = new Set(
+              [...typeParametersMentionedInThisSignature].filter(identity =>
+                flexibleTypeParameters.has(identity),
+              ),
+            )
             const applicationIsStuck =
               // When the applied function is itself a bare type parameter, an
               // eager return type would lose track of which concrete function
@@ -342,39 +361,19 @@ const inferTypeImplementation = (
               // applied function's own type and mustn't have been instantiated
               // by its argument. Such an application can only be reduced once
               // the enclosing function is applied.
-              (() => {
-                const boundTypeParameters = new Set(
-                  [...typeArguments.keys()].map(
-                    typeParameter => typeParameter.identity,
-                  ),
-                )
-                const freeTypeParameters = new Set(
-                  [...parameterTypes.values()].flatMap(
-                    enclosingParameterType => [
-                      ...typeParameterIdentitiesWithinType(
-                        enclosingParameterType,
-                      ),
-                    ],
-                  ),
-                ).difference(boundTypeParameters)
-                const typeParametersMentionedInThisSignature =
-                  typeParameterIdentitiesWithinType(appliedFunctionType)
-                const applicationIsStuckOnAFreeTypeParameter = [
-                  ...typeParameterIdentitiesWithinType(eagerReturnType),
-                ].some(
-                  identity =>
-                    typeParametersMentionedInThisSignature.has(identity) &&
-                    freeTypeParameters.has(identity),
-                )
-                return applicationIsStuckOnAFreeTypeParameter
-              })()
-
+              [...typeParameterIdentitiesWithinType(eagerReturnType)].some(
+                identity =>
+                  typeParametersMentionedInThisSignature.has(identity) &&
+                  flexibleTypeParameters.has(identity) &&
+                  !boundTypeParameters.has(identity),
+              )
             return cacheOnSuccess(
               either.makeRight(
                 applicationIsStuck ?
                   makeApplicationType(
                     appliedFunctionType,
                     argumentTypeResult.value,
+                    flexibleParametersOfApplication,
                   )
                 : eagerReturnType,
               ),

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -16,6 +16,7 @@ import { types } from '../type-system.js'
 import { typesBySymbol } from './prelude-types.js'
 import { isAssignable, simplifyUnionType } from './subtyping.js'
 import {
+  makeApplicationType,
   makeFunctionType,
   makeIndexedAccessType,
   makeObjectType,
@@ -117,6 +118,8 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
     }
   } else {
     return matchTypeFormat<Type>(type, {
+      // TODO: Recurse into the application's reduction once that's reachable.
+      application: _type => types.nothing,
       function: type => {
         if (typeof firstKey === 'string') {
           // Functions do not have properties.
@@ -274,6 +277,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
         assignableTo: leafType,
       }),
     parameter: leafType => leafType,
+    application: leafType => leafType,
     indexedAccess: leafType => leafType,
     union: leafType =>
       makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
@@ -315,6 +319,11 @@ const containedTypeParametersImplementation = (
             containedTypeParametersImplementation(child, [...root, key]),
           )
           .reduce(mergeTypeParametersByKeyPath, new Map()),
+      application: type =>
+        mergeTypeParametersByKeyPath(
+          containedTypeParametersImplementation(type.function, root),
+          containedTypeParametersImplementation(type.argument, root),
+        ),
       indexedAccess: type =>
         mergeTypeParametersByKeyPath(
           containedTypeParametersImplementation(type.object, root),
@@ -391,6 +400,19 @@ const findKeyPathsToTypeParameterImplementation = (
             (accumulator, paths) => new Set([...accumulator, ...paths]),
             new Set(),
           ),
+      application: type =>
+        new Set([
+          ...findKeyPathsToTypeParameterImplementation(
+            type.function,
+            typeParameterToFind,
+            root,
+          ),
+          ...findKeyPathsToTypeParameterImplementation(
+            type.argument,
+            typeParameterToFind,
+            root,
+          ),
+        ]),
       indexedAccess: type =>
         new Set([
           ...findKeyPathsToTypeParameterImplementation(
@@ -509,6 +531,11 @@ export const getTypesForTypeParameters = ({
       // I could perhaps use it to drill into the argument type. Is that sound?
       indexedAccess: _ => new Map(),
 
+      // A application type in a function parameter is necessarily stuck on an
+      // argument from an enclosing function that hasn't been applied, so no
+      // bindings are inferred from it.
+      application: _ => new Map(),
+
       parameter: parameterType =>
         (
           isAssignable({
@@ -565,6 +592,43 @@ export const getTypesForTypeParameters = ({
   }
 }
 
+export const typeParameterIdentitiesWithinType = (
+  type: Type,
+): ReadonlySet<symbol> =>
+  new Set(
+    [...containedTypeParameters(type).values()].flatMap(({ typeParameters }) =>
+      [...typeParameters.members].map(typeParameter => typeParameter.identity),
+    ),
+  )
+
+/**
+ * Attempt to reduce a (possibly stuck) application of `functionType(argument)`.
+ * When the applied function's return type only depends on its own parameter
+ * type, applying it results in a concrete return type. Otherwise the
+ * application remains stuck.
+ */
+const reduceApplication = (functionType: Type, argumentType: Type): Type => {
+  if (functionType.kind === 'function') {
+    const parameterIdentities = typeParameterIdentitiesWithinType(
+      functionType.signature.parameter,
+    )
+    const returnIsDeterminedByParameter = [
+      ...typeParameterIdentitiesWithinType(functionType.signature.return),
+    ].every(identity => parameterIdentities.has(identity))
+    return returnIsDeterminedByParameter ?
+        supplyTypeArguments(
+          functionType.signature.return,
+          getTypesForTypeParameters({
+            parameterType: functionType.signature.parameter,
+            argumentType: argumentType,
+          }),
+        )
+      : makeApplicationType(functionType, argumentType)
+  } else {
+    return makeApplicationType(functionType, argumentType)
+  }
+}
+
 /**
  * Substitute the given `typeParameter` with the given `typeArgument` within
  * `type`, recursively visiting object properties, union members, etc.
@@ -606,6 +670,11 @@ export const supplyTypeArgument = (
         }
         return makeObjectType(substitutedChildren)
       },
+      application: type =>
+        reduceApplication(
+          supplyTypeArgument(type.function, typeParameter, typeArgument),
+          supplyTypeArgument(type.argument, typeParameter, typeArgument),
+        ),
       indexedAccess: type =>
         either.match(
           atomKeyPathComponentFromType(
@@ -716,6 +785,7 @@ export const updateTypeAtKeyPathIfValid = (
             return type
         }
       },
+      application: type => type,
       indexedAccess: type => type,
       object: type => {
         if (typeof firstKey === 'string') {
@@ -902,6 +972,11 @@ const atomKeyPathComponentFromType = (
   type: Type,
 ): Either<TypeMismatchError, AtomKeyPathComponent> =>
   matchTypeFormat<Either<TypeMismatchError, AtomKeyPathComponent>>(type, {
+    application: _ =>
+      either.makeLeft({
+        kind: 'typeMismatch',
+        message: `${type.kind} types are not valid key path components`,
+      }),
     function: _ =>
       either.makeLeft({
         kind: 'typeMismatch',
@@ -924,6 +999,7 @@ const atomKeyPathComponentFromType = (
       }),
     parameter: type => {
       switch (type.constraint.assignableTo.kind) {
+        case 'application':
         case 'function':
         case 'indexedAccess':
         case 'object':

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -119,8 +119,24 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
     }
   } else {
     return matchTypeFormat<Type>(type, {
-      // TODO: Recurse into the application's reduction once that's reachable.
-      application: _type => types.nothing,
+      application: applicationType => {
+        // Indexing into a stuck application stays stuck, provided the key path
+        // is valid for the application's upper bound. Otherwise the property
+        // definitely doesn't exist.
+        const typeAtKeyPathInUpperBound = applyKeyPathToType(
+          replaceAllTypeParametersWithTheirConstraints(applicationType),
+          keyPath,
+        )
+        return (
+            typeAtKeyPathInUpperBound.kind === 'union' &&
+              typeAtKeyPathInUpperBound.members.size === 0
+          ) ?
+            types.nothing
+          : nestedIndexedAccess(applicationType, [
+              firstKey,
+              ...remainingKeyPath,
+            ])
+      },
       function: type => {
         if (typeof firstKey === 'string') {
           // Functions do not have properties.

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -23,6 +23,7 @@ import {
   makeTypeParameter,
   makeUnionType,
   matchTypeFormat,
+  type FunctionType,
   type IndexedAccessType,
   type ObjectType,
   type Type,
@@ -600,6 +601,20 @@ export const typeParameterIdentitiesWithinType = (
       [...typeParameters.members].map(typeParameter => typeParameter.identity),
     ),
   )
+
+/**
+ * If `type` is something that can be applied, return its signature.
+ */
+export const applicableFunctionSignature = (
+  type: Type,
+): Option<FunctionType['signature']> =>
+  type.kind === 'function' ? option.makeSome(type.signature)
+  : (
+    type.kind === 'parameter' &&
+    type.constraint.assignableTo.kind === 'function'
+  ) ?
+    option.makeSome(type.constraint.assignableTo.signature)
+  : option.none
 
 /**
  * Attempt to reduce a (possibly stuck) application of `functionType(argument)`.

--- a/src/language/semantics/type-system/type-utilities.ts
+++ b/src/language/semantics/type-system/type-utilities.ts
@@ -618,30 +618,29 @@ export const applicableFunctionSignature = (
 
 /**
  * Attempt to reduce a (possibly stuck) application of `functionType(argument)`.
- * When the applied function's return type only depends on its own parameter
- * type, applying it results in a concrete return type. Otherwise the
- * application remains stuck.
+ * While the function still contains any of the `flexibleParameters` (type
+ * parameters an enclosing function will instantiate), the application stays
+ * stuck. Once they're all gone the function is applied: any of its own type
+ * parameters are bound from the argument, and type parameters appearing only in
+ * the return legitimately remain.
  */
-const reduceApplication = (functionType: Type, argumentType: Type): Type => {
-  if (functionType.kind === 'function') {
-    const parameterIdentities = typeParameterIdentitiesWithinType(
-      functionType.signature.parameter,
-    )
-    const returnIsDeterminedByParameter = [
-      ...typeParameterIdentitiesWithinType(functionType.signature.return),
-    ].every(identity => parameterIdentities.has(identity))
-    return returnIsDeterminedByParameter ?
-        supplyTypeArguments(
-          functionType.signature.return,
-          getTypesForTypeParameters({
-            parameterType: functionType.signature.parameter,
-            argumentType: argumentType,
-          }),
-        )
-      : makeApplicationType(functionType, argumentType)
-  } else {
-    return makeApplicationType(functionType, argumentType)
-  }
+const reduceApplication = (
+  functionType: Type,
+  argumentType: Type,
+  flexibleParameters: ReadonlySet<symbol>,
+): Type => {
+  const stillAwaitingFlexibleParameter = [
+    ...typeParameterIdentitiesWithinType(functionType),
+  ].some(identity => flexibleParameters.has(identity))
+  return !stillAwaitingFlexibleParameter && functionType.kind === 'function' ?
+      supplyTypeArguments(
+        functionType.signature.return,
+        getTypesForTypeParameters({
+          parameterType: functionType.signature.parameter,
+          argumentType: argumentType,
+        }),
+      )
+    : makeApplicationType(functionType, argumentType, flexibleParameters)
 }
 
 /**
@@ -689,6 +688,7 @@ export const supplyTypeArgument = (
         reduceApplication(
           supplyTypeArgument(type.function, typeParameter, typeArgument),
           supplyTypeArgument(type.argument, typeParameter, typeArgument),
+          type.flexibleParameters,
         ),
       indexedAccess: type =>
         either.match(


### PR DESCRIPTION
This is similar to #191, but for function applications rather than indexed access.

When a function whose type depends on enclosing functions' type parameters is applied, the inferred return type previously lost its dependency on how those parameters become instantiated. This prevented higher-order reasoning about e.g. generic functions passed as arguments then applied (as in `(f: ?a ~> ?b) => :f(true)`).

The new `ApplicationType` keeps such an application "stuck" until the necessary type arguments are available, at which point it reduces. For example the above function applied to an identity function is now correctly inferred to have the type `true`.

I believe this addresses the final possibly-stuck eliminator (`@if` and `@index` were addressed in #191, this pull request addresses `@apply`, and I don't think any of the remaining keyword expressions require this sort of analysis).