### PR TITLE
Improve `@union` => `UnionType` conversion during inference

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -954,6 +954,17 @@ testCases(
   ],
 
   [
+    `((x: :atom.type) => @if {
+       @runtime { context => :context.program.start_time atom.equals foo }
+       { deeper: :x }
+       foo
+     }) ~ ((y: :atom.type) => ({ deeper: :y } | foo))`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
     `{
       apply_to_1: (identity: (a => :a)) => :identity(1)
       :apply_to_1(:identity) ~ 1

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -19,6 +19,7 @@ import {
   readLookupExpression,
   readPanicExpression,
   readRuntimeExpression,
+  readUnionExpression,
   type ExpressionContext,
   type FunctionParameterTypeInfo,
   type KeyPath,
@@ -462,6 +463,33 @@ const inferTypeImplementation = (
   const panicExpressionResult = readPanicExpression(node)
   if (either.isRight(panicExpressionResult)) {
     return cacheOnSuccess(either.makeRight(types.nothing))
+  }
+
+  // @union: infer each member as a type and combine them into a (flat) union.
+  const unionExpressionResult = readUnionExpression(node)
+  if (either.isRight(unionExpressionResult)) {
+    return cacheOnSuccess(
+      either.map(
+        either.sequence(
+          Object.entries(unionExpressionResult.value[1]).map(([key, member]) =>
+            inferTypeImplementation(
+              member,
+              parameterTypes,
+              lookingUpKeys,
+              descendantContext(['1', key]),
+            ),
+          ),
+        ),
+        memberTypes =>
+          makeUnionType(
+            memberTypes.flatMap(memberType =>
+              memberType.kind === 'union' ?
+                [...memberType.members]
+              : [memberType],
+            ),
+          ),
+      ),
+    )
   }
 
   if (isObjectNode(node) && containsAnyUnelaboratedNodes(node)) {


### PR DESCRIPTION
Previously this fell through to `literalTypeFromSemanticGraph`, but there are edge cases that doesn't handle well.

I'm going to try to move away from relying on `literalTypeFromSemanticGraph` as much as possible.