### PR TITLE
Allow assigning stuck types to opaque types when possible

### DIFF
--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -9,6 +9,7 @@ import {
   type Type,
   type UnionType,
 } from './type-formats.js'
+import { replaceAllTypeParametersWithTheirConstraints } from './type-substitution.js'
 
 export const nothing = makeUnionType([]) // the bottom type
 
@@ -25,6 +26,7 @@ export const boolean = makeUnionType(['false', 'true'])
 export const atomTypeSymbol = Symbol('atom')
 export const atom = makeOpaqueType(atomTypeSymbol, {
   isAssignableFromLiteralType: (_literalType: string) => true,
+  upperBoundOfStuckType: replaceAllTypeParametersWithTheirConstraints,
   nearestOpaqueAssignableFrom: () => optionAdt.makeSome(integer),
   nearestOpaqueAssignableTo: () => optionAdt.none,
 })
@@ -33,6 +35,7 @@ export const integerTypeSymbol = Symbol('integer')
 export const integer = makeOpaqueType(integerTypeSymbol, {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|-?[1-9](?:[0-9])*)+$/.test(literalType),
+  upperBoundOfStuckType: replaceAllTypeParametersWithTheirConstraints,
   nearestOpaqueAssignableFrom: () => optionAdt.makeSome(naturalNumber),
   nearestOpaqueAssignableTo: () => optionAdt.makeSome(atom),
 })
@@ -41,6 +44,7 @@ export const naturalNumberTypeSymbol = Symbol('natural_number')
 export const naturalNumber = makeOpaqueType(naturalNumberTypeSymbol, {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|[1-9](?:[0-9])*)+$/.test(literalType),
+  upperBoundOfStuckType: replaceAllTypeParametersWithTheirConstraints,
   nearestOpaqueAssignableFrom: () => optionAdt.none,
   nearestOpaqueAssignableTo: () => optionAdt.makeSome(integer),
 })

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -191,6 +191,16 @@ typeAssignabilitySuite('application types (not assignable)', [
   [[boolean, applicationBoolean], false],
 ])
 
+typeAssignabilitySuite('opaque type from stuck type (assignable)', [
+  [[makeUnionType([applicationBoolean]), atom], true],
+  [[makeUnionType([indexedAccessBoolean]), atom], true],
+])
+
+typeAssignabilitySuite('opaque type from stuck type (not assignable)', [
+  [[makeUnionType([applicationBoolean]), integer], false],
+  [[makeUnionType([indexedAccessBoolean]), integer], false],
+])
+
 typeAssignabilitySuite('prelude types (not assignable)', [
   [[nullType, nothing], false],
   [[nullType, boolean], false],

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -90,6 +90,12 @@ export const makeOpaqueType = (
   symbol: TypeSymbol,
   subtyping: {
     readonly isAssignableFromLiteralType: (literalType: string) => boolean
+    // `upperBoundOfStuckType` is injected to avoid a
+    // cycle with `type-substitution.ts`. `makeOpaqueType` is called in static
+    // module scope from `prelude-types.ts`.
+    readonly upperBoundOfStuckType: (
+      type: ApplicationType | IndexedAccessType,
+    ) => Type
   } & (
     | {
         readonly nearestOpaqueAssignableFrom: () => None
@@ -110,10 +116,12 @@ export const makeOpaqueType = (
     kind: 'opaque',
     isAssignableFrom: source =>
       matchTypeFormat(source, {
-        // TODO: Use the stuck type's upper bound once the cycle with
-        // `type-substitution.ts` can be avoided.
-        application: _ => false,
-        indexedAccess: _ => false,
+        // A stuck application/indexed access is assignable to an opaque type
+        // when its concrete upper bound is.
+        application: source =>
+          self.isAssignableFrom(subtyping.upperBoundOfStuckType(source)),
+        indexedAccess: source =>
+          self.isAssignableFrom(subtyping.upperBoundOfStuckType(source)),
 
         function: _ => false,
         object: _ => false,


### PR DESCRIPTION
For example, if it is known that a stuck indexed access type will eventually reduce to some concrete atom, then it's assignable to `:atom.type`.