### PR TITLE
Make `~`/`@check` allow width subtyping

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2061,6 +2061,28 @@ testCases(
   ],
 
   [
+    `{ a: 1, b: 2 } ~ { a: 1 }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `(x: { a: 1, b: 2 }) => :x ~ { a: 1 }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{ a: 1 } ~ { a: 1, b: 2 }`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
     `(_ => x) ~ ((:something.type ~> :atom.type) | (:something.type ~> :atom.type))`,
     result => {
       assert(either.isRight(result))

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -10,7 +10,10 @@ import {
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
-import { inferType } from '../../../semantics/type-system.js'
+import {
+  inferType,
+  recursivelyInexact,
+} from '../../../semantics/type-system.js'
 
 const check = ({
   value,
@@ -33,10 +36,12 @@ const check = ({
           location: [...context.location, '1', 'type'],
         }),
         typeAsType => {
+          // `@check` targets are upper bounds; they allow width subtyping.
+          const targetType = recursivelyInexact(typeAsType)
           if (
             isAssignable({
               source: valueAsType,
-              target: typeAsType,
+              target: targetType,
             })
           ) {
             return either.makeRight(value)
@@ -45,7 +50,7 @@ const check = ({
               kind: 'typeMismatch',
               message: `the value \`${stringifySemanticGraphForEndUser(
                 value,
-              )}\` (inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) is not assignable to the type \`${stringifyTypeForEndUser(typeAsType)}\``,
+              )}\` (inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) is not assignable to the type \`${stringifyTypeForEndUser(targetType)}\``,
             })
           }
         },

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -33,6 +33,7 @@ export {
   applicableFunctionSignatures,
   applyKeyPathToType,
   getTypesForTypeParameters,
+  recursivelyInexact,
   replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArgument,
   supplyTypeArguments,


### PR DESCRIPTION
Programs like `{ a: 1, b: 2 } ~ { a: 1 }` now typecheck.