### PR TITLE
Improve semantics of hole constraints referencing type parameters

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1529,6 +1529,43 @@ testCases(
   ],
 
   [
+    `a => (x: (?b: :a)) => (:x ~ :a)`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `a => (x: (?b: :a)) => (:b ~ :a)`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `a => (x: (?b: { foo: :a })) => (:x ~ { foo: :a })`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `a => (x: (?b: :a)) => (:x ~ :integer.type)`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `a => (x: (?b: :a)) => (:b ~ :integer.type)`,
+    result => {
+      assert(either.isLeft(result))
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
     `{ outer: a => (f: :a ~> ?b) => ((g: :f(:a)) => :g)(:f(:a)) }`,
     result => {
       assert(either.isRight(result))

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -27,7 +27,7 @@ import {
 import {
   collectHolesByName,
   findDuplicateHoleNames,
-  makeHoleExpression,
+  makeHoleExpressionWithExtantTypeParameter,
 } from '../../../semantics/expressions/hole-expression.js'
 import { makeTypeParameter } from '../../../semantics/type-system/type-formats.js'
 
@@ -113,14 +113,17 @@ const apply = (
       'return with a different key to avoid collision with a stupidly-named parameter'
     : 'return'
 
+  // Put each `@hole` from the annotation into scope under its name so the body
+  // can refer to it (e.g. `(first: ?a) => (second: :a) => …`). When the
+  // argument can be used to pin down type parameters, re-mint their `@hole`s
+  // with constraints specialized to this call site. Holes can also remain
+  // generic, staying stuck until an enclosing function is applied.
   const holeBindings: readonly (readonly [string, SemanticGraph])[] =
     option.match(getParameterTypeAnnotation(expression), {
       none: _ => [],
       some: annotation => {
-        // Specialize each hole's type parameter using the inferred type of the
-        // argument, so references like `:a` in the body see the concrete type
-        // rather than the original unconstrained type parameter.
-        const specializationsByTypeParameterName = either.match(
+        const typesForTypeParametersByName = either.match(
+          // Use the inferred argument type to pin down type parameters.
           inferType(argument, {
             ...applySiteContext,
             location: [...applySiteContext.location, '1', 'argument'],
@@ -151,26 +154,28 @@ const apply = (
               name !== ignoredKey,
           )
           .map(([name, hole]) => {
-            const specializedType = specializationsByTypeParameterName.get(name)
-            return [
-              name,
-              specializedType === undefined ? hole : (
-                makeHoleExpression(
+            const typeForTypeParameter = typesForTypeParametersByName.get(name)
+            if (typeForTypeParameter === undefined) {
+              return [name, hole]
+            } else {
+              return [
+                name,
+                makeHoleExpressionWithExtantTypeParameter(
                   name,
                   hole[1].constraint,
-                  // `specializedType` may itself be a type parameter; collapse
-                  // it to its concrete upper bound so the constraint is
-                  // concrete. This is merely to simplify the type for error
-                  // messages, etc and does not impact analysis.
                   makeTypeParameter(name, {
                     assignableTo:
+                      // `typeForTypeParameter` may still contain unsolved type
+                      // parameters. If so, eliminate them. This is merely to
+                      // simplify the type in diagnostics and doesn't affect
+                      // semantics.
                       replaceAllTypeParametersWithTheirConstraints(
-                        specializedType,
+                        typeForTypeParameter,
                       ),
                   }),
-                )
-              ),
-            ]
+                ),
+              ]
+            }
           })
       },
     })

--- a/src/language/semantics/expressions/hole-expression.ts
+++ b/src/language/semantics/expressions/hole-expression.ts
@@ -9,7 +9,7 @@ import {
   type ObjectNode,
 } from '../object-node.js'
 import type { SemanticGraph } from '../semantic-graph.js'
-import { typeFromSemanticGraph } from '../type-system.js'
+import { typeFromSemanticGraph, types } from '../type-system.js'
 import type { TypeParameter } from '../type-system/type-formats.js'
 import {
   isTypeParameter,
@@ -19,6 +19,17 @@ import {
   ignoredKey,
   readArgumentsFromExpression,
 } from './expression-utilities.js'
+
+/**
+ * The source of truth for a hole's constraint:
+ * - `'expression'`: resolve it from the expression itself (`[1].constraint`).
+ *   Resolution occurs with a specific `ExpressionContext` (so constraints
+ *   containing `@lookup`s are correctly scoped).
+ * - `'typeParameter'`: the constraint has already been resolved and is stored
+ *   in the hole's type parameter (`typeParameterKey`). It shouldn't be
+ *   re-derived from the expression.
+ */
+export type HoleConstraintSource = 'expression' | 'typeParameter'
 
 export type HoleExpression = ObjectNode & {
   readonly 0: '@hole'
@@ -32,8 +43,12 @@ export type HoleExpression = ObjectNode & {
   // This is stashed on the node so that repeated reads (e.g. successive
   // type-inference passes) return a parameter with stable identity.
   readonly [typeParameterKey]: TypeParameter
+
+  // The source of truth for this hole's constraint. See `HoleConstraintSource`.
+  readonly [constraintSourceKey]: HoleConstraintSource
 }
 const typeParameterKey = Symbol('typeParameter')
+const constraintSourceKey = Symbol('constraintSource')
 
 /**
  * Mints a new type parameter for the node if one doesn't already exist.
@@ -81,30 +96,62 @@ export const readHoleExpression = (
                 node[typeParameterKey]
               : undefined
             return either.map(
+              // TODO: Try to get an `ExpressionContext` in here so `inferType`
+              // can be used instead of `typeFromSemanticGraph`. That'd probably
+              // eliminate the need to resolve constraints anywhere else and
+              // would allow ditching the constraint source stuff.
               typeFromSemanticGraph(assignableToNode, {
                 // Constraints are merely upper bounds.
                 objectsAreExact: false,
               }),
-              assignableTo => {
+              eagerlyResolvedConstraint => {
+                const constraintIsResolvable =
+                  existingTypeParameter === undefined &&
+                  // A constraint referencing a type parameter via `@lookup`
+                  // can't be resolved here as we don't have context. Start from
+                  // a provisional top bound; type inference resolves the real
+                  // constraint (see the `@hole` case in `type-inference.ts`).
+                  !containsLookupExpression(assignableToNode)
+
                 const typeParameter =
                   existingTypeParameter ??
-                  makeTypeParameter(name, { assignableTo })
-                // Side effect: stash the type parameter on the original `node`
-                // as well, so that reads from elsewhere (annotation inference,
-                // `@lookup`s, etc) get the same identity.
-                Object.assign(node, { [typeParameterKey]: typeParameter })
-                const reconstructedNode = makeObjectNode({
-                  0: '@hole',
-                  1: makeObjectNode({
-                    name,
-                    constraint: makeObjectNode({
-                      assignableTo: assignableToNode,
+                  makeTypeParameter(name, {
+                    assignableTo:
+                      constraintIsResolvable ?
+                        eagerlyResolvedConstraint
+                      : types.something,
+                  })
+
+                const constraintSource: HoleConstraintSource =
+                  (
+                    constraintIsResolvable ||
+                    (constraintSourceKey in node &&
+                      node[constraintSourceKey] === 'typeParameter')
+                  ) ?
+                    'typeParameter'
+                  : 'expression'
+
+                // Side effect: set the type parameter and constraint source on
+                // the original node so that reads from elsewhere share the
+                // same identity (and constraint source).
+                Object.assign(node, {
+                  [typeParameterKey]: typeParameter,
+                  [constraintSourceKey]: constraintSource,
+                })
+
+                return {
+                  [typeParameterKey]: typeParameter,
+                  [constraintSourceKey]: constraintSource,
+                  ...makeObjectNode({
+                    0: '@hole',
+                    1: makeObjectNode({
+                      name,
+                      constraint: makeObjectNode({
+                        assignableTo: assignableToNode,
+                      }),
                     }),
                   }),
-                })
-                return Object.assign(reconstructedNode, {
-                  [typeParameterKey]: typeParameter,
-                })
+                }
               },
             )
           }
@@ -116,7 +163,7 @@ export const readHoleExpression = (
       message: 'not a `@hole` expression',
     })
 
-export const makeHoleExpression = (
+export const makeHoleExpressionWithExtantTypeParameter = (
   name: Atom,
   constraint: HoleExpression[1]['constraint'],
   parameter: TypeParameter,
@@ -126,11 +173,18 @@ export const makeHoleExpression = (
       0: '@hole',
       1: makeObjectNode({ name, constraint }),
     }),
-    { [typeParameterKey]: parameter },
+    {
+      [typeParameterKey]: parameter,
+      [constraintSourceKey]: 'typeParameter' as const,
+    },
   )
 
 export const getHoleTypeParameter = (node: HoleExpression): TypeParameter =>
   node[typeParameterKey]
+
+export const getHoleConstraintSource = (
+  node: HoleExpression,
+): HoleConstraintSource => node[constraintSourceKey]
 
 /**
  * Walk an annotation, returning a `Map` from hole names to their expressions.
@@ -242,3 +296,13 @@ export const findDuplicateHoleNames = (
   visit(annotation)
   return duplicates
 }
+
+const containsLookupExpression = (node: SemanticGraph): boolean =>
+  isKeywordExpressionWithArgument('@lookup', node) ||
+  (isFunctionNode(node) ?
+    either.match(node.serialize(), {
+      right: containsLookupExpression,
+      left: _ => false,
+    })
+  : isObjectNode(node) ? Object.values(node).some(containsLookupExpression)
+  : false)

--- a/src/language/semantics/expressions/lookup-expression.ts
+++ b/src/language/semantics/expressions/lookup-expression.ts
@@ -20,7 +20,6 @@ import {
   stringifySemanticGraphForEndUser,
   type SemanticGraph,
 } from '../semantic-graph.js'
-import type { TypeParameter } from '../type-system.js'
 import {
   ignoredKey,
   readArgumentsFromExpression,
@@ -31,11 +30,7 @@ import {
   getParameterTypeAnnotation,
   readFunctionExpression,
 } from './function-expression.js'
-import {
-  collectHolesByName,
-  getHoleTypeParameter,
-  type HoleExpression,
-} from './hole-expression.js'
+import { collectHolesByName, type HoleExpression } from './hole-expression.js'
 import { makeIndexExpression } from './index-expression.js'
 
 export type LookupExpression = ObjectNode & {
@@ -99,7 +94,7 @@ export const lookup = ({
   Option<{
     readonly foundLocation: 'prelude' | KeyPath
     readonly foundValue: SemanticGraph
-    readonly typeParameterOfFoundHole: Option<TypeParameter>
+    readonly foundHole: Option<HoleExpression>
   }>
 > => {
   if (key === ignoredKey) {
@@ -119,7 +114,7 @@ export const lookup = ({
           option.makeSome({
             foundLocation: 'prelude',
             foundValue: valueFromPrelude,
-            typeParameterOfFoundHole: option.none,
+            foundHole: option.none,
           }),
         )
   } else {
@@ -156,7 +151,7 @@ export const lookup = ({
           readonly kind: 'found'
           readonly foundValue: SemanticGraph
           readonly foundLocation: KeyPath
-          readonly typeParameterOfFoundHole: Option<TypeParameter>
+          readonly foundHole: Option<HoleExpression>
         }
       | {
           readonly kind: 'notFound'
@@ -196,10 +191,7 @@ export const lookup = ({
               kind: 'found',
               foundValue: makeLookupExpression(key),
               foundLocation: [...pathToCurrentScope, key],
-              typeParameterOfFoundHole: option.map(
-                matchedHole,
-                getHoleTypeParameter,
-              ),
+              foundHole: matchedHole,
             }
           } else {
             return {
@@ -221,7 +213,7 @@ export const lookup = ({
                 kind: 'found',
                 foundValue,
                 foundLocation: [...pathToCurrentScope, key],
-                typeParameterOfFoundHole: option.none,
+                foundHole: option.none,
               }),
               none: _ => ({
                 kind: 'notFound',
@@ -237,7 +229,7 @@ export const lookup = ({
         option.makeSome({
           foundValue: result.foundValue,
           foundLocation: result.foundLocation,
-          typeParameterOfFoundHole: result.typeParameterOfFoundHole,
+          foundHole: result.foundHole,
         }),
       )
     } else {

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -19,7 +19,7 @@ import {
 } from '../semantics.js'
 import { inlinePlz, unparse, type Notation } from '../unparsing.js'
 import { isExpression } from './expression.js'
-import { makeHoleExpression } from './expressions/hole-expression.js'
+import { makeHoleExpressionWithExtantTypeParameter } from './expressions/hole-expression.js'
 import { serializeFunctionNode, type FunctionNode } from './function-node.js'
 import { isSemanticGraph } from './is-semantic-graph.js'
 import { stringifyKeyPathForEndUser, type KeyPath } from './key-path.js'
@@ -356,7 +356,7 @@ export const typeToSemanticGraph = (
         // Side effect: remember the type parameter. This is a direct mutation
         // because it needs to be visible to usages not in this call stack.
         alreadyIntroducedTypeParameterIdentities.add(type.identity)
-        return makeHoleExpression(
+        return makeHoleExpressionWithExtantTypeParameter(
           type.name,
           makeObjectNode({
             assignableTo: recurseWithSameTypeParameters(

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -30,6 +30,7 @@ import {
 } from '../expressions/function-expression.js'
 import {
   collectHoleTypeParameterIdentities,
+  getHoleConstraintSource,
   getHoleTypeParameter,
   readHoleExpression,
 } from '../expressions/hole-expression.js'
@@ -198,10 +199,20 @@ const inferTypeImplementation = (
     } else if (!lookingUpKeys.has(key)) {
       const lookupResult = lookup({ key, context })
       if (either.isRight(lookupResult) && option.isSome(lookupResult.value)) {
-        const { foundValue, foundLocation, typeParameterOfFoundHole } =
+        const { foundValue, foundLocation, foundHole } =
           lookupResult.value.value
-        const innerResult = option.match(typeParameterOfFoundHole, {
-          some: either.makeRight,
+        const innerResult = option.match(foundHole, {
+          // The hole lives in an enclosing parameter annotation. Infer it here
+          // so its constraint is resolved in the current scope. The result is
+          // the hole's type, which is the same as this `@lookup`'s type, so
+          // caching both under this location is consistent.
+          some: holeExpression =>
+            inferTypeImplementation(
+              holeExpression,
+              parameterTypes,
+              new Set([...lookingUpKeys, key]),
+              context,
+            ),
           none: _ =>
             inferTypeImplementation(
               foundValue,
@@ -493,12 +504,33 @@ const inferTypeImplementation = (
     )
   }
 
-  // @hole: a hole denotes its type parameter.
+  // @hole: a hole denotes its type parameter. Unless its constraint is already
+  // sourced from the carried type parameter, resolve it here.
   const holeExpressionResult = readHoleExpression(node)
   if (either.isRight(holeExpressionResult)) {
-    return cacheOnSuccess(
-      either.makeRight(getHoleTypeParameter(holeExpressionResult.value)),
-    )
+    const holeExpression = holeExpressionResult.value
+    const parameter = getHoleTypeParameter(holeExpression)
+
+    switch (getHoleConstraintSource(holeExpression)) {
+      case 'expression':
+        return cacheOnSuccess(
+          either.map(
+            inferTypeImplementation(
+              holeExpression[1].constraint.assignableTo,
+              parameterTypes,
+              lookingUpKeys,
+              descendantContext(['1', 'constraint', 'assignableTo']),
+            ),
+            resolvedConstraint => ({
+              ...parameter,
+              constraint: { assignableTo: resolvedConstraint },
+            }),
+          ),
+        )
+      case 'typeParameter':
+        // The stashed parameter's constraint was already resolved, so trust it.
+        return cacheOnSuccess(either.makeRight(parameter))
+    }
   }
 
   // Non-specific default case for object nodes: recurse into properties and


### PR DESCRIPTION
It's not currently possible to resolve `@lookup`s from expression readers like `readHoleExpression` (there's no `ExpressionContext`). But `@hole` constraints may contain `@lookup`s; for example:

```plz
a => (x: (?b: :a)) => …
```

The constraint was processed with `typeFromSemanticGraph` while reading the `@hole` expression, which meant `?b`'s constraint would previously become a garbage `ObjectType` representing an un-elaborated `@lookup` expression rather than the looked-up type parameter for `a`.

To fix this, typifying a constraint containing a `@lookup` is now deferred until the `Type` is needed by inference (e.g. when it's referenced by a `@check` expression). `HoleExpression` has gained an additional bit of mutable state to keep track of this (stored in a symbolic property on the expression node, similar to the type parameter).