### PR TITLE
Refine more stdlib return types 

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1945,6 +1945,91 @@ testCases(
   ],
 
   [
+    `{
+      test: a =>
+        (:integer.from(:a) match {
+          some: b => :b
+          none: _ => 0
+        }) ~ :integer.type
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      test: a =>
+        (:integer.from(:a) match {
+          some: b => :b
+          none: _ => 0
+        }) ~ :natural_number.type
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      test: a =>
+        (:integer.from(:a) match {
+          some: _ => true
+          none: _ => false
+        }) ~ :boolean.type
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    // TODO: This should be rejected by static analysis (the `match` object is
+    // not exhaustive).
+    `{
+      test: a =>
+        :integer.from(:a) match {
+          some: _ => 1
+        }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    // TODO: This should be rejected by static analysis (a case has an incorrect
+    // parameter type).
+    `{
+      test: a =>
+        :integer.from(:a) match {
+          some: (b: :boolean.type) => 1
+          none: _ => 2
+        }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    // TODO: This should be rejected by static analysis (`:a` may have arbitrary
+    // tags).
+    `{
+      test: (a: { tag: :atom.type, value: :something.type }) =>
+        :a match {
+          some: _ => 1
+          none: _ => 2
+        }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
     `"-1-1" ~ :integer.type`,
     result => {
       assert(either.isLeft(result))

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2126,9 +2126,18 @@ testCases(
   ],
 
   [
-    // TODO: It'd be great to be able to reason generically about non-literal
-    // standard library function arguments so cases like this typecheck.
-    `({ a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }) ~ { a: 1, b: :atom.type }`,
+    `(
+      { a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }
+    ) ~ { a: 1, b: :atom.type }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(
+      { a: 1 } object.overlay @runtime { context => { b: :context.program.start_time } }
+    ) ~ { a: 1, b: 2 }`,
     result => {
       assert(either.isLeft(result))
       assert.deepEqual(result.value.kind, 'typeMismatch')
@@ -2146,6 +2155,68 @@ testCases(
     `:object.from_property(@runtime { _ => some_key })("some value") ~ { some_key: "some value" }`,
     result => {
       assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: :integer.type) =>
+        :object.from_property(a)(:x) ~ { a: :integer.type }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: :integer.type) =>
+        :object.from_property(a)(:x) ~ { a: :integer.type, b: :integer.type }
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      f: (x: :integer.type) =>
+        :object.overlay({ b: :x })({ a: :x }) ~ { a: :integer.type, b: :integer.type }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: :integer.type) =>
+        :object.lookup(a)({ a: :x }) ~ { tag: some, value: :integer.type }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: :integer.type) =>
+        :object.lookup(c)({ a: :x }) ~ { tag: none, value: {} }
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (x: :integer.type) =>
+        :object.lookup(a)({ a: :x }) ~ { tag: none, value: {} }
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
     },
   ],
 ])

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -1,5 +1,5 @@
 import either from '@matt.kantor/either'
-import option from '@matt.kantor/option'
+import option, { type Option } from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
 import { isFunctionNode } from '../function-node.js'
 import { isSemanticGraph } from '../is-semantic-graph.js'
@@ -15,11 +15,19 @@ import {
 } from '../semantic-graph.js'
 import { isAssignable, types } from '../type-system.js'
 import { typeFromSemanticGraph } from '../type-system/literal-type.js'
+import { asUnionWithLiteralAtomMembers } from '../type-system/subtyping.js'
 import {
   makeFunctionType,
   makeObjectType,
   makeTypeParameter,
+  matchTypeFormat,
+  unionOfTypes,
+  type Type,
 } from '../type-system/type-formats.js'
+import {
+  applyKeyPathToType,
+  applyTypeToArgumentType,
+} from '../type-system/type-substitution.js'
 import {
   emptyContextForStdlibApplications,
   preludeFunctionArity1,
@@ -41,6 +49,41 @@ const nodeIsTagged = (node: SemanticGraph): node is TaggedNode =>
   (typeof node['tag'] === 'string' ||
     (isSemanticGraph(node['tag']) && typeof node['tag'] === 'string')) &&
   node['value'] !== undefined
+
+/**
+ * Computes the upper bound of `match`'s return type, which is the union of each
+ * reachable case's return type.
+ */
+const computeMatchReturnType = (parameterTypes: readonly Type[]): Type => {
+  const [casesType, matcheeType] = parameterTypes
+  if (casesType === undefined || matcheeType === undefined) {
+    throw new Error(
+      '`match` function did not receive two arguments. This is a bug!',
+    )
+  } else {
+    // For every statically-known tag of the matchee, look up the case for that
+    // tag and apply its type to the matchee's `value` type.
+    return option.match(
+      option.flatMap(enumerateTaggedVariants(matcheeType), variants =>
+        option.sequence(
+          variants.map(({ tag, value }) => {
+            const caseType = applyKeyPathToType(casesType, [tag])
+            return caseType.kind === 'union' && caseType.members.size === 0 ?
+                option.none
+              : applyTypeToArgumentType(caseType, value)
+          }),
+        ),
+      ),
+      {
+        none: _ =>
+          // TODO: Ideally this would be impossible, but `match` needs a fancier
+          // signature to make that happen.
+          types.something,
+        some: unionOfTypes,
+      },
+    )
+  }
+}
 
 export const globalFunctions = {
   identity: preludeFunctionArity1(
@@ -164,13 +207,9 @@ export const globalFunctions = {
   match: preludeFunctionArity2(
     ['match'],
     {
-      // TODO: Make this signature generic:
-      //  - The first parameter's keys must cover the possible tag values in the
-      //    second parameter.
-      //  - The first parameter's property values must be functions accepting
-      //    the corresponding variant of the second parameter as input.
-      //  - The final return type should be a union or all the return types from
-      //    the first parameter.
+      // TODO: Tighten this up, rejecting:
+      //  - Non-exhaustive cases.
+      //  - Case functions with incorrect parameter types.
       parameter: types.object,
       return: makeFunctionType({
         parameter: makeObjectType({
@@ -212,5 +251,47 @@ export const globalFunctions = {
         })
       }
     },
+    computeMatchReturnType,
   ),
 } as const
+
+const enumerateTaggedVariants = (
+  type: Type,
+): Option<
+  readonly {
+    readonly tag: Atom
+    readonly value: Type
+  }[]
+> =>
+  matchTypeFormat(type, {
+    union: type =>
+      option.map(
+        option.sequence(
+          [...type.members].map(member =>
+            typeof member === 'string' ?
+              option.none
+            : enumerateTaggedVariants(member),
+          ),
+        ),
+        variantsPerMember => variantsPerMember.flat(),
+      ),
+    object: type => {
+      const tagType = type.children['tag']
+      const valueType = type.children['value']
+      return (
+          tagType === undefined ||
+            valueType === undefined ||
+            tagType.kind !== 'union'
+        ) ?
+          option.none
+        : option.map(asUnionWithLiteralAtomMembers(tagType), tags =>
+            [...tags.members].map(tag => ({ tag, value: valueType })),
+          )
+    },
+    application: _ => option.none,
+    function: _ => option.none,
+    indexedAccess: _ => option.none,
+    intrinsicApplication: _ => option.none,
+    opaque: _ => option.none,
+    parameter: _ => option.none,
+  })

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -1,16 +1,131 @@
 import either from '@matt.kantor/either'
+import option from '@matt.kantor/option'
+import type { Atom } from '../../parsing.js'
 import {
   isObjectNode,
   objectNodeFromOrderedEntries,
   orderedEntriesOfObjectNode,
 } from '../object-node.js'
 import { types } from '../type-system.js'
-import { makeFunctionType } from '../type-system/type-formats.js'
+import { asUnionWithLiteralAtomMembers } from '../type-system/subtyping.js'
+import {
+  makeFunctionType,
+  makeObjectType,
+  makeUnionType,
+  unionOfTypes,
+  type ObjectType,
+  type Type,
+} from '../type-system/type-formats.js'
+import { applyKeyPathToType } from '../type-system/type-substitution.js'
 import { computeFromReturnType } from './return-type-refiners.js'
 import {
   preludeFunctionArity1,
   preludeFunctionArity2,
 } from './stdlib-utilities.js'
+
+const computeFromPropertyReturnType = (
+  parameterTypes: readonly Type[],
+): Type => {
+  const [keyType, valueType] = parameterTypes
+  if (keyType === undefined || valueType === undefined) {
+    throw new Error(
+      '`from_property` function did not receive two arguments. This is a bug!',
+    )
+  } else {
+    return option.match(
+      // TODO: Consider also supporting type parameters/stuck types via their
+      // upper bounds.
+      keyType.kind === 'union' ?
+        asUnionWithLiteralAtomMembers(keyType)
+      : option.none,
+      {
+        none: _ => types.object,
+        some: keys =>
+          unionOfTypes(
+            [...keys.members].map(key =>
+              makeObjectType({ [key]: valueType }, { exact: true }),
+            ),
+          ),
+      },
+    )
+  }
+}
+
+const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
+  const [object2Type, object1Type] = parameterTypes
+  if (object2Type === undefined || object1Type === undefined) {
+    throw new Error(
+      '`overlay` function did not receive two arguments. This is a bug!',
+    )
+  } else {
+    // TODO: Consider also supporting type parameters/stuck types via their
+    // upper bounds.
+    return object2Type.kind === 'object' && object1Type.kind === 'object' ?
+        makeObjectType(
+          {
+            ...Object.fromEntries(
+              Object.entries(object1Type.children)
+                .filter(([key]) => object2Type.children[key] === undefined)
+                .map(([key, child]) => [
+                  key,
+                  object2Type.exact ? child
+                    // The property may exist as excess (with an unknown type).
+                  : types.something,
+                ]),
+            ),
+            ...object2Type.children,
+          },
+          { exact: object1Type.exact && object2Type.exact },
+        )
+      : types.object
+  }
+}
+
+const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
+  const [keyType, objectType] = parameterTypes
+  if (keyType === undefined || objectType === undefined) {
+    throw new Error(
+      '`lookup` function did not receive two arguments. This is a bug!',
+    )
+  } else {
+    // TODO: Consider also supporting type parameters/stuck types via their
+    // upper bounds.
+    return keyType.kind === 'union' && objectType.kind === 'object' ?
+        option.match(asUnionWithLiteralAtomMembers(keyType), {
+          none: _ => types.option(types.something),
+          some: keys => {
+            const keysAsArray = [...keys.members]
+            return keysAsArray.length === 1 && keysAsArray[0] !== undefined ?
+                lookupReturnForKey(keysAsArray[0], objectType)
+              : types.option(types.something)
+          },
+        })
+      : types.option(types.something)
+  }
+}
+
+// `lookup(key)(object)` returns `some(object[key])` when the key is definitely
+// present, `none` when it is definitely absent (an `exact` object lacking it),
+// or an `option` otherwise (the key may be an excess property).
+const lookupReturnForKey = (key: Atom, objectType: ObjectType): Type => {
+  const valueType = applyKeyPathToType(objectType, [key])
+  return (
+    valueType.kind === 'union' && valueType.members.size === 0 ?
+      objectType.exact ?
+        makeObjectType(
+          {
+            tag: makeUnionType(['none']),
+            value: makeObjectType({}, { exact: true }),
+          },
+          { exact: true },
+        )
+      : types.option(types.something)
+    : makeObjectType(
+        { tag: makeUnionType(['some']), value: valueType },
+        { exact: true },
+      )
+  )
+}
 
 export const object = {
   type: objectNodeFromOrderedEntries([]),
@@ -18,7 +133,6 @@ export const object = {
   lookup: preludeFunctionArity2(
     ['object', 'lookup'],
     {
-      // TODO
       parameter: types.atom,
       return: makeFunctionType({
         parameter: types.object,
@@ -55,6 +169,7 @@ export const object = {
         })
       }
     },
+    computeLookupReturnType,
   ),
 
   from: preludeFunctionArity1(
@@ -81,7 +196,6 @@ export const object = {
   from_property: preludeFunctionArity2(
     ['object', 'from_property'],
     {
-      // TODO
       parameter: types.atom,
       return: makeFunctionType({
         parameter: types.something,
@@ -100,12 +214,12 @@ export const object = {
         )
       }
     },
+    computeFromPropertyReturnType,
   ),
 
   overlay: preludeFunctionArity2(
     ['object', 'overlay'],
     {
-      // TODO
       parameter: types.object,
       return: makeFunctionType({
         parameter: types.object,
@@ -143,5 +257,6 @@ export const object = {
         })
       }
     },
+    computeOverlayReturnType,
   ),
 } as const

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -31,6 +31,7 @@ import {
 } from './type-formats.js'
 import {
   applyKeyPathToType,
+  applyTypeToArgumentType,
   enumerateInhabitants,
   getTypesForTypeParameters,
   supplyTypeArgument,
@@ -475,4 +476,53 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
     ['wrap', makeObjectType({ value: A })],
     `{ value: ${stringifyTypeForEndUser(A)} }`,
   ],
+])
+
+const applyTypeToArgumentTypeSuite = testCases(
+  ([functionLikeType, argumentType]: readonly [
+    functionLikeType: Type,
+    argumentType: Type,
+  ]) =>
+    optionAdt.match(applyTypeToArgumentType(functionLikeType, argumentType), {
+      none: _ => 'none',
+      some: stringifyTypeForEndUser,
+    }),
+  ([functionLikeType, argumentType]) =>
+    `applying \`${stringifyTypeForEndUser(functionLikeType)}\` to \`${stringifyTypeForEndUser(argumentType)}\``,
+)
+
+applyTypeToArgumentTypeSuite('applyTypeToArgumentType', [
+  [
+    [makeFunctionType({ parameter: A, return: A }), integer],
+    stringifyTypeForEndUser(integer),
+  ],
+
+  [
+    [makeFunctionType({ parameter: atom, return: integer }), atom],
+    stringifyTypeForEndUser(integer),
+  ],
+
+  [
+    [
+      makeTypeParameter('f', {
+        assignableTo: makeFunctionType({ parameter: A, return: A }),
+      }),
+      integer,
+    ],
+    stringifyTypeForEndUser(integer),
+  ],
+
+  [
+    [
+      makeUnionType([
+        makeFunctionType({ parameter: atom, return: integer }),
+        makeFunctionType({ parameter: atom, return: atom }),
+      ]),
+      atom,
+    ],
+    stringifyTypeForEndUser(makeUnionType([integer, atom])),
+  ],
+
+  [[object, integer], 'none'],
+  [[integer, atom], 'none'],
 ])

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -392,6 +392,29 @@ export const applicableFunctionSignatures = (
   })
 
 /**
+ * Apply a function-like type to an argument type, returning the union of its
+ * signatures' return types (with type parameters bound from the argument), or
+ * `none` when `functionLikeType` isn't applicable as a function.
+ */
+export const applyTypeToArgumentType = (
+  functionLikeType: Type,
+  argumentType: Type,
+): Option<Type> =>
+  option.map(applicableFunctionSignatures(functionLikeType), signatures =>
+    unionOfTypes(
+      signatures.map(signature =>
+        supplyTypeArguments(
+          signature.return,
+          getTypesForTypeParameters({
+            parameterType: signature.parameter,
+            argumentType,
+          }),
+        ),
+      ),
+    ),
+  )
+
+/**
  * Attempt to reduce a (possibly stuck) application of `functionType(argument)`.
  * While the function still contains any of the `parametersStuckOn` (type
  * parameters an enclosing function will instantiate), the application stays


### PR DESCRIPTION
This is a further generalization of the work started in #200. It refines the return types of `match`, `object.from_property`, `object.overlay`, and `object.lookup` depending on their argument types.