### PR TITLE
Improve `@hole` handling during type inference

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1478,6 +1478,16 @@ testCases(
   ],
 
   [
+    `{
+      lookup_foo: a => (f: :a ~> (?b: { foo: :a })) => :f(:a).foo
+      :lookup_foo(hello)(@runtime { _ => _ => { foo: hello } }) ~ hello
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
     `{ outer: a => (f: :a ~> ?b) => ((g: :f(:a)) => :g)(:f(:a)) }`,
     result => {
       assert(either.isRight(result))

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -30,7 +30,11 @@ import {
   getParameterTypeAnnotation,
   type FunctionExpression,
 } from '../expressions/function-expression.js'
-import { collectHoleTypeParameterIdentities } from '../expressions/hole-expression.js'
+import {
+  collectHoleTypeParameterIdentities,
+  getHoleTypeParameter,
+  readHoleExpression,
+} from '../expressions/hole-expression.js'
 import { genericizeFunctionParameterAnnotation } from './genericize-function-parameter.js'
 import { literalTypeFromSemanticGraph } from './literal-type.js'
 import * as types from './prelude-types.js'
@@ -489,6 +493,14 @@ const inferTypeImplementation = (
             ),
           ),
       ),
+    )
+  }
+
+  // @hole: a hole denotes its type parameter.
+  const holeExpressionResult = readHoleExpression(node)
+  if (either.isRight(holeExpressionResult)) {
+    return cacheOnSuccess(
+      either.makeRight(getHoleTypeParameter(holeExpressionResult.value)),
     )
   }
 


### PR DESCRIPTION
Same idea as #203, but for `@hole` instead of `@union`.