### PR TITLE
Enable inference caching in more scenarios

### DIFF
--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -64,9 +64,10 @@ export type ExpressionContext = {
    */
   readonly cacheKeyPrefixOverride?: KeyPath | undefined
   /**
-   * Marks contexts that have no position at all, so caching is disabled.
+   * Marks a context originating outside the program (e.g. functions called from
+   * higher-order standard library functions).
    */
-  readonly locationDoesNotCorrespondWithTruePosition?: true | undefined
+  readonly isExternalToProgram?: true | undefined
   readonly skipReelaboration?: true | undefined
   /**
    * When set, `@panic` returns its (un-elaborated) expression instead of

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -53,6 +53,19 @@ export type ExpressionContext = {
     StringifiedKeyPath,
     FunctionParameterTypeInfo
   >
+  /**
+   * `location` is typically both the origin for `@lookup`s and the prefix for
+   * cache keys, but a few inference sites run with `location` pointing at a
+   * scope other than the node's true position (e.g. function parameter
+   * annotations are looked up from the function's scope rather than the
+   * annotation's). For those, `cacheKeyPrefixOverride` is used.
+   *
+   * When this is `undefined`, `location` is used for cache keys.
+   */
+  readonly cacheKeyPrefixOverride?: KeyPath | undefined
+  /**
+   * Marks contexts that have no position at all, so caching is disabled.
+   */
   readonly locationDoesNotCorrespondWithTruePosition?: true | undefined
   readonly skipReelaboration?: true | undefined
   /**

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -44,9 +44,8 @@ const handleUnavailableDependencies =
   }
 
 /**
- * Use with calls of user-defined functions from the standard library (which
- * conceptually occur from "outside your program" and therefore do not have a
- * meaningful `ExpressionContext`).
+ * Use with function calls from the standard library (which conceptually occur
+ * "outside your program" and don't have a meaningful `ExpressionContext`).
  */
 export const emptyContextForStdlibApplications: ExpressionContext = {
   keywordHandlers: {
@@ -66,7 +65,7 @@ export const emptyContextForStdlibApplications: ExpressionContext = {
   program: objectNodeFromOrderedEntries([]),
   mutableInferenceCache: new Map(),
   mutableFunctionParameterCache: new Map(),
-  locationDoesNotCorrespondWithTruePosition: true,
+  isExternalToProgram: true,
 }
 
 export const serializeOnceAppliedFunction =

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -551,7 +551,7 @@ const getFunctionParameterType = (
     functionParameterKey,
   ])
   const cachedParameterTypeInfo =
-    contextOfFunction.locationDoesNotCorrespondWithTruePosition === true ?
+    contextOfFunction.isExternalToProgram === true ?
       undefined
     : contextOfFunction.mutableFunctionParameterCache.get(parameterCacheKey)
   if (cachedParameterTypeInfo !== undefined) {
@@ -639,8 +639,7 @@ const getFunctionParameterType = (
                     contextOfFunction.mutableInferenceCache,
                   mutableFunctionParameterCache:
                     contextOfFunction.mutableFunctionParameterCache,
-                  locationDoesNotCorrespondWithTruePosition:
-                    contextOfFunction.locationDoesNotCorrespondWithTruePosition,
+                  isExternalToProgram: contextOfFunction.isExternalToProgram,
                 }
                 const contextuallyAppliedFunctionType = inferType(
                   applyExpressionResult.value[1].function,
@@ -706,9 +705,7 @@ const getFunctionParameterType = (
         },
       }),
       parameterTypeInfo => {
-        if (
-          contextOfFunction.locationDoesNotCorrespondWithTruePosition !== true
-        ) {
+        if (contextOfFunction.isExternalToProgram !== true) {
           // Side effect: cache the parameter type so its type-parameter
           // identities remain stable.
           contextOfFunction.mutableFunctionParameterCache.set(

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -113,7 +113,9 @@ const inferTypeImplementation = (
   lookingUpKeys: ReadonlySet<Atom>,
   context: ExpressionContext,
 ): Either<ElaborationError, Type> => {
-  const cacheKey = stringifyTypeKeyPathForEndUser(context.location)
+  const cacheKey = stringifyTypeKeyPathForEndUser(
+    context.cacheKeyPrefixOverride ?? context.location,
+  )
   const cached = context.mutableInferenceCache.get(cacheKey)
   if (cached !== undefined) {
     return either.makeRight(cached)
@@ -138,6 +140,10 @@ const inferTypeImplementation = (
   const descendantContext = (subPath: KeyPath): ExpressionContext => ({
     ...context,
     location: [...context.location, ...subPath],
+    cacheKeyPrefixOverride:
+      context.cacheKeyPrefixOverride === undefined ?
+        undefined
+      : [...context.cacheKeyPrefixOverride, ...subPath],
   })
 
   if (
@@ -204,15 +210,15 @@ const inferTypeImplementation = (
               foundLocation === 'prelude' ?
                 {
                   ...context,
-                  // We don't have a way to key the cache for inferences from
-                  // the prelude. Use a fresh cache so as not to pollute the
-                  // shared one.
-                  mutableInferenceCache: new Map(),
-                  locationDoesNotCorrespondWithTruePosition: true,
+                  // Prelude values exist outside the program, so use an
+                  // artificial key. `@` can't be a real key (it'd be escaped as
+                  // `@@`), so this can't collide with an actual location.
+                  cacheKeyPrefixOverride: ['@', key],
                 }
               : {
                   ...context,
                   location: foundLocation,
+                  cacheKeyPrefixOverride: undefined,
                 },
             ),
         })
@@ -541,7 +547,7 @@ const getFunctionParameterType = (
   // type parameters are identified by an internal `symbol`. To keep identities
   // consistent, cache parameter types here.
   const parameterCacheKey = stringifyTypeKeyPathForEndUser([
-    ...contextOfFunction.location,
+    ...(contextOfFunction.cacheKeyPrefixOverride ?? contextOfFunction.location),
     functionParameterKey,
   ])
   const cachedParameterTypeInfo =
@@ -557,14 +563,17 @@ const getFunctionParameterType = (
           either.map(
             // Type annotation lookups happen from the function's scope rather
             // than their own location (a property within the `@function`), so
-            // location-keyed caching is disabled for this inference.
-            // TODO: Consider separating out the cache key prefix from the
-            // `context.location` somehow so that I can say "lookups start from
-            // X, cache key paths are rooted at Y".
+            // `location` stays anchored at the function while cache keys are
+            // rooted at the annotation's true position.
             inferType(annotation, {
               ...contextOfFunction,
-              mutableInferenceCache: new Map(),
-              locationDoesNotCorrespondWithTruePosition: true,
+              cacheKeyPrefixOverride: [
+                ...(contextOfFunction.cacheKeyPrefixOverride ??
+                  contextOfFunction.location),
+                '1',
+                'parameter',
+                getParameterName(expression),
+              ],
             }),
             annotationType => {
               const parameterName = getParameterName(expression)
@@ -622,6 +631,10 @@ const getFunctionParameterType = (
                   program: contextOfFunction.program,
                   keywordHandlers: contextOfFunction.keywordHandlers,
                   location: contextOfFunction.location.slice(0, -2),
+                  cacheKeyPrefixOverride:
+                    contextOfFunction.cacheKeyPrefixOverride === undefined ?
+                      undefined
+                    : contextOfFunction.cacheKeyPrefixOverride.slice(0, -2),
                   mutableInferenceCache:
                     contextOfFunction.mutableInferenceCache,
                   mutableFunctionParameterCache:
@@ -638,6 +651,17 @@ const getFunctionParameterType = (
                       '1',
                       'function',
                     ],
+                    cacheKeyPrefixOverride:
+                      (
+                        contextOfEnclosingExpression.cacheKeyPrefixOverride ===
+                        undefined
+                      ) ?
+                        undefined
+                      : [
+                          ...contextOfEnclosingExpression.cacheKeyPrefixOverride,
+                          '1',
+                          'function',
+                        ],
                   },
                 )
 


### PR DESCRIPTION
In a few places where type inference happens, `context.location` doesn't correspond with the true position of the node within the program and therefore couldn't be used in cache keys. This commit introduces a separate `context.cacheKeyPrefixOverride` property which can now be used to enable caching in these scenarios.