### PR TITLE
Preserve refined intrinsic bounds through partial application

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -841,6 +841,14 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   ],
   [
     `{
+      |>: (f: ?a ~> ?b) => (a: :a) => :f(:a)
+      three: 1 |> :integer.add(2)
+      six: :three |> :integer.add(3)
+    }.six`,
+    success('6'),
+  ],
+  [
+    `{
       <|: a => (f: :a ~> ?b) => :f(:a)
       ab: :atom.append(b) <| a
       abc: :atom.append(c) <| :ab

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1138,6 +1138,18 @@ testCases(
 
   [
     `{
+      pipe: (f: ?a ~> ?b) => (a: :a) => :f(:a)
+      bad: :pipe(:integer.add(1))(a)
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
       f: (x: (?b: :atom.type)) => :x
       :f(hello) ~ hello
     }`,

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1854,6 +1854,13 @@ testCases(
   ],
 
   [
+    `{ increment: (x: :natural_number.type) => (:x + 1) ~ :natural_number.type }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
     `{ double: (x: :natural_number.type) => (2 * :x) ~ :natural_number.type }`,
     result => {
       assert(either.isRight(result))

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -13,6 +13,7 @@ import {
   makeFunctionNode,
   objectNodeFromOrderedEntries,
   readFunctionExpression,
+  replaceAllTypeParametersWithTheirConstraints,
   serialize,
   updateValueAtKeyPathInSemanticGraph,
   type Expression,
@@ -157,7 +158,16 @@ const apply = (
                 makeHoleExpression(
                   name,
                   hole[1].constraint,
-                  makeTypeParameter(name, { assignableTo: specializedType }),
+                  // `specializedType` may itself be a type parameter; collapse
+                  // it to its concrete upper bound so the constraint is
+                  // concrete. This is merely to simplify the type for error
+                  // messages, etc and does not impact analysis.
+                  makeTypeParameter(name, {
+                    assignableTo:
+                      replaceAllTypeParametersWithTheirConstraints(
+                        specializedType,
+                      ),
+                  }),
                 )
               ),
             ]

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -122,20 +122,21 @@ export const preludeFunctionArity2 = (
     argument1: SemanticGraph,
   ) => Either<FunctionNodeCallError, FunctionNodeCallSignature>,
   computeRefinedReturnType?: (argumentTypes: readonly Type[]) => Type,
-) =>
-  makeFunctionNode(
-    liftIntrinsicSignature(
-      signature,
-      intrinsicApplicationTypeReducerArity2(f),
-      computeRefinedReturnType,
-    ),
+) => {
+  const liftedSignature = liftIntrinsicSignature(
+    signature,
+    intrinsicApplicationTypeReducerArity2(f),
+    computeRefinedReturnType,
+  )
+  return makeFunctionNode(
+    liftedSignature,
     () => either.makeRight(keyPathToLookupExpression(keyPath)),
     option.none,
     handleUnavailableDependencies(argument1 =>
       either.flatMap(
         refineReturnedFunctionType(
-          signature.parameter,
-          signature.return,
+          liftedSignature.parameter,
+          liftedSignature.return,
           argument1,
         ),
         refinedReturn =>
@@ -150,6 +151,7 @@ export const preludeFunctionArity2 = (
       ),
     ),
   )
+}
 
 export const preludeFunctionArity3 = (
   keyPath: NonEmptyKeyPath,
@@ -184,8 +186,8 @@ export const preludeFunctionArity3 = (
     handleUnavailableDependencies(argument1 =>
       either.flatMap(
         refineReturnedFunctionType(
-          signature.parameter,
-          signature.return,
+          liftedSignature.parameter,
+          liftedSignature.return,
           argument1,
         ),
         refinedReturn1 =>
@@ -408,7 +410,7 @@ const liftIntrinsicSignature = (
  */
 const refineReturnedFunctionType = (
   parameterType: Type,
-  returnedType: FunctionType,
+  returnedType: Type,
   argument: SemanticGraph,
 ): Either<FunctionNodeCallError, FunctionType> =>
   either.flatMap(

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -305,7 +305,9 @@ export const getTypesForTypeParameters = ({
         (
           isAssignable({
             source: argumentType,
-            target: parameterType.constraint.assignableTo,
+            target: replaceAllTypeParametersWithTheirConstraints(
+              parameterType.constraint.assignableTo,
+            ),
           })
         ) ?
           new Map([[parameterType, argumentType]])


### PR DESCRIPTION
Refined return types from all standard library functions now behave symmetrically when passed a literal and a variable. Before this, an application like `1 + :a` had a refined type, but `:a + 1` didn't.

---

_This one has a lot of nuance, so put on your thinking cap before proceeding. If you just want to know how this cashes out, skip the below and instead look at the added test cases._

Previously, the types for partial applications were built from the original/un-lifted signatures (those from stdlib definitions), and with a concrete leading argument this meant we'd use the declared return type rather than any refinement of it.

Now the lifted signatures are used during refinement, making calls like `:a + 1` behave the same as `1 + :a` type-wise.

Doing this uncovered an issue: for a type parameter constrained by another type parameter, `getTypesForTypeParameters` wouldn't return a binding unless the argument was assignable to the (rigid) constraining type parameter itself. Since e.g. `1` is not assignable to a rigid `(?a: :integer.type)`, this could result in no bindings being returned.

This is relevant because lifted partial applications model remaining parameters as type parameters so the argument's type can flow into the refined return type, and when such a partially-applied function is passed to a generic higher-order function you naturally end up with type parameters constrained to other type parameters. The net result was that sensible-looking programs like the below wouldn't typecheck:

```plz
{
  pipe: (f: ?a ~> ?b) => (a: :a) => :f(:a)
  two: 1 pipe :integer.add(1)
}
```

The fix was to make `getTypesForTypeParameters` compare against the constraint's concrete upper bound instead. Soundness for rigid type parameters is unaffected because the analysis for `@apply` still checks the argument against the bare parameter.