### PR TITLE
Stop confusingly referring to all singleton types as "unit types"

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Please has a
 with support for [subtyping](https://en.wikipedia.org/wiki/Subtyping),
 [union types](https://en.wikipedia.org/wiki/Union_type),
 [generic function types](https://en.wikipedia.org/wiki/Generic_function), and
-[literal (unit) types](https://en.wikipedia.org/wiki/Unit_type) for atoms.
+[literal (singleton) types](https://en.wikipedia.org/wiki/Unit_type) for atoms.
 
 Types can be inferred in most situations, but function parameters can be
 annotated:

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -348,8 +348,8 @@ const signatureParts = (
 /**
  * Lift a standard library function's signature to be generic over its
  * parameters and return an `IntrinsicApplicationType`. This lets the type
- * system compute precise return types from unit argument types via `reduce`
- * (which should apply the function itself).
+ * system compute precise return types from singleton argument types via
+ * `reduce` (which should apply the function itself).
  *
  * Functions whose return already contains a type parameter (e.g. `identity`)
  * don't need extra precision, so their signature is left unchanged.


### PR DESCRIPTION
I kept the link to <https://en.wikipedia.org/wiki/Unit_type> for now while I wait for a reply to [my question on the Talk page](https://en.wikipedia.org/wiki/Talk:Unit_type#Unit_type_vs_singleton_type).