### PR TITLE
Refine some stdlib return types even when given non-enumerable argument types

### DIFF
--- a/examples/.snapshot
+++ b/examples/.snapshot
@@ -169,7 +169,7 @@ exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
             }
           }
         } object.from_property :state.current)
-        current: :state.current + 1 assume :natural_number.type
+        current: :state.current + 1
       })
     }
     internal_return: :fizzbuzz_internal({
@@ -364,7 +364,7 @@ exports[`examples > is-prime.plz > roundtripped syntax tree 1`] = `
     else: @if {
       (:n % :divisor integer.equals 0)
       then: false
-      else: :divisor + 1 assume :natural_number.type try_divisor :n
+      else: :divisor + 1 try_divisor :n
     }
   }
   is_prime: (n: :natural_number.type) => @if {

--- a/examples/fizzbuzz.plz
+++ b/examples/fizzbuzz.plz
@@ -22,7 +22,7 @@
             }
           }
         })
-        current: (:state.current + 1) assume :natural_number.type
+        current: :state.current + 1
       })
     }
     internal_return: :fizzbuzz_internal({ current: 1, output: {} })

--- a/examples/is-prime.plz
+++ b/examples/is-prime.plz
@@ -12,7 +12,7 @@
       else: @if {
         :n % :divisor integer.equals 0
         then: false
-        else: :try_divisor(:n)((:divisor + 1) assume :natural_number.type)
+        else: :try_divisor(:n)(:divisor + 1)
       }
     }
 

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1847,6 +1847,45 @@ testCases(
   ],
 
   [
+    `{ increment: (x: :natural_number.type) => (1 + :x) ~ :natural_number.type }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ double: (x: :natural_number.type) => (2 * :x) ~ :natural_number.type }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ f: (x: :natural_number.type) => ((1 + :x) + :x) ~ :natural_number.type }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ decrement: (x: :natural_number.type) => (:x - 1) ~ :natural_number.type }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ increment: (x: :integer.type) => (1 + :x) ~ :natural_number.type }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
     `"-1-1" ~ :integer.type`,
     result => {
       assert(either.isLeft(result))

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1886,6 +1886,46 @@ testCases(
   ],
 
   [
+    `{ f: (x: :integer.type) => :integer.is(:x) ~ true }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ f: (x: :natural_number.type) => :integer.is(:x) ~ true }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ f: (x: :atom.type) => :integer.is(:x) ~ true }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{ f: (x: :something.type) => :something.is(:x) ~ true }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      needs_some: (o: { tag: some, value: :integer.type }) => :o
+      use: (x: :integer.type) => :needs_some(:integer.from(:x))
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
     `"-1-1" ~ :integer.type`,
     result => {
       assert(either.isLeft(result))

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -345,7 +345,9 @@ export const typeToSemanticGraph = (
     // A stuck intrinsic application is displayed as its (concrete) upper bound,
     // which is also how it behaves for assignability.
     intrinsicApplication: type =>
-      recurseWithSameTypeParameters(type.upperBound),
+      recurseWithSameTypeParameters(
+        type.computeUpperBound(type.parameterTypes),
+      ),
     opaque: type => typeSymbolToSemanticGraph(type.symbol),
     parameter: type => {
       if (alreadyIntroducedTypeParameterIdentities.has(type.identity)) {

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -2,6 +2,7 @@ import either from '@matt.kantor/either'
 import { objectNodeFromOrderedEntries } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType } from '../type-system/type-formats.js'
+import { computeFromReturnType } from './return-type-refiners.js'
 import {
   preludeFunctionArity1,
   preludeFunctionArity2,
@@ -92,6 +93,7 @@ export const atom = {
             ['value', objectNodeFromOrderedEntries([])],
           ]),
       ),
+    computeFromReturnType(types.atom),
   ),
 
   prepend: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/boolean.ts
+++ b/src/language/semantics/stdlib/boolean.ts
@@ -5,6 +5,10 @@ import { type SemanticGraph } from '../semantic-graph.js'
 import { types } from '../type-system.js'
 import { makeFunctionType } from '../type-system/type-formats.js'
 import {
+  computeFromReturnType,
+  computeIsReturnType,
+} from './return-type-refiners.js'
+import {
   preludeFunctionArity1,
   preludeFunctionArity2,
 } from './stdlib-utilities.js'
@@ -24,6 +28,7 @@ export const boolean = {
       return: types.boolean,
     },
     argument => either.makeRight(nodeIsBoolean(argument) ? 'true' : 'false'),
+    computeIsReturnType(types.boolean),
   ),
 
   from: preludeFunctionArity1(
@@ -44,6 +49,7 @@ export const boolean = {
             ['value', objectNodeFromOrderedEntries([])],
           ]),
       ),
+    computeFromReturnType(types.boolean),
   ),
 
   not: preludeFunctionArity1(

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -1,11 +1,27 @@
 import either from '@matt.kantor/either'
 import { objectNodeFromOrderedEntries } from '../object-node.js'
-import { types } from '../type-system.js'
-import { makeFunctionType, makeUnionType } from '../type-system/type-formats.js'
+import { isAssignable, types } from '../type-system.js'
+import {
+  makeFunctionType,
+  makeUnionType,
+  type Type,
+} from '../type-system/type-formats.js'
 import {
   preludeFunctionArity1,
   preludeFunctionArity2,
 } from './stdlib-utilities.js'
+
+// Addition and multiplication (for example) are closed over the natural
+// numbers: the sum or product of natural numbers is always a natural number.
+// This isn't true for subtraction (for example).
+const closedOverNaturalNumbers = (argumentTypes: readonly Type[]): Type =>
+  (
+    argumentTypes.every(argumentType =>
+      isAssignable({ source: argumentType, target: types.naturalNumber }),
+    )
+  ) ?
+    types.naturalNumber
+  : types.integer
 
 export const integer = {
   type: types.integer.symbol,
@@ -51,6 +67,7 @@ export const integer = {
         })
       }
     },
+    closedOverNaturalNumbers,
   ),
 
   equals: preludeFunctionArity2(
@@ -245,6 +262,7 @@ export const integer = {
         })
       }
     },
+    closedOverNaturalNumbers,
   ),
 
   subtract: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -2,7 +2,11 @@ import either from '@matt.kantor/either'
 import { objectNodeFromOrderedEntries } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType, makeUnionType } from '../type-system/type-formats.js'
-import { closedOver } from './return-type-refiners.js'
+import {
+  closedOver,
+  computeFromReturnType,
+  computeIsReturnType,
+} from './return-type-refiners.js'
 import {
   preludeFunctionArity1,
   preludeFunctionArity2,
@@ -115,6 +119,7 @@ export const integer = {
           'true'
         : 'false',
       ),
+    computeIsReturnType(types.integer),
   ),
 
   from: preludeFunctionArity1(
@@ -141,6 +146,7 @@ export const integer = {
             ['value', objectNodeFromOrderedEntries([])],
           ]),
       ),
+    computeFromReturnType(types.integer),
   ),
 
   is_greater_than: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/integer.ts
+++ b/src/language/semantics/stdlib/integer.ts
@@ -1,11 +1,8 @@
 import either from '@matt.kantor/either'
 import { objectNodeFromOrderedEntries } from '../object-node.js'
-import { isAssignable, types } from '../type-system.js'
-import {
-  makeFunctionType,
-  makeUnionType,
-  type Type,
-} from '../type-system/type-formats.js'
+import { types } from '../type-system.js'
+import { makeFunctionType, makeUnionType } from '../type-system/type-formats.js'
+import { closedOver } from './return-type-refiners.js'
 import {
   preludeFunctionArity1,
   preludeFunctionArity2,
@@ -14,14 +11,7 @@ import {
 // Addition and multiplication (for example) are closed over the natural
 // numbers: the sum or product of natural numbers is always a natural number.
 // This isn't true for subtraction (for example).
-const closedOverNaturalNumbers = (argumentTypes: readonly Type[]): Type =>
-  (
-    argumentTypes.every(argumentType =>
-      isAssignable({ source: argumentType, target: types.naturalNumber }),
-    )
-  ) ?
-    types.naturalNumber
-  : types.integer
+const closedOverNaturalNumbers = closedOver(types.naturalNumber, types.integer)
 
 export const integer = {
   type: types.integer.symbol,

--- a/src/language/semantics/stdlib/natural-number.ts
+++ b/src/language/semantics/stdlib/natural-number.ts
@@ -3,6 +3,10 @@ import { objectNodeFromOrderedEntries } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType, makeUnionType } from '../type-system/type-formats.js'
 import {
+  computeFromReturnType,
+  computeIsReturnType,
+} from './return-type-refiners.js'
+import {
   preludeFunctionArity1,
   preludeFunctionArity2,
 } from './stdlib-utilities.js'
@@ -28,6 +32,7 @@ export const natural_number = {
           'true'
         : 'false',
       ),
+    computeIsReturnType(types.naturalNumber),
   ),
 
   from: preludeFunctionArity1(
@@ -54,6 +59,7 @@ export const natural_number = {
             ['value', objectNodeFromOrderedEntries([])],
           ]),
       ),
+    computeFromReturnType(types.naturalNumber),
   ),
 
   modulo: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -6,6 +6,7 @@ import {
 } from '../object-node.js'
 import { types } from '../type-system.js'
 import { makeFunctionType } from '../type-system/type-formats.js'
+import { computeFromReturnType } from './return-type-refiners.js'
 import {
   preludeFunctionArity1,
   preludeFunctionArity2,
@@ -74,6 +75,7 @@ export const object = {
             ['value', objectNodeFromOrderedEntries([])],
           ]),
       ),
+    computeFromReturnType(types.object),
   ),
 
   from_property: preludeFunctionArity2(

--- a/src/language/semantics/stdlib/return-type-refiners.ts
+++ b/src/language/semantics/stdlib/return-type-refiners.ts
@@ -1,5 +1,11 @@
+import { types } from '../type-system.js'
+import { option as optionType } from '../type-system/prelude-types.js'
 import { isAssignable } from '../type-system/subtyping.js'
-import { type Type } from '../type-system/type-formats.js'
+import {
+  makeObjectType,
+  makeUnionType,
+  type Type,
+} from '../type-system/type-formats.js'
 
 /**
  * Builds a `computeRefinedReturnType` function for an operation closed over
@@ -17,3 +23,44 @@ export const closedOver =
     ) ?
       closedType
     : fallback
+
+/**
+ * Builds a `computeRefinedReturnType` function for an `is`-style predicate:
+ * when the argument type is assignable to `target` the result is necessarily
+ * the literal `true`, otherwise it stays `:boolean.type`.
+ */
+export const computeIsReturnType =
+  (target: Type) =>
+  (argumentTypes: readonly Type[]): Type => {
+    const [argumentType] = argumentTypes
+    if (argumentTypes.length > 1 || argumentType === undefined) {
+      throw new Error(
+        '`is` function received more than one argument. This is a bug!',
+      )
+    } else {
+      return isAssignable({ source: argumentType, target }) ?
+          makeUnionType(['true'])
+        : types.boolean
+    }
+  }
+
+/**
+ * Builds a `computeRefinedReturnType` function for a `from`-style downcast:
+ * when the argument type is assignable to `elementType` the conversion always
+ * succeeds, so the result is narrowed to the `some` branch carrying the
+ * argument's own type. Otherwise it stays a full `option(elementType)`.
+ */
+export const computeFromReturnType =
+  (elementType: Type) =>
+  (argumentTypes: readonly Type[]): Type => {
+    const [argumentType] = argumentTypes
+    if (argumentTypes.length > 1 || argumentType === undefined) {
+      throw new Error(
+        '`from` function received more than one argument. This is a bug!',
+      )
+    } else {
+      return isAssignable({ source: argumentType, target: elementType }) ?
+          makeObjectType({ tag: makeUnionType(['some']), value: argumentType })
+        : optionType(elementType)
+    }
+  }

--- a/src/language/semantics/stdlib/return-type-refiners.ts
+++ b/src/language/semantics/stdlib/return-type-refiners.ts
@@ -1,0 +1,19 @@
+import { isAssignable } from '../type-system/subtyping.js'
+import { type Type } from '../type-system/type-formats.js'
+
+/**
+ * Builds a `computeRefinedReturnType` function for an operation closed over
+ * `closedType`: when every argument type is assignable to `closedType` the
+ * result is bounded by `closedType` (e.g. addition is closed over natural
+ * numbers), otherwise by `fallback`.
+ */
+export const closedOver =
+  (closedType: Type, fallback: Type) =>
+  (argumentTypes: readonly Type[]): Type =>
+    (
+      argumentTypes.every(argumentType =>
+        isAssignable({ source: argumentType, target: closedType }),
+      )
+    ) ?
+      closedType
+    : fallback

--- a/src/language/semantics/stdlib/something.ts
+++ b/src/language/semantics/stdlib/something.ts
@@ -1,5 +1,6 @@
 import either from '@matt.kantor/either'
 import { types } from '../type-system.js'
+import { computeIsReturnType } from './return-type-refiners.js'
 import { preludeFunctionArity1 } from './stdlib-utilities.js'
 
 export const something = {
@@ -12,5 +13,6 @@ export const something = {
       return: types.boolean,
     },
     _ => either.makeRight('true'),
+    computeIsReturnType(types.something),
   ),
 } as const

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -99,9 +99,14 @@ export const preludeFunctionArity1 = (
   keyPath: NonEmptyKeyPath,
   signature: FunctionType['signature'],
   f: FunctionNodeCallSignature,
+  computeRefinedReturnType?: (argumentTypes: readonly Type[]) => Type,
 ) =>
   makeFunctionNode(
-    liftIntrinsicSignature(signature, intrinsicApplicationTypeReducerArity1(f)),
+    liftIntrinsicSignature(
+      signature,
+      intrinsicApplicationTypeReducerArity1(f),
+      computeRefinedReturnType,
+    ),
     () => either.makeRight(keyPathToLookupExpression(keyPath)),
     option.none,
     handleUnavailableDependencies(f),
@@ -116,9 +121,14 @@ export const preludeFunctionArity2 = (
   f: (
     argument1: SemanticGraph,
   ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
+  computeRefinedReturnType?: (argumentTypes: readonly Type[]) => Type,
 ) =>
   makeFunctionNode(
-    liftIntrinsicSignature(signature, intrinsicApplicationTypeReducerArity2(f)),
+    liftIntrinsicSignature(
+      signature,
+      intrinsicApplicationTypeReducerArity2(f),
+      computeRefinedReturnType,
+    ),
     () => either.makeRight(keyPathToLookupExpression(keyPath)),
     option.none,
     handleUnavailableDependencies(argument1 =>
@@ -160,10 +170,12 @@ export const preludeFunctionArity3 = (
       argument2: SemanticGraph,
     ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>
   >,
+  computeRefinedReturnType?: (argumentTypes: readonly Type[]) => Type,
 ) => {
   const liftedSignature = liftIntrinsicSignature(
     signature,
     intrinsicApplicationTypeReducerArity3(f),
+    computeRefinedReturnType,
   )
   return makeFunctionNode(
     liftedSignature,
@@ -359,6 +371,9 @@ const liftIntrinsicSignature = (
   reduce: (
     argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
+  // An optional argument-type-sensitive upper bound for the stuck application.
+  // Defaults to the function's (concrete) declared return type.
+  computeRefinedReturnType?: (argumentTypes: readonly Type[]) => Type,
 ): FunctionType['signature'] => {
   if (containedTypeParameters(makeFunctionType(signature)).size > 0) {
     return signature
@@ -373,7 +388,11 @@ const liftIntrinsicSignature = (
     const liftedFunctionType = parameterTypes.reduceRight<Type>(
       (returnSoFar, parameter) =>
         makeFunctionType({ parameter, return: returnSoFar }),
-      makeIntrinsicApplicationType(parameterTypes, reduce, finalReturn),
+      makeIntrinsicApplicationType(
+        parameterTypes,
+        reduce,
+        computeRefinedReturnType ?? (() => finalReturn),
+      ),
     )
     return liftedFunctionType.kind === 'function' ?
         liftedFunctionType.signature

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -88,7 +88,13 @@ export type IntrinsicApplicationType = {
     // `argumentValues` is expected to be aligned with `parameterTypes`.
     argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>
-  readonly upperBound: Type
+  /**
+   * Returns the upper bound of this (stuck) application given its current
+   * parameter types. It's recomputed whenever the parameter types change (e.g.
+   * as type arguments are supplied), letting the bound narrow as arguments
+   * become known.
+   */
+  readonly computeUpperBound: (parameterTypes: readonly Type[]) => Type
 }
 
 export const makeIntrinsicApplicationType = (
@@ -96,12 +102,12 @@ export const makeIntrinsicApplicationType = (
   reduce: (
     argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
-  upperBound: Type,
+  computeUpperBound: (parameterTypes: readonly Type[]) => Type,
 ): IntrinsicApplicationType => ({
   kind: 'intrinsicApplication',
   parameterTypes,
   reduce,
-  upperBound,
+  computeUpperBound,
 })
 
 export type ObjectType = {

--- a/src/language/semantics/type-system/type-parameter-analysis.ts
+++ b/src/language/semantics/type-system/type-parameter-analysis.ts
@@ -67,7 +67,7 @@ const containedTypeParametersImplementation = (
           containedTypeParametersImplementation(type.key, root),
         ),
       intrinsicApplication: type =>
-        [...type.parameterTypes, type.upperBound]
+        [...type.parameterTypes, type.computeUpperBound(type.parameterTypes)]
           .map(type => containedTypeParametersImplementation(type, root))
           .reduce(mergeTypeParametersByKeyPath, new Map()),
       opaque: _ => new Map(),
@@ -169,7 +169,10 @@ const findKeyPathsToTypeParameterImplementation = (
         ]),
       intrinsicApplication: type =>
         new Set(
-          [...type.parameterTypes, type.upperBound].flatMap(type => [
+          [
+            ...type.parameterTypes,
+            type.computeUpperBound(type.parameterTypes),
+          ].flatMap(type => [
             ...findKeyPathsToTypeParameterImplementation(
               type,
               typeParameterToFind,

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -335,13 +335,16 @@ const describeReducedArguments = (
     ]),
   )
 
+// This same function is reused to satisfy `assert.deepEqual`.
+const computeUpperBound = (_parameterTypes: readonly Type[]): Type => something
+
 const intrinsicReductionSuite = testCases(
   (typeArgument: Type) =>
     supplyTypeArgument(
       makeIntrinsicApplicationType(
         [A, makeObjectType({ b: makeUnionType(['2']) }, { exact: true })],
         describeReducedArguments,
-        object,
+        computeUpperBound,
       ),
       A,
       typeArgument,
@@ -375,7 +378,7 @@ intrinsicReductionSuite('intrinsic application reduction over object types', [
         makeObjectType({ b: makeUnionType(['2']) }, { exact: true }),
       ],
       describeReducedArguments,
-      makeObjectType({}),
+      computeUpperBound,
     ),
   ],
 ])

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -213,7 +213,9 @@ export const replaceAllTypeParametersWithTheirConstraints = (
   type: Type,
 ): Type =>
   type.kind === 'intrinsicApplication' ?
-    replaceAllTypeParametersWithTheirConstraints(type.upperBound)
+    replaceAllTypeParametersWithTheirConstraints(
+      type.computeUpperBound(type.parameterTypes),
+    )
     // TODO: Specialize the below to only traverse `type` once.
   : [...containedTypeParameters(type).values()]
       .flatMap(({ typeParameters }) => [...typeParameters.members])
@@ -492,10 +494,14 @@ const reduceIntrinsicApplication = (
   reduce: (
     argumentValues: readonly SemanticGraph[],
   ) => Either<FunctionNodeCallError, Type>,
-  upperBound: Type,
+  computeUpperBound: (parameterTypes: readonly Type[]) => Type,
 ): Type => {
   const argumentPossibilities = parameterTypes.map(enumerateInhabitants)
-  const stuck = makeIntrinsicApplicationType(parameterTypes, reduce, upperBound)
+  const stuck = makeIntrinsicApplicationType(
+    parameterTypes,
+    reduce,
+    computeUpperBound,
+  )
   return option.match(option.sequence(argumentPossibilities), {
     none: _ => stuck,
     some: argumentPossibilities =>
@@ -571,7 +577,7 @@ export const supplyTypeArgument = (
             supplyTypeArgument(parameterType, typeParameter, typeArgument),
           ),
           type.reduce,
-          supplyTypeArgument(type.upperBound, typeParameter, typeArgument),
+          type.computeUpperBound,
         ),
       indexedAccess: type => {
         const substitutedKey = supplyTypeArgument(
@@ -667,7 +673,8 @@ export const recursivelyInexact = (type: Type): Type =>
         makeIntrinsicApplicationType(
           type.parameterTypes.map(recursivelyInexact),
           type.reduce,
-          recursivelyInexact(type.upperBound),
+          parameterTypes =>
+            recursivelyInexact(type.computeUpperBound(parameterTypes)),
         ),
       object: type =>
         makeObjectType(


### PR DESCRIPTION
This is a further generalization of the work started in #200. Many standard library functions are now known to return narrower types even when given non-enumerable input types, e.g. we statically know that adding together two natural numbers is guaranteed to return a natural number, even without having specific argument possibilities to try.