### PR TITLE
Implement "exact" `ObjectType`s

### DIFF
--- a/src/language/semantics/expressions/hole-expression.ts
+++ b/src/language/semantics/expressions/hole-expression.ts
@@ -81,7 +81,10 @@ export const readHoleExpression = (
                 node[typeParameterKey]
               : undefined
             return either.map(
-              literalTypeFromSemanticGraph(assignableToNode),
+              literalTypeFromSemanticGraph(assignableToNode, {
+                // Constraints are merely upper bounds.
+                objectsAreExact: false,
+              }),
               assignableTo => {
                 const typeParameter =
                   existingTypeParameter ??

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -85,24 +85,29 @@ export const globalFunctions = {
     },
     type =>
       either.makeRight(value =>
-        either.flatMap(literalTypeFromSemanticGraph(value), valueAsType =>
-          either.flatMap(literalTypeFromSemanticGraph(type), typeAsType => {
-            if (
-              isAssignable({
-                source: valueAsType,
-                target: typeAsType,
-              })
-            ) {
-              return either.makeRight(value)
-            } else {
-              return either.makeLeft({
-                kind: 'typeMismatch',
-                message: `the value \`${stringifySemanticGraphForEndUser(
-                  value,
-                )}\` is not assignable to the type \`${stringifyTypeForEndUser(typeAsType)}\``,
-              })
-            }
-          }),
+        either.flatMap(
+          literalTypeFromSemanticGraph(value, { objectsAreExact: true }),
+          valueAsType =>
+            either.flatMap(
+              literalTypeFromSemanticGraph(type, { objectsAreExact: false }),
+              typeAsType => {
+                if (
+                  isAssignable({
+                    source: valueAsType,
+                    target: typeAsType,
+                  })
+                ) {
+                  return either.makeRight(value)
+                } else {
+                  return either.makeLeft({
+                    kind: 'typeMismatch',
+                    message: `the value \`${stringifySemanticGraphForEndUser(
+                      value,
+                    )}\` is not assignable to the type \`${stringifyTypeForEndUser(typeAsType)}\``,
+                  })
+                }
+              },
+            ),
         ),
       ),
   ),

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -230,6 +230,8 @@ const synthesizeTypeParameterName = (index: number) => {
 // The reducers below apply an intrinsic function (`f`) to concrete argument
 // atoms (unit types), lifting the result back to a type. This lets
 // `IntrinsicApplicationType`s reduce via the same code that evaluates values.
+// Returned object types are exact because they describe actual values produced
+// by `f`.
 
 const intrinsicApplicationTypeReducerArity1 =
   (f: FunctionNodeCallSignature) =>
@@ -242,7 +244,10 @@ const intrinsicApplicationTypeReducerArity1 =
         })
       : either.flatMap(
           f(argument, emptyContextForStdlibApplications),
-          literalTypeFromSemanticGraph,
+          resultValue =>
+            literalTypeFromSemanticGraph(resultValue, {
+              objectsAreExact: true,
+            }),
         )
   }
 
@@ -263,7 +268,10 @@ const intrinsicApplicationTypeReducerArity2 =
           either.flatMap(f(argument1), f1 =>
             f1(argument2, emptyContextForStdlibApplications),
           ),
-          literalTypeFromSemanticGraph,
+          resultValue =>
+            literalTypeFromSemanticGraph(resultValue, {
+              objectsAreExact: true,
+            }),
         )
   }
 
@@ -295,7 +303,10 @@ const intrinsicApplicationTypeReducerArity3 =
               f2(argument3, emptyContextForStdlibApplications),
             ),
           ),
-          literalTypeFromSemanticGraph,
+          resultValue =>
+            literalTypeFromSemanticGraph(resultValue, {
+              objectsAreExact: true,
+            }),
         )
   }
 
@@ -376,18 +387,21 @@ const refineReturnedFunctionType = (
   returnedType: FunctionType,
   argument: SemanticGraph,
 ): Either<FunctionNodeCallError, FunctionType> =>
-  either.flatMap(literalTypeFromSemanticGraph(argument), argumentType => {
-    const refinedReturnType = supplyTypeArguments(
-      returnedType,
-      getTypesForTypeParameters({
-        parameterType,
-        argumentType,
-      }),
-    )
-    return refinedReturnType.kind === 'function' ?
-        either.makeRight(refinedReturnType)
-      : either.makeLeft({
-          kind: 'bug',
-          message: `supplying type arguments to a standard library function somehow transformed it into a ${refinedReturnType.kind} type`,
-        })
-  })
+  either.flatMap(
+    literalTypeFromSemanticGraph(argument, { objectsAreExact: true }),
+    argumentType => {
+      const refinedReturnType = supplyTypeArguments(
+        returnedType,
+        getTypesForTypeParameters({
+          parameterType,
+          argumentType,
+        }),
+      )
+      return refinedReturnType.kind === 'function' ?
+          either.makeRight(refinedReturnType)
+        : either.makeLeft({
+            kind: 'bug',
+            message: `supplying type arguments to a standard library function somehow transformed it into a ${refinedReturnType.kind} type`,
+          })
+    },
+  )

--- a/src/language/semantics/type-system/genericize-function-parameter.ts
+++ b/src/language/semantics/type-system/genericize-function-parameter.ts
@@ -12,6 +12,7 @@ import {
   stringifyTypeKeyPathForEndUser,
   type TypeKeyPath,
 } from './type-key-path.js'
+import { recursivelyInexact } from './type-substitution.js'
 
 export type GenericizedFunctionParameterAnnotation = {
   readonly type: Type
@@ -111,7 +112,10 @@ const genericizeLeaf =
   (leafType: Type): GenericizedFunctionParameterAnnotation => {
     const typeParameter = makeTypeParameter(
       synthesizeTypeParameterName(parameterName, keyPath),
-      { assignableTo: leafType },
+      {
+        // The constraint is an upper bound, so it can't be exact.
+        assignableTo: recursivelyInexact(leafType),
+      },
     )
     return {
       type: typeParameter,

--- a/src/language/semantics/type-system/literal-type.ts
+++ b/src/language/semantics/type-system/literal-type.ts
@@ -25,6 +25,7 @@ import { makeObjectType, makeUnionType, type Type } from './type-formats.js'
  */
 export const literalTypeFromSemanticGraph = (
   node: SemanticGraph,
+  options: { readonly objectsAreExact: boolean },
 ): Either<Bug, Type> => {
   if (typeof node === 'string') {
     return either.makeRight({
@@ -51,7 +52,9 @@ export const literalTypeFromSemanticGraph = (
       right: unionExpression =>
         either.map(
           either.sequence(
-            Object.values(unionExpression[1]).map(literalTypeFromSemanticGraph),
+            Object.values(unionExpression[1]).map(member =>
+              literalTypeFromSemanticGraph(member, options),
+            ),
           ),
           memberTypes =>
             makeUnionType(
@@ -71,13 +74,16 @@ export const literalTypeFromSemanticGraph = (
             either.map(
               either.sequence(
                 Object.entries(node).map(([key, value]) =>
-                  either.map(literalTypeFromSemanticGraph(value), childType => [
-                    key,
-                    childType,
-                  ]),
+                  either.map(
+                    literalTypeFromSemanticGraph(value, options),
+                    childType => [key, childType],
+                  ),
                 ),
               ),
-              entries => makeObjectType(Object.fromEntries(entries)),
+              entries =>
+                makeObjectType(Object.fromEntries(entries), {
+                  exact: options.objectsAreExact,
+                }),
             ),
         ),
     })

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -619,6 +619,18 @@ typeAssignabilitySuite('custom types (assignable)', [
     ],
     true,
   ],
+  [
+    [makeObjectType({}, { exact: true }), makeObjectType({}, { exact: true })],
+    true,
+  ],
+  [
+    [
+      // exact object types are assignable to inexact ones
+      makeObjectType({ a: makeUnionType(['a']) }, { exact: true }),
+      makeObjectType({}),
+    ],
+    true,
+  ],
   // TODO: Improve assignability checks for unions of objects to make this test
   // case pass:
   // [
@@ -778,6 +790,11 @@ typeAssignabilitySuite('custom types (not assignable)', [
         return: makeUnionType(['a', 'b']),
       }),
     ],
+    false,
+  ],
+  [
+    // inexact object types are not assignable to exact ones
+    [makeObjectType({}, { exact: false }), makeObjectType({}, { exact: true })],
     false,
   ],
 ])

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -231,28 +231,33 @@ export const isAssignable = ({
               )
             },
             object: target => {
-              // Make sure all properties in the target are present and valid in
-              // the source (recursively). Values may have additional properties
-              // beyond what is required by the target and still be assignable to
-              // it.
-              for (const [key, typePropertyValue] of Object.entries(
-                target.children,
-              )) {
-                if (source.children[key] === undefined) {
-                  return false
-                } else {
-                  // Recursively check the property:
-                  if (
-                    !isAssignable({
-                      source: source.children[key],
-                      target: typePropertyValue,
-                    })
-                  ) {
+              if (target.exact && !source.exact) {
+                // Inexact object types aren't assignable to exact ones.
+                return false
+              } else {
+                // Make sure all properties in the target are present and valid
+                // in the source (recursively). Values may have additional
+                // properties beyond what is required by the target and still be
+                // assignable to it.
+                for (const [key, typePropertyValue] of Object.entries(
+                  target.children,
+                )) {
+                  if (source.children[key] === undefined) {
                     return false
+                  } else {
+                    // Recursively check the property:
+                    if (
+                      !isAssignable({
+                        source: source.children[key],
+                        target: typePropertyValue,
+                      })
+                    ) {
+                      return false
+                    }
                   }
                 }
+                return true
               }
-              return true
             },
             opaque: target => target.isAssignableFrom(source),
             parameter: _target => false, // an object type is never directly assignable to a type parameter

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -108,13 +108,20 @@ export const makeIntrinsicApplicationType = (
 export type ObjectType = {
   readonly kind: 'object'
   readonly children: Readonly<Record<Atom, Type>>
+  /**
+   * When `true`, every inhabitant of this type has exactly the specified keys
+   * and can't be subtyped by objects with additional properties.
+   */
+  readonly exact: boolean
 }
 
 export const makeObjectType = <Children extends Readonly<Record<Atom, Type>>>(
   children: Children,
+  options: { readonly exact: boolean } = { exact: false },
 ): ObjectType & { readonly children: Children } => ({
   kind: 'object',
   children,
+  exact: options.exact,
 })
 
 export type OpaqueType = {

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -146,7 +146,9 @@ const inferTypeImplementation = (
     typeof node === 'symbol' ||
     typeof node === 'function'
   ) {
-    return cacheOnSuccess(literalTypeFromSemanticGraph(node))
+    return cacheOnSuccess(
+      literalTypeFromSemanticGraph(node, { objectsAreExact: false }),
+    )
   }
 
   // @function: infer parameter type from context (or an explicit annotation)

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -58,6 +58,7 @@ import {
   applicableFunctionSignatures,
   applyKeyPathToType,
   getTypesForTypeParameters,
+  recursivelyInexact,
   supplyTypeArguments,
 } from './type-substitution.js'
 
@@ -519,7 +520,12 @@ const inferTypeImplementation = (
           ),
         ),
       ),
-      entries => makeObjectType(Object.fromEntries(entries)),
+      entries =>
+        makeObjectType(Object.fromEntries(entries), {
+          // Expressions will have different keys after elaboration, otherwise
+          // this is a literal object where all properties are known.
+          exact: !isExpression(node),
+        }),
     ),
   )
 }
@@ -576,7 +582,8 @@ const getFunctionParameterType = (
               // to describe concrete function types rather than generic ones.
               if (parameterName === ignoredKey) {
                 return {
-                  parameterType: annotationType,
+                  // Function parameter types are always inexact.
+                  parameterType: recursivelyInexact(annotationType),
                   typeParametersBoundByFunction: new Set<symbol>(),
                 }
               } else {
@@ -654,7 +661,8 @@ const getFunctionParameterType = (
                     contextuallyAppliedFunctionType.value.signature.parameter
                       .signature.parameter
                   return option.makeSome({
-                    parameterType: borrowedParameterType,
+                    // Function parameter types are always inexact.
+                    parameterType: recursivelyInexact(borrowedParameterType),
                     typeParametersBoundByFunction:
                       typeParameterIdentitiesWithinType(borrowedParameterType),
                   })

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -4,13 +4,11 @@ import type { ElaborationError } from '../../errors.js'
 import type { Atom } from '../../parsing.js'
 import {
   applyKeyPathToSemanticGraph,
-  containsAnyUnelaboratedNodes,
   getParameterName,
   ignoredKey,
   isAssignable,
   isExpression,
   isFunctionNode,
-  isObjectNode,
   lookup,
   readApplyExpression,
   readFunctionExpression,
@@ -504,29 +502,26 @@ const inferTypeImplementation = (
     )
   }
 
-  if (isObjectNode(node) && containsAnyUnelaboratedNodes(node)) {
-    // Infer unelaborated descendants' types.
-    return cacheOnSuccess(
-      either.map(
-        either.sequence(
-          Object.entries(node).map(([key, value]) =>
-            either.map(
-              inferTypeImplementation(
-                value,
-                parameterTypes,
-                lookingUpKeys,
-                descendantContext([key]),
-              ),
-              childType => [key, childType] as const,
+  // Non-specific default case for object nodes: recurse into properties and
+  // infer their types, then create an `ObjectType`.
+  return cacheOnSuccess(
+    either.map(
+      either.sequence(
+        Object.entries(node).map(([key, value]) =>
+          either.map(
+            inferTypeImplementation(
+              value,
+              parameterTypes,
+              lookingUpKeys,
+              descendantContext([key]),
             ),
+            childType => [key, childType],
           ),
         ),
-        entries => makeObjectType(Object.fromEntries(entries)),
       ),
-    )
-  } else {
-    return cacheOnSuccess(literalTypeFromSemanticGraph(node))
-  }
+      entries => makeObjectType(Object.fromEntries(entries)),
+    ),
+  )
 }
 
 /**

--- a/src/language/semantics/type-system/type-key-path.ts
+++ b/src/language/semantics/type-system/type-key-path.ts
@@ -130,14 +130,17 @@ export const updateTypeAtKeyPathIfValid = (
           if (next === undefined) {
             return type
           } else {
-            return makeObjectType({
-              ...type.children,
-              [firstKey]: updateTypeAtKeyPathIfValid(
-                next,
-                remainingKeyPath,
-                operation,
-              ),
-            })
+            return makeObjectType(
+              {
+                ...type.children,
+                [firstKey]: updateTypeAtKeyPathIfValid(
+                  next,
+                  remainingKeyPath,
+                  operation,
+                ),
+              },
+              { exact: type.exact },
+            )
           }
         } else {
           return type

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import { testCases } from '../../../test-utilities.test.js'
 import { stringifyKeyPathForEndUser, type KeyPath } from '../key-path.js'
 import { stringifyTypeForEndUser } from '../semantic-graph.js'
@@ -219,6 +220,34 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
     ]),
   ],
 ])
+
+const genericizationConstraintSuite = testCases(
+  (annotation: Type) =>
+    genericizeFunctionParameterAnnotation('x', annotation).type,
+  annotation =>
+    `genericizing \`x: ${stringifyTypeForEndUser(annotation)}\` strips exactness`,
+)
+
+genericizationConstraintSuite(
+  'genericization produces inexact object constraints',
+  [
+    [
+      // The constraint is an upper bound for its instantiations (which should
+      // admit subtypes), so it must not be exact.
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+      ]),
+      parameterType => {
+        assert(parameterType.kind === 'parameter')
+        const constraint = parameterType.constraint.assignableTo
+        assert(constraint.kind === 'union')
+        const [member] = [...constraint.members]
+        assert(typeof member === 'object' && member.kind === 'object')
+        assert.deepEqual(member.exact, false)
+      },
+    ],
+  ],
+)
 
 const genericizeParameterAnnotationSuite = testCases(
   ([parameterName, annotation]: readonly [

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -8,6 +8,7 @@ import { asUnionWithLiteralAtomMembers, isAssignable } from './subtyping.js'
 import {
   makeApplicationType,
   makeFunctionType,
+  makeIndexedAccessType,
   makeIntrinsicApplicationType,
   makeObjectType,
   makeTypeParameter,
@@ -511,7 +512,7 @@ export const supplyTypeArgument = (
             typeArgument,
           )
         }
-        return makeObjectType(substitutedChildren)
+        return makeObjectType(substitutedChildren, { exact: type.exact })
       },
       application: type =>
         reduceApplication(
@@ -586,6 +587,69 @@ export const supplyTypeArguments = (
     (partiallyAppliedType, [typeParameter, typeArgument]) =>
       supplyTypeArgument(partiallyAppliedType, typeParameter, typeArgument),
     type,
+  )
+
+/**
+ * Recursively clear `exact` from every object type within `type`. Used when a
+ * type is adopted from a user-written type position (e.g. parameter type
+ * annotations), where subtyping means wider values may inhabit it.
+ *
+ * Type parameters are kept by reference (their identities matter), so their
+ * constraints are not adjusted here; make sure constraints are inexact while
+ * creating type parameters instead.
+ */
+export const recursivelyInexact = (type: Type): Type =>
+  // Avoid infinite recursion when we hit the top type.
+  type === something ? type : (
+    matchTypeFormat<Type>(type, {
+      application: type =>
+        makeApplicationType(
+          recursivelyInexact(type.function),
+          recursivelyInexact(type.argument),
+          type.parametersStuckOn,
+        ),
+      function: type =>
+        makeFunctionType({
+          parameter: recursivelyInexact(type.signature.parameter),
+          return: recursivelyInexact(type.signature.return),
+        }),
+      indexedAccess: type =>
+        makeIndexedAccessType(
+          recursivelyInexact(type.object),
+          recursivelyInexact(type.key),
+        ),
+      intrinsicApplication: type =>
+        makeIntrinsicApplicationType(
+          type.parameterTypes.map(recursivelyInexact),
+          type.reduce,
+          recursivelyInexact(type.upperBound),
+        ),
+      object: type =>
+        makeObjectType(
+          Object.fromEntries(
+            Object.entries(type.children).map(([key, child]) => [
+              key,
+              recursivelyInexact(child),
+            ]),
+          ),
+          { exact: false },
+        ),
+      opaque: type => type,
+      parameter: type => type,
+      union: type =>
+        makeUnionType(
+          [...type.members].flatMap(member => {
+            if (typeof member === 'string') {
+              return [member]
+            } else {
+              const strippedMember = recursivelyInexact(member)
+              return strippedMember.kind === 'union' ?
+                  [...strippedMember.members]
+                : [strippedMember]
+            }
+          }),
+        ),
+    })
   )
 
 const isNothing = (type: Type) =>


### PR DESCRIPTION
Exact object types cannot be width-subtyped (objects with excess properties not explicitly listed in the type aren't inhabitants of the type).

This concept doesn't have explicit user-facing syntax and is not especially useful on its own, but it's necessary for an upcoming enhancement: statically refining applications of object-returning standard library functions (a generalization of #200).