### PR TITLE
Drop "-prototype" suffix from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A functional programming language oriented around edge-labeled trees[^1].
 ## Quick Start
 
 ```sh
-git clone git@github.com:mkantor/please-lang-prototype.git
-cd please-lang-prototype
+git clone git@github.com:mkantor/please-lang.git
+cd please-lang
 npm install
 npm run build
 echo '@runtime { context => :context.program.start_time }' | ./please


### PR DESCRIPTION
It's still a prototype (the README continues to call this out), but that fact doesn't need to be encoded in the URL.

I imagine future development on post-prototype implementations will occur in this same repository (there probably won't even be a bright line—more of a "Ship of Theseus" process).

I've already renamed the repository on GitHub. The old URL will continue to work.