### PR TITLE
Generalize intrinsic application analysis to object-typed arguments

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1904,4 +1904,65 @@ testCases(
       assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
+
+  [
+    `({ a: 1 } object.overlay @runtime { _ => { b: 2 } }) ~ { a: 1, b: 2 }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `({ a: 1 } object.overlay @runtime { _ => { a: 2 } }) ~ { a: 2 }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `({ a: 1 } object.overlay @runtime { _ => { a: 2 } }) ~ { a: 1 }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `({ a: 1 } object.overlay @runtime { context =>
+      @if {
+        @runtime { context =>
+          :context.program.start_time atom.equals "arbitrary atom"
+        }
+        { b: 2 }
+        { b: 3 }
+      }
+    }) ~ ({ a: 1, b: 2 } | { a: 1, b: 3 })`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    // TODO: It'd be great to be able to reason generically about non-literal
+    // standard library function arguments so cases like this typecheck.
+    `({ a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }) ~ { a: 1, b: :atom.type }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `({ a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }) ~ :something.type`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `:object.from_property(@runtime { _ => some_key })("some value") ~ { some_key: "some value" }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
 ])

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -1,6 +1,5 @@
 import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
-import type { Atom } from '../../parsing.js'
 import {
   keyPathToLookupExpression,
   makeApplyExpression,
@@ -228,15 +227,17 @@ const synthesizeTypeParameterName = (index: number) => {
 }
 
 // The reducers below apply an intrinsic function (`f`) to concrete argument
-// atoms (unit types), lifting the result back to a type. This lets
+// values, lifting the result back to a type. This lets
 // `IntrinsicApplicationType`s reduce via the same code that evaluates values.
 // Returned object types are exact because they describe actual values produced
 // by `f`.
 
 const intrinsicApplicationTypeReducerArity1 =
   (f: FunctionNodeCallSignature) =>
-  (argumentAtoms: readonly Atom[]): Either<FunctionNodeCallError, Type> => {
-    const [argument] = argumentAtoms
+  (
+    argumentValues: readonly SemanticGraph[],
+  ): Either<FunctionNodeCallError, Type> => {
+    const [argument] = argumentValues
     return argument === undefined ?
         either.makeLeft({
           kind: 'bug',
@@ -257,8 +258,10 @@ const intrinsicApplicationTypeReducerArity2 =
       argument1: SemanticGraph,
     ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
   ) =>
-  (argumentAtoms: readonly Atom[]): Either<FunctionNodeCallError, Type> => {
-    const [argument1, argument2] = argumentAtoms
+  (
+    argumentValues: readonly SemanticGraph[],
+  ): Either<FunctionNodeCallError, Type> => {
+    const [argument1, argument2] = argumentValues
     return argument1 === undefined || argument2 === undefined ?
         either.makeLeft({
           kind: 'bug',
@@ -286,8 +289,10 @@ const intrinsicApplicationTypeReducerArity3 =
       ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>
     >,
   ) =>
-  (argumentAtoms: readonly Atom[]): Either<FunctionNodeCallError, Type> => {
-    const [argument1, argument2, argument3] = argumentAtoms
+  (
+    argumentValues: readonly SemanticGraph[],
+  ): Either<FunctionNodeCallError, Type> => {
+    const [argument1, argument2, argument3] = argumentValues
     return (
         argument1 === undefined ||
           argument2 === undefined ||
@@ -352,7 +357,7 @@ const signatureParts = (
 const liftIntrinsicSignature = (
   signature: FunctionType['signature'],
   reduce: (
-    argumentAtoms: readonly Atom[],
+    argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
 ): FunctionType['signature'] => {
   if (containedTypeParameters(makeFunctionType(signature)).size > 0) {

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -2,7 +2,7 @@ import type { Either } from '@matt.kantor/either'
 import option, { type None, type Some } from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
 import type { FunctionNodeCallError } from '../function-node.js'
-import type { TypeSymbol } from '../semantic-graph.js'
+import type { SemanticGraph, TypeSymbol } from '../semantic-graph.js'
 
 export type FunctionType = {
   readonly kind: 'function'
@@ -77,17 +77,16 @@ export const makeApplicationType = (
  * becomes one of these, letting the type system compute the result type from
  * argument types even when argument values are unelaborated.
  *
- * It reduces once every argument is a concrete atom type (or union thereof).
- * Until then it stays stuck, behaving like `upperBound` for assignability
- * purposes.
+ * It reduces once every argument type's inhabitants can be exhaustively
+ * enumerated (the type is finitely-sized). Until then it stays stuck, behaving
+ * like `upperBound` for assignability purposes.
  */
 export type IntrinsicApplicationType = {
   readonly kind: 'intrinsicApplication'
   readonly parameterTypes: readonly Type[]
   readonly reduce: (
     // `argumentValues` is expected to be aligned with `parameterTypes`.
-    // TODO: Support non-`Atom` arguments?
-    argumentValues: readonly Atom[],
+    argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>
   readonly upperBound: Type
 }
@@ -95,7 +94,7 @@ export type IntrinsicApplicationType = {
 export const makeIntrinsicApplicationType = (
   parameterTypes: readonly Type[],
   reduce: (
-    argumentValues: readonly Atom[],
+    argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
   upperBound: Type,
 ): IntrinsicApplicationType => ({

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -1,7 +1,15 @@
+import either, { type Either } from '@matt.kantor/either'
+import optionAdt from '@matt.kantor/option'
 import assert from 'node:assert'
 import { testCases } from '../../../test-utilities.test.js'
+import type { FunctionNodeCallError } from '../function-node.js'
 import { stringifyKeyPathForEndUser, type KeyPath } from '../key-path.js'
-import { stringifyTypeForEndUser } from '../semantic-graph.js'
+import { objectNodeFromOrderedEntries } from '../object-node.js'
+import {
+  stringifySemanticGraphForEndUser,
+  stringifyTypeForEndUser,
+  type SemanticGraph,
+} from '../semantic-graph.js'
 import { genericizeFunctionParameterAnnotation } from './genericize-function-parameter.js'
 import {
   atom,
@@ -14,6 +22,7 @@ import {
 } from './prelude-types.js'
 import {
   makeFunctionType,
+  makeIntrinsicApplicationType,
   makeObjectType,
   makeTypeParameter,
   makeUnionType,
@@ -22,7 +31,9 @@ import {
 } from './type-formats.js'
 import {
   applyKeyPathToType,
+  enumerateInhabitants,
   getTypesForTypeParameters,
+  supplyTypeArgument,
 } from './type-substitution.js'
 
 const A = makeTypeParameter('a', { assignableTo: something })
@@ -218,6 +229,154 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
       [A, atom],
       [B, naturalNumber],
     ]),
+  ],
+])
+
+const enumerateInhabitantsSuite = testCases(
+  (type: Type) => enumerateInhabitants(type),
+  type => `enumerating the inhabitants of \`${stringifyTypeForEndUser(type)}\``,
+)
+
+enumerateInhabitantsSuite('enumerateInhabitants', [
+  [makeUnionType(['x']), optionAdt.makeSome(['x'])],
+
+  [makeUnionType(['x', 'y']), optionAdt.makeSome(['x', 'y'])],
+
+  // The bottom type has zero inhabitants (which is different from not being
+  // enumerable).
+  [nothing, optionAdt.makeSome([])],
+
+  [something, optionAdt.none],
+
+  [atom, optionAdt.none],
+
+  [A, optionAdt.none],
+
+  [makeFunctionType({ parameter: atom, return: atom }), optionAdt.none],
+
+  // The `object` type is inexact (any object inhabits it).
+  [object, optionAdt.none],
+
+  [
+    makeObjectType({}, { exact: true }),
+    optionAdt.makeSome([objectNodeFromOrderedEntries([])]),
+  ],
+
+  [
+    makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+    optionAdt.makeSome([objectNodeFromOrderedEntries([['a', '1']])]),
+  ],
+
+  // Object types default to being inexact.
+  [makeObjectType({ a: makeUnionType(['1']) }), optionAdt.none],
+
+  [
+    makeObjectType(
+      { a: makeUnionType(['1', '2']), b: makeUnionType(['x']) },
+      { exact: true },
+    ),
+    optionAdt.makeSome([
+      objectNodeFromOrderedEntries([
+        ['a', '1'],
+        ['b', 'x'],
+      ]),
+      objectNodeFromOrderedEntries([
+        ['a', '2'],
+        ['b', 'x'],
+      ]),
+    ]),
+  ],
+
+  [makeObjectType({ a: atom }, { exact: true }), optionAdt.none],
+
+  [
+    makeObjectType(
+      { a: makeObjectType({ b: makeUnionType(['1']) }, { exact: true }) },
+      { exact: true },
+    ),
+    optionAdt.makeSome([
+      objectNodeFromOrderedEntries([
+        ['a', objectNodeFromOrderedEntries([['b', '1']])],
+      ]),
+    ]),
+  ],
+
+  [
+    makeObjectType(
+      { a: makeObjectType({ b: makeUnionType(['1']) }) },
+      { exact: true },
+    ),
+    optionAdt.none,
+  ],
+
+  [
+    makeUnionType([
+      makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+      'z',
+    ]),
+    optionAdt.makeSome([objectNodeFromOrderedEntries([['a', '1']]), 'z']),
+  ],
+])
+
+/**
+ * Describes each argument value as a literal atom type so tests can observe
+ * exactly which argument combinations were reduced.
+ */
+const describeReducedArguments = (
+  argumentValues: readonly SemanticGraph[],
+): Either<FunctionNodeCallError, Type> =>
+  either.makeRight(
+    makeUnionType([
+      stringifySemanticGraphForEndUser(
+        objectNodeFromOrderedEntries(
+          argumentValues.map((value, index) => [String(index), value]),
+        ),
+      ),
+    ]),
+  )
+
+const intrinsicReductionSuite = testCases(
+  (typeArgument: Type) =>
+    supplyTypeArgument(
+      makeIntrinsicApplicationType(
+        [A, makeObjectType({ b: makeUnionType(['2']) }, { exact: true })],
+        describeReducedArguments,
+        object,
+      ),
+      A,
+      typeArgument,
+    ),
+  typeArgument =>
+    `supplying \`${stringifyTypeForEndUser(typeArgument)}\` to a stuck intrinsic application`,
+)
+
+intrinsicReductionSuite('intrinsic application reduction over object types', [
+  [
+    makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+    makeUnionType(['{ { a: 1 }, { b: 2 } }']),
+  ],
+
+  [makeUnionType(['z']), makeUnionType(['{ z, { b: 2 } }'])],
+
+  [
+    makeUnionType([
+      makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+      makeObjectType({ a: makeUnionType(['2']) }, { exact: true }),
+    ]),
+    makeUnionType(['{ { a: 1 }, { b: 2 } }', '{ { a: 2 }, { b: 2 } }']),
+  ],
+
+  // An inexact object type isn't enumerable, so the application stays stuck.
+  [
+    makeObjectType({ a: makeUnionType(['1']) }),
+    makeIntrinsicApplicationType(
+      [
+        makeObjectType({ a: makeUnionType(['1']) }),
+        makeObjectType({ b: makeUnionType(['2']) }, { exact: true }),
+      ],
+      describeReducedArguments,
+      makeObjectType({}),
+    ),
   ],
 ])
 

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -1,10 +1,11 @@
 import either, { type Either } from '@matt.kantor/either'
 import option, { type Option } from '@matt.kantor/option'
 import type { Writable } from '../../../utility-types.js'
-import type { Atom } from '../../parsing.js'
 import type { FunctionNodeCallError } from '../function-node.js'
+import { objectNodeFromOrderedEntries } from '../object-node.js'
+import type { SemanticGraph } from '../semantic-graph.js'
 import { nothing, something } from './prelude-types.js'
-import { asUnionWithLiteralAtomMembers, isAssignable } from './subtyping.js'
+import { isAssignable } from './subtyping.js'
 import {
   makeApplicationType,
   makeFunctionType,
@@ -434,28 +435,72 @@ const cartesianProduct = <Element>(lists: readonly (readonly Element[])[]) =>
   )
 
 /**
+ * Enumerate every value inhabiting the given finitely-sized `type`, or return
+ * `none` if `type` has infinite inhabitants. Literal atom types, exact object
+ * types whose property types are enumerable, and unions of enumerable types are
+ * enumerable.
+ */
+export const enumerateInhabitants = (
+  type: Type,
+): Option<readonly SemanticGraph[]> =>
+  // Avoid infinite recursion when we hit the top type.
+  type === something ?
+    option.none
+  : matchTypeFormat(type, {
+      application: _ => option.none,
+      function: _ => option.none,
+      indexedAccess: _ => option.none,
+      intrinsicApplication: _ => option.none,
+      opaque: _ => option.none,
+      parameter: _ => option.none,
+      object: type =>
+        !type.exact ?
+          option.none
+        : option.map(
+            option.sequence(
+              Object.entries(type.children).map(([key, child]) =>
+                option.map(enumerateInhabitants(child), childInhabitants =>
+                  childInhabitants.map(
+                    childInhabitant => [key, childInhabitant] as const,
+                  ),
+                ),
+              ),
+            ),
+            entryPossibilitiesPerProperty =>
+              cartesianProduct(entryPossibilitiesPerProperty).map(
+                objectNodeFromOrderedEntries,
+              ),
+          ),
+      union: type =>
+        option.map(
+          option.sequence(
+            [...type.members].map(member =>
+              typeof member === 'string' ?
+                option.makeSome([member])
+              : enumerateInhabitants(member),
+            ),
+          ),
+          inhabitantsPerMember => inhabitantsPerMember.flat(),
+        ),
+    })
+
+/**
  * Attempt to reduce a (possibly stuck) intrinsic application.
  */
 const reduceIntrinsicApplication = (
   parameterTypes: readonly Type[],
   reduce: (
-    argumentValues: readonly Atom[],
+    argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
   upperBound: Type,
 ): Type => {
-  const argumentValues = parameterTypes.map(type =>
-    type.kind !== 'union' ? option.none : asUnionWithLiteralAtomMembers(type),
-  )
+  const argumentPossibilities = parameterTypes.map(enumerateInhabitants)
   const stuck = makeIntrinsicApplicationType(parameterTypes, reduce, upperBound)
-  return option.match(option.sequence(argumentValues), {
+  return option.match(option.sequence(argumentPossibilities), {
     none: _ => stuck,
-    some: argumentValues =>
+    some: argumentPossibilities =>
       either.match(
-        either.sequence(
-          cartesianProduct(argumentValues.map(union => [...union.members])).map(
-            reduce,
-          ),
-        ),
+        either.sequence(cartesianProduct(argumentPossibilities).map(reduce)),
         {
           left: _ => stuck,
           right: resultTypes =>


### PR DESCRIPTION
Standard library functions now refine their return types when applied to object-typed arguments, even ones coming from runtime values: `({ a: 1 } object.overlay @runtime { _ => { b: 2 } }) ~ { a: 1, b: 2 }` typechecks.

This is a generalization of #200.