### PR TITLE
Interpret `@check` type annotations with `inferType`

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -965,6 +965,25 @@ testCases(
   ],
 
   [
+    `(x: :atom.type) => (:x ~ :x)`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(x: :atom.type) =>
+      (@if {
+         @runtime { context => :context.program.start_time atom.equals foo }
+         :x
+         foo
+       } ~ (:x | foo))`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
     `{
       apply_to_1: (identity: (a => :a)) => :identity(1)
       :apply_to_1(:identity) ~ 1

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -10,10 +10,7 @@ import {
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
-import {
-  inferType,
-  literalTypeFromSemanticGraph,
-} from '../../../semantics/type-system.js'
+import { inferType } from '../../../semantics/type-system.js'
 
 const check = ({
   value,
@@ -30,23 +27,29 @@ const check = ({
       location: [...context.location, '1', 'value'],
     }),
     valueAsType =>
-      either.flatMap(literalTypeFromSemanticGraph(type), typeAsType => {
-        if (
-          isAssignable({
-            source: valueAsType,
-            target: typeAsType,
-          })
-        ) {
-          return either.makeRight(value)
-        } else {
-          return either.makeLeft({
-            kind: 'typeMismatch',
-            message: `the value \`${stringifySemanticGraphForEndUser(
-              value,
-            )}\` (inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) is not assignable to the type \`${stringifyTypeForEndUser(typeAsType)}\``,
-          })
-        }
-      }),
+      either.flatMap(
+        inferType(type, {
+          ...context,
+          location: [...context.location, '1', 'type'],
+        }),
+        typeAsType => {
+          if (
+            isAssignable({
+              source: valueAsType,
+              target: typeAsType,
+            })
+          ) {
+            return either.makeRight(value)
+          } else {
+            return either.makeLeft({
+              kind: 'typeMismatch',
+              message: `the value \`${stringifySemanticGraphForEndUser(
+                value,
+              )}\` (inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) is not assignable to the type \`${stringifyTypeForEndUser(typeAsType)}\``,
+            })
+          }
+        },
+      ),
   )
 
 export const checkKeywordHandler: KeywordHandler = (


### PR DESCRIPTION
The right-hand side of `~` was interpreted with `literalTypeFromSemanticGraph`, which can't resolve type parameter references and fell back to structural object types for most expressions. It now uses `inferType` instead.