### PR TITLE
Refine stdlib return types when applying to atoms or unions thereof

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1491,4 +1491,103 @@ testCases(
       assert(either.isRight(result))
     },
   ],
+
+  [
+    `:boolean.not(@runtime { _ => true }) ~ false`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `:atom.append(@runtime { _ => b })(a) ~ ab`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(1 + @runtime { _ => 1 }) ~ 2`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(1 + @runtime { context =>
+      @if {
+        @runtime { context =>
+          :context.program.start_time atom.equals "arbitrary atom"
+        }
+        1
+        2
+      }
+    }) ~ (2 | 3)`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      add_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
+      requires_a_natural_number: (a: :natural_number.type) => :a
+      :requires_a_natural_number(:add_natural_numbers(@runtime { _ => 1 })(@runtime { _ => 1 }))
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      add_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
+      requires_a_natural_number: (a: :natural_number.type) => :a
+      :requires_a_natural_number(:add_natural_numbers(@runtime { _ => 1 })(@runtime { _ => -1 }))
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      add_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
+      requires_a_natural_number: (a: :natural_number.type) => :a
+      :requires_a_natural_number(:add_natural_numbers(@runtime { _ => -1 })(@runtime { _ => 1 }))
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      subtract_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a - :b
+      requires_a_natural_number: (a: :natural_number.type) => :a
+      :requires_a_natural_number(:subtract_natural_numbers(@runtime { _ => 2 })(@runtime { _ => 1 }))
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      subtract_natural_numbers: (b: :natural_number.type) => (a: :natural_number.type) => :a + :b
+      requires_a_natural_number: (a: :natural_number.type) => :a
+      illegal: (a: :integer.type) => :requires_a_natural_number(:subtract_natural_numbers(@runtime { _ => 1 })(:a))
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
 ])

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -342,6 +342,10 @@ export const typeToSemanticGraph = (
           recurseWithSameTypeParameters(value),
         ]),
       ),
+    // A stuck intrinsic application is displayed as its (concrete) upper bound,
+    // which is also how it behaves for assignability.
+    intrinsicApplication: type =>
+      recurseWithSameTypeParameters(type.upperBound),
     opaque: type => typeSymbolToSemanticGraph(type.symbol),
     parameter: type => {
       if (alreadyIntroducedTypeParameterIdentities.has(type.identity)) {

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -1,5 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
+import type { Atom } from '../../parsing.js'
 import {
   keyPathToLookupExpression,
   makeApplyExpression,
@@ -17,7 +18,14 @@ import {
   type SemanticGraph,
 } from '../semantic-graph.js'
 import { literalTypeFromSemanticGraph } from '../type-system/literal-type.js'
-import { type FunctionType, type Type } from '../type-system/type-formats.js'
+import {
+  makeFunctionType,
+  makeIntrinsicApplicationType,
+  makeTypeParameter,
+  type FunctionType,
+  type Type,
+} from '../type-system/type-formats.js'
+import { containedTypeParameters } from '../type-system/type-parameter-analysis.js'
 import {
   getTypesForTypeParameters,
   supplyTypeArguments,
@@ -78,7 +86,10 @@ export const serializeTwiceAppliedFunction =
   () =>
     either.makeRight(
       makeApplyExpression({
-        function: serializeOnceAppliedFunction(keyPath, argument1)().value,
+        function: makeApplyExpression({
+          function: keyPathToLookupExpression(keyPath),
+          argument: argument1,
+        }),
         argument: argument2,
       }),
     )
@@ -89,7 +100,7 @@ export const preludeFunctionArity1 = (
   f: FunctionNodeCallSignature,
 ) =>
   makeFunctionNode(
-    signature,
+    liftIntrinsicSignature(signature, intrinsicApplicationTypeReducerArity1(f)),
     () => either.makeRight(keyPathToLookupExpression(keyPath)),
     option.none,
     handleUnavailableDependencies(f),
@@ -105,22 +116,27 @@ export const preludeFunctionArity2 = (
     argument1: SemanticGraph,
   ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
 ) =>
-  preludeFunctionArity1(keyPath, signature, argument1 =>
-    either.flatMap(
-      refineReturnedFunctionType(
-        signature.parameter,
-        signature.return,
-        argument1,
-      ),
-      refinedReturn =>
-        either.map(f(argument1), f1 =>
-          makeFunctionNode(
-            refinedReturn.signature,
-            serializeOnceAppliedFunction(keyPath, argument1),
-            option.none,
-            handleUnavailableDependencies(f1),
-          ),
+  makeFunctionNode(
+    liftIntrinsicSignature(signature, intrinsicApplicationTypeReducerArity2(f)),
+    () => either.makeRight(keyPathToLookupExpression(keyPath)),
+    option.none,
+    handleUnavailableDependencies(argument1 =>
+      either.flatMap(
+        refineReturnedFunctionType(
+          signature.parameter,
+          signature.return,
+          argument1,
         ),
+        refinedReturn =>
+          either.map(f(argument1), f1 =>
+            makeFunctionNode(
+              refinedReturn.signature,
+              serializeOnceAppliedFunction(keyPath, argument1),
+              option.none,
+              handleUnavailableDependencies(f1),
+            ),
+          ),
+      ),
     ),
   )
 
@@ -143,51 +159,209 @@ export const preludeFunctionArity3 = (
       argument2: SemanticGraph,
     ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>
   >,
-) =>
-  preludeFunctionArity1(keyPath, signature, argument1 =>
-    either.flatMap(
-      refineReturnedFunctionType(
-        signature.parameter,
-        signature.return,
-        argument1,
-      ),
-      refinedReturn1 =>
-        either.map(f(argument1), f1 =>
-          makeFunctionNode(
-            refinedReturn1.signature,
-            serializeOnceAppliedFunction(keyPath, argument1),
-            option.none,
-            handleUnavailableDependencies(argument2 =>
-              either.flatMap(
-                refinedReturn1.signature.return.kind === 'function' ?
-                  refineReturnedFunctionType(
-                    refinedReturn1.signature.parameter,
-                    refinedReturn1.signature.return,
-                    argument2,
-                  )
-                : either.makeLeft({
-                    kind: 'bug',
-                    message: `supplying type arguments in an arity-3 standard library function somehow transformed its first return type into a ${refinedReturn1.signature.return.kind} type (it should be a function type)`,
-                  }),
-                refinedReturn2 =>
-                  either.map(f1(argument2), f2 =>
-                    makeFunctionNode(
-                      refinedReturn2.signature,
-                      serializeTwiceAppliedFunction(
-                        keyPath,
-                        argument1,
-                        argument2,
+) => {
+  const liftedSignature = liftIntrinsicSignature(
+    signature,
+    intrinsicApplicationTypeReducerArity3(f),
+  )
+  return makeFunctionNode(
+    liftedSignature,
+    () => either.makeRight(keyPathToLookupExpression(keyPath)),
+    option.none,
+    handleUnavailableDependencies(argument1 =>
+      either.flatMap(
+        refineReturnedFunctionType(
+          signature.parameter,
+          signature.return,
+          argument1,
+        ),
+        refinedReturn1 =>
+          either.map(f(argument1), f1 =>
+            makeFunctionNode(
+              refinedReturn1.signature,
+              serializeOnceAppliedFunction(keyPath, argument1),
+              option.none,
+              handleUnavailableDependencies(argument2 =>
+                either.flatMap(
+                  refinedReturn1.signature.return.kind === 'function' ?
+                    refineReturnedFunctionType(
+                      refinedReturn1.signature.parameter,
+                      refinedReturn1.signature.return,
+                      argument2,
+                    )
+                  : either.makeLeft({
+                      kind: 'bug',
+                      message: `supplying type arguments in an arity-3 standard library function somehow transformed its first return type into a ${refinedReturn1.signature.return.kind} type (it should be a function type)`,
+                    }),
+                  refinedReturn2 =>
+                    either.map(f1(argument2), f2 =>
+                      makeFunctionNode(
+                        refinedReturn2.signature,
+                        serializeTwiceAppliedFunction(
+                          keyPath,
+                          argument1,
+                          argument2,
+                        ),
+                        option.none,
+                        handleUnavailableDependencies(f2),
                       ),
-                      option.none,
-                      handleUnavailableDependencies(f2),
                     ),
-                  ),
+                ),
               ),
             ),
           ),
-        ),
+      ),
     ),
   )
+}
+
+const synthesizeTypeParameterName = (index: number) => {
+  if (index < 0 || !Number.isInteger(index)) {
+    throw new Error('Index was negative or non-integral. This is a bug!')
+  } else {
+    const wraparoundCount = Math.floor(index / 26)
+    const suffix = wraparoundCount === 0 ? '' : String(wraparoundCount)
+    return String.fromCharCode((index % 26) + 97).concat(suffix)
+  }
+}
+
+// The reducers below apply an intrinsic function (`f`) to concrete argument
+// atoms (unit types), lifting the result back to a type. This lets
+// `IntrinsicApplicationType`s reduce via the same code that evaluates values.
+
+const intrinsicApplicationTypeReducerArity1 =
+  (f: FunctionNodeCallSignature) =>
+  (argumentAtoms: readonly Atom[]): Either<FunctionNodeCallError, Type> => {
+    const [argument] = argumentAtoms
+    return argument === undefined ?
+        either.makeLeft({
+          kind: 'bug',
+          message: "argument list didn't contain enough arguments",
+        })
+      : either.flatMap(
+          f(argument, emptyContextForStdlibApplications),
+          literalTypeFromSemanticGraph,
+        )
+  }
+
+const intrinsicApplicationTypeReducerArity2 =
+  (
+    f: (
+      argument1: SemanticGraph,
+    ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
+  ) =>
+  (argumentAtoms: readonly Atom[]): Either<FunctionNodeCallError, Type> => {
+    const [argument1, argument2] = argumentAtoms
+    return argument1 === undefined || argument2 === undefined ?
+        either.makeLeft({
+          kind: 'bug',
+          message: "argument list didn't contain enough arguments",
+        })
+      : either.flatMap(
+          either.flatMap(f(argument1), f1 =>
+            f1(argument2, emptyContextForStdlibApplications),
+          ),
+          literalTypeFromSemanticGraph,
+        )
+  }
+
+const intrinsicApplicationTypeReducerArity3 =
+  (
+    f: (
+      argument1: SemanticGraph,
+    ) => Either<
+      FunctionNodeCallError,
+      (
+        argument2: SemanticGraph,
+      ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>
+    >,
+  ) =>
+  (argumentAtoms: readonly Atom[]): Either<FunctionNodeCallError, Type> => {
+    const [argument1, argument2, argument3] = argumentAtoms
+    return (
+        argument1 === undefined ||
+          argument2 === undefined ||
+          argument3 === undefined
+      ) ?
+        either.makeLeft({
+          kind: 'bug',
+          message: "argument list didn't contain enough arguments",
+        })
+      : either.flatMap(
+          either.flatMap(f(argument1), f1 =>
+            either.flatMap(f1(argument2), f2 =>
+              f2(argument3, emptyContextForStdlibApplications),
+            ),
+          ),
+          literalTypeFromSemanticGraph,
+        )
+  }
+
+type SignatureParts = {
+  // The constraint at each curried parameter position, in application order.
+  readonly parameterConstraints: readonly Type[]
+  // The innermost (non-function) return type.
+  readonly finalReturn: Type
+}
+
+const signatureParts = (
+  signature: FunctionType['signature'],
+): SignatureParts => {
+  const prependParameter = (
+    parameter: Type,
+    { parameterConstraints, finalReturn }: SignatureParts,
+  ): SignatureParts => ({
+    parameterConstraints: [parameter, ...parameterConstraints],
+    finalReturn,
+  })
+  const partsFromReturn = (returnType: Type): SignatureParts =>
+    returnType.kind === 'function' ?
+      prependParameter(
+        returnType.signature.parameter,
+        partsFromReturn(returnType.signature.return),
+      )
+    : { parameterConstraints: [], finalReturn: returnType }
+  return prependParameter(
+    signature.parameter,
+    partsFromReturn(signature.return),
+  )
+}
+
+/**
+ * Lift a standard library function's signature to be generic over its
+ * parameters and return an `IntrinsicApplicationType`. This lets the type
+ * system compute precise return types from unit argument types via `reduce`
+ * (which should apply the function itself).
+ *
+ * Functions whose return already contains a type parameter (e.g. `identity`)
+ * don't need extra precision, so their signature is left unchanged.
+ */
+const liftIntrinsicSignature = (
+  signature: FunctionType['signature'],
+  reduce: (
+    argumentAtoms: readonly Atom[],
+  ) => Either<FunctionNodeCallError, Type>,
+): FunctionType['signature'] => {
+  if (containedTypeParameters(makeFunctionType(signature)).size > 0) {
+    return signature
+  } else {
+    const { parameterConstraints, finalReturn } = signatureParts(signature)
+    // Make signatures implicitly generic, just like userland functions.
+    const parameterTypes = parameterConstraints.map((constraint, index) =>
+      makeTypeParameter(synthesizeTypeParameterName(index), {
+        assignableTo: constraint,
+      }),
+    )
+    const liftedFunctionType = parameterTypes.reduceRight<Type>(
+      (returnSoFar, parameter) =>
+        makeFunctionType({ parameter, return: returnSoFar }),
+      makeIntrinsicApplicationType(parameterTypes, reduce, finalReturn),
+    )
+    return liftedFunctionType.kind === 'function' ?
+        liftedFunctionType.signature
+      : signature
+  }
+}
 
 /**
  * Substitute type parameters using an argument's type into the returned

--- a/src/language/semantics/type-system/genericize-function-parameter.ts
+++ b/src/language/semantics/type-system/genericize-function-parameter.ts
@@ -74,6 +74,7 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
     parameter: leafType => leafType,
     application: leafType => leafType,
     indexedAccess: leafType => leafType,
+    intrinsicApplication: leafType => leafType,
     union: leafType =>
       makeTypeParameter(synthesizeTypeParameterName(parameterName, keyPath), {
         assignableTo: leafType,

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -1,3 +1,5 @@
+import type { Option } from '@matt.kantor/option'
+import option from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
 import {
   makeObjectType,
@@ -31,227 +33,268 @@ export const isAssignable = ({
 
   return (
     source === target || // in this case there's no reason to spend time checking structural assignability
-    matchTypeFormat(source, {
-      application: source =>
-        target.kind === 'application' ?
-          // Two stuck applications are assignable when their functions and
-          // arguments are mutually assignable.
-          isAssignable({ source: source.function, target: target.function }) &&
-          isAssignable({ source: target.function, target: source.function }) &&
-          isAssignable({ source: source.argument, target: target.argument }) &&
-          isAssignable({ source: target.argument, target: source.argument })
-        : isAssignable({
+    (target.kind === 'intrinsicApplication' ?
+      // An intrinsic application behaves as its (concrete) upper bound when
+      // appearing as the target, mirroring the source case below. This ensures
+      // structurally-equivalent-but-not-identical intrinsic applications are
+      // mutually assignable.
+      isAssignable({
+        source,
+        target: replaceAllTypeParametersWithTheirConstraints(target),
+      })
+    : matchTypeFormat(source, {
+        application: source =>
+          target.kind === 'application' ?
+            // Two stuck applications are assignable when their functions and
+            // arguments are mutually assignable.
+            isAssignable({
+              source: source.function,
+              target: target.function,
+            }) &&
+            isAssignable({
+              source: target.function,
+              target: source.function,
+            }) &&
+            isAssignable({
+              source: source.argument,
+              target: target.argument,
+            }) &&
+            isAssignable({
+              source: target.argument,
+              target: source.argument,
+            })
+          : isAssignable({
+              source: replaceAllTypeParametersWithTheirConstraints(source),
+              target,
+            }),
+        function: source =>
+          matchTypeFormat(target, {
+            function: target => {
+              // Functions are contravariant in parameters, covariant in return
+              // types.
+              if (
+                source.signature.parameter.kind === 'parameter' &&
+                source.signature.return.kind === 'parameter' &&
+                source.signature.parameter.identity ===
+                  source.signature.return.identity
+              ) {
+                // The source is an identity function (`a => a`), which means this
+                // much simpler check can be performed. This also allows correctly
+                // handling the fact that `a => a` is assignable to a type like
+                // `atom => atom`.
+                return (
+                  isAssignable({
+                    source: target.signature.parameter,
+                    target: target.signature.return,
+                  }) &&
+                  isAssignable({
+                    source: target.signature.parameter,
+                    target: source.signature.parameter.constraint.assignableTo,
+                  })
+                )
+              } else {
+                const sourceParameterTypeParameters = containedTypeParameters(
+                  source.signature.parameter,
+                )
+                const targetParameterTypeParameters = containedTypeParameters(
+                  target.signature.parameter,
+                )
+
+                // An example showing how this will be used: When checking whether
+                // `{ a: (a <: atom) } => a` is assignable to `{ a: (b <: "a") }
+                // => b`, the parameter types are compatible if `{ a: (b <: "a")
+                // }` is assignable to `{ a: atom }` (it is).
+                let sourceParameterWithTypeParametersReplacedByConstraints =
+                  source.signature.parameter
+
+                // An example showing how this will be used: When checking whether
+                // `a => { a: a, b: atom }` is assignable to `(b <: atom) => { a:
+                // b }`, the return types are compatible if `{ a: b, b: atom }` is
+                // assignable to `{ a: b }` (it is).
+                let sourceReturnWithTypeParametersReplacedByTargetTypeParameters =
+                  source.signature.return
+
+                for (const [
+                  stringifiedKeyPath,
+                  sourceTypeParametersAtThisKeyPath,
+                ] of sourceParameterTypeParameters) {
+                  for (const sourceTypeParameter of sourceTypeParametersAtThisKeyPath
+                    .typeParameters.members) {
+                    sourceParameterWithTypeParametersReplacedByConstraints =
+                      supplyTypeArgument(
+                        sourceParameterWithTypeParametersReplacedByConstraints,
+                        sourceTypeParameter,
+                        sourceTypeParameter.constraint.assignableTo,
+                      )
+
+                    const correspondingTargetTypeParameter =
+                      targetParameterTypeParameters.get(stringifiedKeyPath)
+
+                    if (correspondingTargetTypeParameter !== undefined) {
+                      const locationsOfSourceTypeParameterInSourceReturn =
+                        findKeyPathsToTypeParameter(
+                          source.signature.return,
+                          sourceTypeParameter,
+                        )
+
+                      for (const locationOfSourceTypeParameterInSourceReturn of locationsOfSourceTypeParameterInSourceReturn) {
+                        sourceReturnWithTypeParametersReplacedByTargetTypeParameters =
+                          updateTypeAtKeyPathIfValid(
+                            sourceReturnWithTypeParametersReplacedByTargetTypeParameters,
+                            locationOfSourceTypeParameterInSourceReturn,
+                            typeAtKeyPath => {
+                              if (
+                                typeAtKeyPath.kind === 'parameter' &&
+                                typeAtKeyPath.identity ===
+                                  sourceTypeParameter.identity
+                              ) {
+                                return correspondingTargetTypeParameter.typeParameters
+                              } else {
+                                return typeAtKeyPath
+                              }
+                            },
+                          )
+                      }
+                    }
+                  }
+                }
+
+                return (
+                  // Contravariant parameter check:
+                  isAssignable({
+                    source: target.signature.parameter,
+                    target:
+                      sourceParameterWithTypeParametersReplacedByConstraints,
+                  }) &&
+                  // Covariant return type check:
+                  isAssignable({
+                    source:
+                      sourceReturnWithTypeParametersReplacedByTargetTypeParameters,
+                    target: target.signature.return,
+                  })
+                )
+              }
+            },
+            application: _target => false,
+            indexedAccess: _target => false,
+            intrinsicApplication: _target => {
+              // This case is handled above.
+              throw new Error(
+                'Intrinsic application target should have already been handled. This is a bug!',
+              )
+            },
+            object: _target => false, // functions are never assignable to objects
+            opaque: target => target.isAssignableFrom(source),
+            parameter: _target => false, // a function type is never directly assignable to a type parameter
+            union: target => isNonUnionAssignableToUnion({ source, target }),
+          }),
+        indexedAccess: source =>
+          isAssignable({
             source: replaceAllTypeParametersWithTheirConstraints(source),
             target,
           }),
-      function: source =>
-        matchTypeFormat(target, {
-          function: target => {
-            // Functions are contravariant in parameters, covariant in return
-            // types.
-            if (
-              source.signature.parameter.kind === 'parameter' &&
-              source.signature.return.kind === 'parameter' &&
-              source.signature.parameter.identity ===
-                source.signature.return.identity
-            ) {
-              // The source is an identity function (`a => a`), which means this
-              // much simpler check can be performed. This also allows correctly
-              // handling the fact that `a => a` is assignable to a type like
-              // `atom => atom`.
-              return (
-                isAssignable({
-                  source: target.signature.parameter,
-                  target: target.signature.return,
-                }) &&
-                isAssignable({
-                  source: target.signature.parameter,
-                  target: source.signature.parameter.constraint.assignableTo,
-                })
+        intrinsicApplication: source =>
+          isAssignable({
+            source: replaceAllTypeParametersWithTheirConstraints(source),
+            target,
+          }),
+        object: source =>
+          matchTypeFormat(target, {
+            function: _target => false, // objects are never assignable to functions
+            application: _target => false,
+            indexedAccess: _target => false,
+            intrinsicApplication: _target => {
+              // This case is handled above.
+              throw new Error(
+                'Intrinsic application target should have already been handled. This is a bug!',
               )
-            } else {
-              const sourceParameterTypeParameters = containedTypeParameters(
-                source.signature.parameter,
-              )
-              const targetParameterTypeParameters = containedTypeParameters(
-                target.signature.parameter,
-              )
-
-              // An example showing how this will be used: When checking whether
-              // `{ a: (a <: atom) } => a` is assignable to `{ a: (b <: "a") }
-              // => b`, the parameter types are compatible if `{ a: (b <: "a")
-              // }` is assignable to `{ a: atom }` (it is).
-              let sourceParameterWithTypeParametersReplacedByConstraints =
-                source.signature.parameter
-
-              // An example showing how this will be used: When checking whether
-              // `a => { a: a, b: atom }` is assignable to `(b <: atom) => { a:
-              // b }`, the return types are compatible if `{ a: b, b: atom }` is
-              // assignable to `{ a: b }` (it is).
-              let sourceReturnWithTypeParametersReplacedByTargetTypeParameters =
-                source.signature.return
-
-              for (const [
-                stringifiedKeyPath,
-                sourceTypeParametersAtThisKeyPath,
-              ] of sourceParameterTypeParameters) {
-                for (const sourceTypeParameter of sourceTypeParametersAtThisKeyPath
-                  .typeParameters.members) {
-                  sourceParameterWithTypeParametersReplacedByConstraints =
-                    supplyTypeArgument(
-                      sourceParameterWithTypeParametersReplacedByConstraints,
-                      sourceTypeParameter,
-                      sourceTypeParameter.constraint.assignableTo,
-                    )
-
-                  const correspondingTargetTypeParameter =
-                    targetParameterTypeParameters.get(stringifiedKeyPath)
-
-                  if (correspondingTargetTypeParameter !== undefined) {
-                    const locationsOfSourceTypeParameterInSourceReturn =
-                      findKeyPathsToTypeParameter(
-                        source.signature.return,
-                        sourceTypeParameter,
-                      )
-
-                    for (const locationOfSourceTypeParameterInSourceReturn of locationsOfSourceTypeParameterInSourceReturn) {
-                      sourceReturnWithTypeParametersReplacedByTargetTypeParameters =
-                        updateTypeAtKeyPathIfValid(
-                          sourceReturnWithTypeParametersReplacedByTargetTypeParameters,
-                          locationOfSourceTypeParameterInSourceReturn,
-                          typeAtKeyPath => {
-                            if (
-                              typeAtKeyPath.kind === 'parameter' &&
-                              typeAtKeyPath.identity ===
-                                sourceTypeParameter.identity
-                            ) {
-                              return correspondingTargetTypeParameter.typeParameters
-                            } else {
-                              return typeAtKeyPath
-                            }
-                          },
-                        )
-                    }
+            },
+            object: target => {
+              // Make sure all properties in the target are present and valid in
+              // the source (recursively). Values may have additional properties
+              // beyond what is required by the target and still be assignable to
+              // it.
+              for (const [key, typePropertyValue] of Object.entries(
+                target.children,
+              )) {
+                if (source.children[key] === undefined) {
+                  return false
+                } else {
+                  // Recursively check the property:
+                  if (
+                    !isAssignable({
+                      source: source.children[key],
+                      target: typePropertyValue,
+                    })
+                  ) {
+                    return false
                   }
                 }
               }
+              return true
+            },
+            opaque: target => target.isAssignableFrom(source),
+            parameter: _target => false, // an object type is never directly assignable to a type parameter
+            union: target => isNonUnionAssignableToUnion({ source, target }),
+          }),
+        opaque: source => source.isAssignableTo(target),
+        parameter: source =>
+          // A type parameter is only assignable to a type parameter if they are
+          // the same parameter. For any other `target`, a type parameter is
+          // assignable to it if its constraint is.
+          target.kind === 'parameter' ?
+            source.identity === target.identity
+          : isAssignable({
+              source: source.constraint.assignableTo,
+              target,
+            }),
+        union: source =>
+          matchTypeFormat(target, {
+            function: target => isUnionAssignableToNonUnion({ source, target }),
+            application: target =>
+              isUnionAssignableToNonUnion({ source, target }),
+            indexedAccess: target =>
+              isUnionAssignableToNonUnion({ source, target }),
+            intrinsicApplication: target =>
+              isUnionAssignableToNonUnion({ source, target }),
+            object: target => isUnionAssignableToNonUnion({ source, target }),
+            opaque: target => isUnionAssignableToNonUnion({ source, target }),
+            parameter: target =>
+              isUnionAssignableToNonUnion({ source, target }),
+            union: target => {
+              // Return true if every member of the source is assignable to some
+              // member of the target.
+              for (const sourceMember of source.members) {
+                const sourceMemberIsAssignableToSomeMemberOfSupertype = (() => {
+                  const preparedTarget = simplifyUnionType(target)
+                  for (const targetMember of preparedTarget.members) {
+                    if (sourceMember === targetMember) {
+                      return true
+                    } else if (typeof targetMember !== 'string') {
+                      if (
+                        isAssignable({
+                          target: targetMember,
+                          source:
+                            typeof sourceMember !== 'string' ? sourceMember : (
+                              makeUnionType([sourceMember])
+                            ),
+                        })
+                      ) {
+                        return true
+                      }
+                    }
+                  }
+                  return false
+                })()
 
-              return (
-                // Contravariant parameter check:
-                isAssignable({
-                  source: target.signature.parameter,
-                  target:
-                    sourceParameterWithTypeParametersReplacedByConstraints,
-                }) &&
-                // Covariant return type check:
-                isAssignable({
-                  source:
-                    sourceReturnWithTypeParametersReplacedByTargetTypeParameters,
-                  target: target.signature.return,
-                })
-              )
-            }
-          },
-          application: _target => false,
-          indexedAccess: _target => false,
-          object: _target => false, // functions are never assignable to objects
-          opaque: target => target.isAssignableFrom(source),
-          parameter: _target => false, // a function type is never directly assignable to a type parameter
-          union: target => isNonUnionAssignableToUnion({ source, target }),
-        }),
-      indexedAccess: source =>
-        isAssignable({
-          source: replaceAllTypeParametersWithTheirConstraints(source),
-          target,
-        }),
-      object: source =>
-        matchTypeFormat(target, {
-          function: _ => false, // objects are never assignable to functions
-          application: _ => false,
-          indexedAccess: _ => false,
-          object: target => {
-            // Make sure all properties in the target are present and valid in
-            // the source (recursively). Values may have additional properties
-            // beyond what is required by the target and still be assignable to
-            // it.
-            for (const [key, typePropertyValue] of Object.entries(
-              target.children,
-            )) {
-              if (source.children[key] === undefined) {
-                return false
-              } else {
-                // Recursively check the property:
-                if (
-                  !isAssignable({
-                    source: source.children[key],
-                    target: typePropertyValue,
-                  })
-                ) {
+                if (!sourceMemberIsAssignableToSomeMemberOfSupertype) {
                   return false
                 }
               }
-            }
-            return true
-          },
-          opaque: target => target.isAssignableFrom(source),
-          parameter: _target => false, // an object type is never directly assignable to a type parameter
-          union: target => isNonUnionAssignableToUnion({ source, target }),
-        }),
-      opaque: source => source.isAssignableTo(target),
-      parameter: source =>
-        // A type parameter is only assignable to a type parameter if they are
-        // the same parameter. For any other `target`, a type parameter is
-        // assignable to it if its constraint is.
-        target.kind === 'parameter' ?
-          source.identity === target.identity
-        : isAssignable({
-            source: source.constraint.assignableTo,
-            target,
+              return true
+            },
           }),
-      union: source =>
-        matchTypeFormat(target, {
-          function: target => isUnionAssignableToNonUnion({ source, target }),
-          application: target =>
-            isUnionAssignableToNonUnion({ source, target }),
-          indexedAccess: target =>
-            isUnionAssignableToNonUnion({ source, target }),
-          object: target => isUnionAssignableToNonUnion({ source, target }),
-          opaque: target => isUnionAssignableToNonUnion({ source, target }),
-          parameter: target => isUnionAssignableToNonUnion({ source, target }),
-          union: target => {
-            // Return true if every member of the source is assignable to some
-            // member of the target.
-            for (const sourceMember of source.members) {
-              const sourceMemberIsAssignableToSomeMemberOfSupertype = (() => {
-                const preparedTarget = simplifyUnionType(target)
-                for (const targetMember of preparedTarget.members) {
-                  if (sourceMember === targetMember) {
-                    return true
-                  } else if (typeof targetMember !== 'string') {
-                    if (
-                      isAssignable({
-                        target: targetMember,
-                        source:
-                          typeof sourceMember !== 'string' ? sourceMember : (
-                            makeUnionType([sourceMember])
-                          ),
-                      })
-                    ) {
-                      return true
-                    }
-                  }
-                }
-                return false
-              })()
-
-              if (!sourceMemberIsAssignableToSomeMemberOfSupertype) {
-                return false
-              }
-            }
-            return true
-          },
-        }),
-    })
+      }))
   )
 }
 
@@ -311,6 +354,28 @@ const isUnionAssignableToNonUnion = ({
     }
     return true
   }
+}
+
+/**
+ * Returns a narrowed version of the `UnionType` if all of its members are
+ * literal atom types.
+ */
+export const asUnionWithLiteralAtomMembers = (
+  type: UnionType,
+): Option<
+  Omit<UnionType, 'members'> & { readonly members: ReadonlySet<Atom> }
+> => {
+  const simplifiedType = simplifyUnionType(type)
+
+  const atomMembers = [...simplifiedType.members].filter(
+    member => typeof member === 'string',
+  )
+
+  const isAtomUnion = atomMembers.length === simplifiedType.members.size
+
+  return !isAtomUnion ?
+      option.none
+    : option.makeSome(makeUnionType(atomMembers))
 }
 
 /**

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -1,6 +1,7 @@
-import type { None, Some } from '@matt.kantor/option'
-import option from '@matt.kantor/option'
+import type { Either } from '@matt.kantor/either'
+import option, { type None, type Some } from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
+import type { FunctionNodeCallError } from '../function-node.js'
 import type { TypeSymbol } from '../semantic-graph.js'
 
 export type FunctionType = {
@@ -67,6 +68,41 @@ export const makeApplicationType = (
   flexibleParameters,
 })
 
+/**
+ * A stuck application of a host-implemented standard library function. Standard
+ * library functions whose return type is concrete (e.g. `:atom.type ~>
+ * :atom.type ~> :atom.type` for `atom.append`) are lifted so their return
+ * becomes one of these, letting the type system compute the result type from
+ * argument types even when argument values are unelaborated.
+ *
+ * It reduces once every argument is a concrete atom type (or union thereof).
+ * Until then it stays stuck, behaving like `upperBound` for assignability
+ * purposes.
+ */
+export type IntrinsicApplicationType = {
+  readonly kind: 'intrinsicApplication'
+  readonly parameterTypes: readonly Type[]
+  readonly reduce: (
+    // `argumentValues` is expected to be aligned with `parameterTypes`.
+    // TODO: Support non-`Atom` arguments?
+    argumentValues: readonly Atom[],
+  ) => Either<FunctionNodeCallError, Type>
+  readonly upperBound: Type
+}
+
+export const makeIntrinsicApplicationType = (
+  parameterTypes: readonly Type[],
+  reduce: (
+    argumentValues: readonly Atom[],
+  ) => Either<FunctionNodeCallError, Type>,
+  upperBound: Type,
+): IntrinsicApplicationType => ({
+  kind: 'intrinsicApplication',
+  parameterTypes,
+  reduce,
+  upperBound,
+})
+
 export type ObjectType = {
   readonly kind: 'object'
   readonly children: Readonly<Record<Atom, Type>>
@@ -94,7 +130,7 @@ export const makeOpaqueType = (
     // cycle with `type-substitution.ts`. `makeOpaqueType` is called in static
     // module scope from `prelude-types.ts`.
     readonly upperBoundOfStuckType: (
-      type: ApplicationType | IndexedAccessType,
+      type: ApplicationType | IndexedAccessType | IntrinsicApplicationType,
     ) => Type
   } & (
     | {
@@ -121,6 +157,8 @@ export const makeOpaqueType = (
         application: source =>
           self.isAssignableFrom(subtyping.upperBoundOfStuckType(source)),
         indexedAccess: source =>
+          self.isAssignableFrom(subtyping.upperBoundOfStuckType(source)),
+        intrinsicApplication: source =>
           self.isAssignableFrom(subtyping.upperBoundOfStuckType(source)),
 
         function: _ => false,
@@ -152,6 +190,7 @@ export const makeOpaqueType = (
         application: _ => false,
         function: _ => false,
         indexedAccess: _ => false,
+        intrinsicApplication: _ => false,
         object: _ => false,
         opaque: target =>
           target === self ||
@@ -254,6 +293,7 @@ export type Type =
   | ApplicationType
   | FunctionType
   | IndexedAccessType
+  | IntrinsicApplicationType
   | ObjectType
   | OpaqueType
   | TypeParameter
@@ -265,6 +305,7 @@ export const matchTypeFormat = <Result>(
     application: (type: ApplicationType) => Result
     function: (type: FunctionType) => Result
     indexedAccess: (type: IndexedAccessType) => Result
+    intrinsicApplication: (type: IntrinsicApplicationType) => Result
     object: (type: ObjectType) => Result
     opaque: (type: OpaqueType) => Result
     parameter: (type: TypeParameter) => Result
@@ -277,6 +318,8 @@ export const matchTypeFormat = <Result>(
     case 'function':
       return cases[type.kind](type)
     case 'indexedAccess':
+      return cases[type.kind](type)
+    case 'intrinsicApplication':
       return cases[type.kind](type)
     case 'object':
       return cases[type.kind](type)

--- a/src/language/semantics/type-system/type-key-path.ts
+++ b/src/language/semantics/type-system/type-key-path.ts
@@ -1,12 +1,12 @@
 import either, { type Either } from '@matt.kantor/either'
-import option, { type Option } from '@matt.kantor/option'
+import option from '@matt.kantor/option'
 import type { ElaborationError, TypeMismatchError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import { quoteAtomIfNecessary } from '../../unparsing/plz-utilities.js'
 import type { ExpressionContext } from '../expression-elaboration.js'
 import type { ObjectNode } from '../object-node.js'
 import type { SemanticGraph } from '../semantic-graph.js'
-import { simplifyUnionType } from './subtyping.js'
+import { asUnionWithLiteralAtomMembers } from './subtyping.js'
 import {
   makeFunctionType,
   makeIndexedAccessType,
@@ -123,6 +123,7 @@ export const updateTypeAtKeyPathIfValid = (
       },
       application: type => type,
       indexedAccess: type => type,
+      intrinsicApplication: type => type,
       object: type => {
         if (typeof firstKey === 'string') {
           const next = type.children[firstKey]
@@ -210,6 +211,11 @@ export const atomKeyPathComponentFromType = (
         kind: 'typeMismatch',
         message: `${type.kind} types are not valid key path components`,
       }),
+    intrinsicApplication: _ =>
+      either.makeLeft({
+        kind: 'typeMismatch',
+        message: `${type.kind} types are not valid key path components`,
+      }),
     object: _ =>
       either.makeLeft({
         kind: 'typeMismatch',
@@ -225,6 +231,7 @@ export const atomKeyPathComponentFromType = (
         case 'application':
         case 'function':
         case 'indexedAccess':
+        case 'intrinsicApplication':
         case 'object':
         case 'opaque':
           return either.makeLeft({
@@ -270,28 +277,6 @@ export const atomKeyPathComponentFromType = (
       )
     },
   })
-
-/**
- * Returns a narrowed version of the `UnionType` if all of its members are
- * literal atom types.
- */
-const asUnionWithLiteralAtomMembers = (
-  type: UnionType,
-): Option<
-  Omit<UnionType, 'members'> & { readonly members: ReadonlySet<Atom> }
-> => {
-  const simplifiedType = simplifyUnionType(type)
-
-  const atomMembers = [...simplifiedType.members].filter(
-    member => typeof member === 'string',
-  )
-
-  const isAtomUnion = atomMembers.length === simplifiedType.members.size
-
-  return !isAtomUnion ?
-      option.none
-    : option.makeSome(makeUnionType(atomMembers))
-}
 
 const indexedAccessFromTypeKeyPathEntry = (
   object: Type,

--- a/src/language/semantics/type-system/type-parameter-analysis.ts
+++ b/src/language/semantics/type-system/type-parameter-analysis.ts
@@ -66,6 +66,10 @@ const containedTypeParametersImplementation = (
           containedTypeParametersImplementation(type.object, root),
           containedTypeParametersImplementation(type.key, root),
         ),
+      intrinsicApplication: type =>
+        [...type.parameterTypes, type.upperBound]
+          .map(type => containedTypeParametersImplementation(type, root))
+          .reduce(mergeTypeParametersByKeyPath, new Map()),
       opaque: _ => new Map(),
       parameter: type =>
         mergeTypeParametersByKeyPath(
@@ -163,6 +167,16 @@ const findKeyPathsToTypeParameterImplementation = (
             root,
           ),
         ]),
+      intrinsicApplication: type =>
+        new Set(
+          [...type.parameterTypes, type.upperBound].flatMap(type => [
+            ...findKeyPathsToTypeParameterImplementation(
+              type,
+              typeParameterToFind,
+              root,
+            ),
+          ]),
+        ),
       opaque: _ => new Set(),
       parameter: type =>
         new Set([

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -1,11 +1,14 @@
-import either from '@matt.kantor/either'
+import either, { type Either } from '@matt.kantor/either'
 import option, { type Option } from '@matt.kantor/option'
 import type { Writable } from '../../../utility-types.js'
+import type { Atom } from '../../parsing.js'
+import type { FunctionNodeCallError } from '../function-node.js'
 import { nothing, something } from './prelude-types.js'
-import { isAssignable } from './subtyping.js'
+import { asUnionWithLiteralAtomMembers, isAssignable } from './subtyping.js'
 import {
   makeApplicationType,
   makeFunctionType,
+  makeIntrinsicApplicationType,
   makeObjectType,
   makeTypeParameter,
   makeUnionType,
@@ -74,6 +77,25 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
           ) ?
             nothing
           : nestedIndexedAccess(applicationType, [
+              firstKey,
+              ...remainingKeyPath,
+            ])
+      },
+      intrinsicApplication: intrinsicApplicationType => {
+        // As with `ApplicationType`s, indexing stays stuck while the key path
+        // is valid for the upper bound. Otherwise the property doesn't exist.
+        const typeAtKeyPathInUpperBound = applyKeyPathToType(
+          replaceAllTypeParametersWithTheirConstraints(
+            intrinsicApplicationType,
+          ),
+          keyPath,
+        )
+        return (
+            typeAtKeyPathInUpperBound.kind === 'union' &&
+              typeAtKeyPathInUpperBound.members.size === 0
+          ) ?
+            nothing
+          : nestedIndexedAccess(intrinsicApplicationType, [
               firstKey,
               ...remainingKeyPath,
             ])
@@ -179,18 +201,20 @@ export const applyKeyPathToType = (type: Type, keyPath: TypeKeyPath): Type => {
 export const replaceAllTypeParametersWithTheirConstraints = (
   type: Type,
 ): Type =>
-  // TODO: Specialize this implementation to only traverse `type` once
-  [...containedTypeParameters(type).values()]
-    .flatMap(({ typeParameters }) => [...typeParameters.members])
-    .reduce(
-      (partiallyAppliedType, typeParameter) =>
-        supplyTypeArgument(
-          partiallyAppliedType,
-          typeParameter,
-          typeParameter.constraint.assignableTo,
-        ),
-      type,
-    )
+  type.kind === 'intrinsicApplication' ?
+    replaceAllTypeParametersWithTheirConstraints(type.upperBound)
+    // TODO: Specialize the below to only traverse `type` once.
+  : [...containedTypeParameters(type).values()]
+      .flatMap(({ typeParameters }) => [...typeParameters.members])
+      .reduce<Type>(
+        (partiallyAppliedType, typeParameter) =>
+          supplyTypeArgument(
+            partiallyAppliedType,
+            typeParameter,
+            typeParameter.constraint.assignableTo,
+          ),
+        type,
+      )
 
 /**
  * Finds concrete types for the `TypeParameter`s in `parameter` by locating the
@@ -210,6 +234,11 @@ export const getTypesForTypeParameters = ({
   // Avoid infinite recursion when we hit the top type.
   if (parameterType === something) {
     return new Map()
+  } else if (argumentType.kind === 'intrinsicApplication') {
+    return getTypesForTypeParameters({
+      parameterType,
+      argumentType: replaceAllTypeParametersWithTheirConstraints(argumentType),
+    })
   } else {
     return matchTypeFormat(parameterType, {
       function: parameterType =>
@@ -255,6 +284,9 @@ export const getTypesForTypeParameters = ({
       // argument from an enclosing function that hasn't been applied, so no
       // bindings are inferred from it.
       application: _ => new Map(),
+
+      // Likewise, a stuck intrinsic application yields no bindings.
+      intrinsicApplication: _ => new Map(),
 
       parameter: parameterType =>
         (
@@ -349,6 +381,10 @@ export const applicableFunctionSignatures = (
       applicableFunctionSignatures(
         replaceAllTypeParametersWithTheirConstraints(type),
       ),
+    intrinsicApplication: type =>
+      applicableFunctionSignatures(
+        replaceAllTypeParametersWithTheirConstraints(type),
+      ),
     object: _ => option.none,
     opaque: _ => option.none,
   })
@@ -378,6 +414,53 @@ const reduceApplication = (
         }),
       )
     : makeApplicationType(functionType, argumentType, flexibleParameters)
+}
+
+const cartesianProduct = <Element>(lists: readonly (readonly Element[])[]) =>
+  lists.reduce<readonly (readonly Element[])[]>(
+    (tuples, list) =>
+      tuples.flatMap(tuple => list.map(value => [...tuple, value])),
+    [[]],
+  )
+
+/**
+ * Attempt to reduce a (possibly stuck) intrinsic application.
+ */
+const reduceIntrinsicApplication = (
+  parameterTypes: readonly Type[],
+  reduce: (
+    argumentValues: readonly Atom[],
+  ) => Either<FunctionNodeCallError, Type>,
+  upperBound: Type,
+): Type => {
+  const argumentValues = parameterTypes.map(type =>
+    type.kind !== 'union' ? option.none : asUnionWithLiteralAtomMembers(type),
+  )
+  const stuck = makeIntrinsicApplicationType(parameterTypes, reduce, upperBound)
+  return option.match(option.sequence(argumentValues), {
+    none: _ => stuck,
+    some: argumentValues =>
+      either.match(
+        either.sequence(
+          cartesianProduct(argumentValues.map(union => [...union.members])).map(
+            reduce,
+          ),
+        ),
+        {
+          left: _ => stuck,
+          right: resultTypes =>
+            resultTypes.length === 1 && resultTypes[0] !== undefined ?
+              resultTypes[0]
+            : makeUnionType(
+                resultTypes.flatMap(resultType =>
+                  resultType.kind === 'union' ?
+                    [...resultType.members]
+                  : [resultType],
+                ),
+              ),
+        },
+      ),
+  })
 }
 
 /**
@@ -427,22 +510,38 @@ export const supplyTypeArgument = (
           supplyTypeArgument(type.argument, typeParameter, typeArgument),
           type.flexibleParameters,
         ),
-      indexedAccess: type =>
-        either.match(
-          atomKeyPathComponentFromType(
-            supplyTypeArgument(type.key, typeParameter, typeArgument),
+      intrinsicApplication: type =>
+        reduceIntrinsicApplication(
+          type.parameterTypes.map(parameterType =>
+            supplyTypeArgument(parameterType, typeParameter, typeArgument),
           ),
-          {
-            left: _ =>
-              // TODO: Should this trigger an error?
-              nothing,
-            right: key =>
-              applyKeyPathToType(
-                supplyTypeArgument(type.object, typeParameter, typeArgument),
-                [key],
-              ),
-          },
+          type.reduce,
+          supplyTypeArgument(type.upperBound, typeParameter, typeArgument),
         ),
+      indexedAccess: type => {
+        const substitutedKey = supplyTypeArgument(
+          type.key,
+          typeParameter,
+          typeArgument,
+        )
+        // A stuck intrinsic application used as a key (e.g. an `atom.equals`
+        // application) is reduced to its upper bound so indexing can proceed
+        // (e.g. `{ false: …, true: … }[boolean]`).
+        const keyForIndexing =
+          substitutedKey.kind === 'intrinsicApplication' ?
+            replaceAllTypeParametersWithTheirConstraints(substitutedKey)
+          : substitutedKey
+        return either.match(atomKeyPathComponentFromType(keyForIndexing), {
+          left: _ =>
+            // TODO: Should this trigger an error?
+            nothing,
+          right: key =>
+            applyKeyPathToType(
+              supplyTypeArgument(type.object, typeParameter, typeArgument),
+              [key],
+            ),
+        })
+      },
       opaque: type => type,
       parameter: type =>
         type.identity === typeParameter.identity ? typeArgument : type,


### PR DESCRIPTION
Many standard library functions can now be narrowly analyzed at the type level, e.g. `(@runtime { _ => 1 }) + (@runtime { _ => 1 })` is now statically known to have the type `2` (previously it was inferred as `:integer.type`).

This is a fairly sizeable change which introduces new machinery like `IntrinsicApplicationType` (but it's better than I feared—I was worried I'd have to implement all stdlib functions again at the type level). It's also not fully general (only atomic arguments are handled precisely, not objects/functions). I'll probably iterate more in this area in the future.

Ignoring whitespace improves the diff.