### PR TITLE
Report parse errors in a friendlier way

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@matt.kantor/either": "^1.4.0",
         "@matt.kantor/option": "^1.2.0",
-        "@matt.kantor/parsing": "^2.1.0"
+        "@matt.kantor/parsing": "^3.1.0"
       },
       "bin": {
         "please": "please"
@@ -253,12 +253,12 @@
       "license": "MIT"
     },
     "node_modules/@matt.kantor/parsing": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@matt.kantor/parsing/-/parsing-2.1.0.tgz",
-      "integrity": "sha512-cMhmmcKzlY6V/FoQTNuV4eQwP9/npa5FzDON+qNgd8avbpeGJl9R3xBYmVQcBY7CDWnJefX020Yqz3YQ5+DvEQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@matt.kantor/parsing/-/parsing-3.1.0.tgz",
+      "integrity": "sha512-ZI51KwhXgecfn8YNwCNDSIv71s0FYIzAlOhK4mX8PqQPXcDDmw7qVRcBq7YRUrZdsW89JL6LbsZt/AVzfpHFfQ==",
       "license": "MIT",
       "dependencies": {
-        "@matt.kantor/either": "^1.0.0"
+        "@matt.kantor/either": "^1.4.0"
       }
     },
     "node_modules/@types/esrecurse": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@matt.kantor/either": "^1.4.0",
     "@matt.kantor/option": "^1.2.0",
-    "@matt.kantor/parsing": "^2.1.0"
+    "@matt.kantor/parsing": "^3.1.0"
   },
   "engines": {
     "node": ">=22.18"

--- a/src/language/cli/0.ts
+++ b/src/language/cli/0.ts
@@ -1,10 +1,13 @@
+import { stripVTControlCharacters } from 'node:util'
 import { parse } from '../parsing/parser.js'
 import { readString } from './input.js'
 import { handleOutput } from './output.js'
 
 const main = async (process: NodeJS.Process): Promise<undefined> =>
   handleOutput(process, async () => {
-    const sourceCode = await readString(process.stdin)
+    const sourceCode = stripVTControlCharacters(
+      await readString(process.stdin),
+    ).trim()
     return parse(sourceCode)
   })
 

--- a/src/language/cli/error-formatting.test.ts
+++ b/src/language/cli/error-formatting.test.ts
@@ -1,0 +1,82 @@
+import { testCases } from '../../test-utilities.test.js'
+import { formatError } from './error-formatting.js'
+
+testCases(
+  ([error, context]: Parameters<typeof formatError>) =>
+    formatError(error, context),
+  ([error, context]) => JSON.stringify({ error, ...context }),
+)('formatError', [
+  [
+    [
+      { message: 'expected "}"', span: [6, 6] },
+      { source: '{ a: 1', filename: '<stdin>' },
+    ],
+    // prettier-ignore
+    [
+      'Error: expected "}"',
+      '',
+      '<stdin>:1:7',
+      '  │',
+      '1 │ { a: 1',
+      '  │       ▔',
+    ].join('\n'),
+  ],
+
+  [
+    [
+      { message: 'oops', span: [0, 0] },
+      { source: 'hi', filename: 'greeting.plz' },
+    ],
+    // prettier-ignore
+    [
+      'Error: oops',
+      '',
+      'greeting.plz:1:1',
+      '  │',
+      '1 │ hi',
+      '  │ ▔',
+    ].join('\n'),
+  ],
+
+  [
+    [
+      { message: 'bad', span: [8, 11] },
+      { source: 'foo\nbar baz', filename: '<stdin>' },
+    ],
+    // prettier-ignore
+    [
+      'Error: bad',
+      '',
+      '<stdin>:2:5',
+      '  │',
+      '2 │ bar baz',
+      '  │     ▔▔▔',
+    ].join('\n'),
+  ],
+
+  [
+    [
+      { message: 'e', span: [18, 19] },
+      {
+        source: Array.from({ length: 10 }, () => 'x').join('\n'),
+        filename: '<stdin>',
+      },
+    ],
+    // prettier-ignore
+    [
+      'Error: e',
+      '',
+      '<stdin>:10:1',
+      '   │',
+      '10 │ x',
+      '   │ ▔',
+    ].join('\n'),
+  ],
+
+  [[{ message: 'no source' }, { filename: 'a' }], 'Error: no source'],
+
+  [
+    [{ message: 'no span' }, { source: 'some source', filename: 'a' }],
+    'Error: no span',
+  ],
+])

--- a/src/language/cli/error-formatting.ts
+++ b/src/language/cli/error-formatting.ts
@@ -1,0 +1,49 @@
+import { styleText } from 'node:util'
+import { snippetAtSpan, type Span } from '../source-location.js'
+
+export type DiagnosticError = {
+  readonly message: string
+  readonly span?: Span | undefined
+}
+
+/**
+ * Render an error as a friendly diagnostic. When both `source` and a `span`
+ * are available the `Error: <message>` header is followed by a framed,
+ * underline-annotated source snippet; otherwise just the header is returned.
+ */
+export const formatError = (
+  error: DiagnosticError,
+  context: {
+    readonly filename: string
+    readonly source?: string
+  },
+): string => {
+  const errorLabel = styleText(['red', 'bold', 'underline'], 'Error')
+  const styledMessage = `${styleText('bold', ':')} ${error.message}`
+  const header = `${errorLabel}${styledMessage}`
+  return context.source === undefined || error.span === undefined ?
+      header
+    : `${header}\n\n${renderFrame(context.source, error.span, context.filename)}`
+}
+
+const renderFrame = (source: string, span: Span, filename: string): string => {
+  const { line, column, lineText, highlightLength } = snippetAtSpan(
+    source,
+    span,
+  )
+  const gutter = (text: string): string => styleText(['gray', 'bold'], text)
+  const padding = ' '.repeat(String(line).length)
+  const location = styleText(
+    'gray',
+    `${styleText('bold', filename)}${styleText('dim', ':')}${line}${styleText('dim', ':')}${column}`,
+  )
+  const underlineIndent = ' '.repeat(column - 1)
+  const underlines = styleText(['red', 'bold'], '▔'.repeat(highlightLength))
+  const verticalBar = styleText('dim', '│')
+  return [
+    location,
+    gutter(`${padding} ${verticalBar}`),
+    `${gutter(`${line} ${verticalBar}`)} ${lineText}`,
+    `${gutter(`${padding} ${verticalBar}`)} ${underlineIndent}${underlines}`,
+  ].join('\n')
+}

--- a/src/language/cli/output.ts
+++ b/src/language/cli/output.ts
@@ -8,11 +8,15 @@ import {
   unparse,
   type Notation,
 } from '../unparsing.js'
+import { formatError, type DiagnosticError } from './error-formatting.js'
 
 export const handleOutput = async (
   process: NodeJS.Process,
-  command: () => Promise<Either<{ readonly message: string }, SyntaxTree>>,
+  command: () =>
+    | Either<DiagnosticError, SyntaxTree>
+    | Promise<Either<DiagnosticError, SyntaxTree>>,
   defaultOutputNotation?: Notation,
+  source?: string,
 ): Promise<undefined> => {
   const args = parseArgs({
     args: process.argv.slice(2), // remove `execPath` and `filename`
@@ -55,7 +59,11 @@ export const handleOutput = async (
   const result = await command()
   either.match(result, {
     left: error => {
-      throw new Error(error.message) // TODO: Improve error reporting.
+      process.stderr.write(
+        `${formatError(error, { filename: '<stdin>', ...(source === undefined ? {} : { source }) })}\n`,
+      )
+      process.exitCode = 1
+      return undefined
     },
     right: output => {
       writeOutput(process.stdout, notation, output)

--- a/src/language/cli/please.test.ts
+++ b/src/language/cli/please.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert'
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import test, { suite } from 'node:test'
+
+const pleasePath = path.join(import.meta.dirname, 'please.js')
+
+type CommandResult = {
+  readonly stdout: string
+  readonly stderr: string
+  readonly code: number
+}
+
+const runPlease = (
+  input: string,
+  commandLineArguments: readonly string[] = [],
+): Promise<CommandResult> =>
+  new Promise(resolve => {
+    const child = execFile(
+      'node',
+      [pleasePath, ...commandLineArguments],
+      (error, stdout, stderr) => {
+        resolve({
+          stdout,
+          stderr,
+          code: error === null ? 0 : Number(error.code ?? 1),
+        })
+      },
+    )
+    child.stdin?.end(input)
+  })
+
+suite('please CLI error reporting', () => {
+  test('renders a framed diagnostic for a syntax error', async () => {
+    const { stdout, stderr, code } = await runPlease('{ a: 1', ['--no-color'])
+    assert.equal(code, 1)
+    assert.equal(stdout, '')
+    assert.equal(
+      stderr,
+      [
+        'Error: expected `}`',
+        '',
+        '<stdin>:1:7',
+        '  │',
+        '1 │ { a: 1',
+        '  │       ▔',
+        '',
+      ].join('\n'),
+    )
+  })
+
+  test('degrades to a plain header when the error has no span', async () => {
+    const { stdout, stderr, code } = await runPlease('1 ~ :boolean.type', [
+      '--no-color',
+    ])
+    assert.equal(code, 1)
+    assert.equal(stdout, '')
+    assert.match(stderr, /^Error: the value `1`/)
+  })
+
+  test('exits zero and writes output for a valid program', async () => {
+    const { stdout, stderr, code } = await runPlease('1 + 1', ['--no-color'])
+    assert.equal(code, 0)
+    assert.equal(stderr, '')
+    assert.equal(stdout.trim(), '2')
+  })
+})

--- a/src/language/cli/please.ts
+++ b/src/language/cli/please.ts
@@ -1,4 +1,5 @@
 import either from '@matt.kantor/either'
+import { stripVTControlCharacters } from 'node:util'
 import { compile } from '../compiling.js'
 import { parse } from '../parsing/parser.js'
 import { evaluate } from '../runtime.js'
@@ -6,20 +7,21 @@ import { prettyPlz } from '../unparsing.js'
 import { readString } from './input.js'
 import { handleOutput } from './output.js'
 
-const main = async (process: NodeJS.Process): Promise<undefined> =>
-  handleOutput(
+const main = async (process: NodeJS.Process): Promise<undefined> => {
+  const sourceCode = stripVTControlCharacters(
+    await readString(process.stdin),
+  ).trim()
+  return handleOutput(
     process,
-    async () => {
-      const sourceCode = await readString(process.stdin)
-
+    () => {
       // TODO: Cache intermediate representations to the filesystem.
       const syntaxTree = parse(sourceCode)
       const program = either.flatMap(syntaxTree, compile)
-      const runtimeOutput = either.flatMap(program, evaluate)
-
-      return runtimeOutput
+      return either.flatMap(program, evaluate)
     },
     prettyPlz,
+    sourceCode,
   )
+}
 
 await main(process)

--- a/src/language/errors.ts
+++ b/src/language/errors.ts
@@ -1,6 +1,9 @@
+import type { Span } from './source-location.js'
+
 export type BadSyntax = {
   readonly kind: 'badSyntax'
   readonly message: string
+  readonly span: Span
 }
 
 export type Bug = {

--- a/src/language/parsing/json.ts
+++ b/src/language/parsing/json.ts
@@ -35,7 +35,7 @@ export type ParsedJsonValue =
 // `interface` (not `type`) is used to avoid a circular reference error.
 interface ParsedJsonRecord extends OrderedRecord<ParsedJsonValue> {}
 
-const whitespace = regularExpression(/^[ \t\n\r]+/)
+const whitespace = regularExpression(/[ \t\n\r]+/)
 const optionalWhitespace = oneOf([whitespace, nothing])
 
 const optionallySurroundedByWhitespace = <Output>(
@@ -50,7 +50,7 @@ const quote = literal('"')
 const backslash = literal('\\')
 
 const unicodeEscape: Parser<string> = map(
-  sequence([backslash, literal('u'), regularExpression(/^[0-9A-Fa-f]{4}/)]),
+  sequence([backslash, literal('u'), regularExpression(/[0-9A-Fa-f]{4}/)]),
   ([_backslash, _u, hex]) => String.fromCharCode(parseInt(hex, 16)),
 )
 const simpleEscape: Parser<string> = map(
@@ -101,7 +101,7 @@ const jsonString: Parser<string> = map(
 )
 
 const jsonNumber: Parser<number> = map(
-  regularExpression(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/),
+  regularExpression(/-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/),
   Number,
 )
 

--- a/src/language/parsing/parser.ts
+++ b/src/language/parsing/parser.ts
@@ -1,12 +1,11 @@
 import either, { type Either } from '@matt.kantor/either'
 import parsing from '@matt.kantor/parsing'
-import { stripVTControlCharacters } from 'node:util'
 import type { ParseError } from '../errors.js'
 import { type SyntaxTree, syntaxTreeParser } from './syntax-tree.js'
 
 export const parse = (input: string): Either<ParseError, SyntaxTree> =>
   either.mapLeft(
-    parsing.parse(syntaxTreeParser, stripVTControlCharacters(input).trim()),
+    parsing.parse(syntaxTreeParser, input),
     (error): ParseError => {
       // Clamp defensively so a theoretical negative offset won't result in a
       // malformed span indicator.

--- a/src/language/parsing/parser.ts
+++ b/src/language/parsing/parser.ts
@@ -7,8 +7,15 @@ import { type SyntaxTree, syntaxTreeParser } from './syntax-tree.js'
 export const parse = (input: string): Either<ParseError, SyntaxTree> =>
   either.mapLeft(
     parsing.parse(syntaxTreeParser, stripVTControlCharacters(input).trim()),
-    error => ({
-      ...error,
-      kind: 'badSyntax',
-    }),
+    (error): ParseError => {
+      // Clamp defensively so a theoretical negative offset won't result in a
+      // malformed span indicator.
+      const offset = Math.max(0, Number(error.offset))
+      return {
+        kind: 'badSyntax',
+        message: error.message,
+        // Parsers currently always report a single failure point.
+        span: [offset, offset],
+      }
+    },
   )

--- a/src/language/parsing/trivia.ts
+++ b/src/language/parsing/trivia.ts
@@ -34,7 +34,7 @@ const singleLineComment = sequence([
   zeroOrMore(butNot(anySingleCharacter, newline, 'newline')),
 ])
 
-export const whitespace = regularExpression(/^\s+/)
+export const whitespace = regularExpression(/\s+/)
 export const whitespaceExceptNewlines = regularExpression(/[^\S\n]+/)
 
 export const trivia = oneOrMore(

--- a/src/language/source-location.test.ts
+++ b/src/language/source-location.test.ts
@@ -1,0 +1,49 @@
+import { testCases } from '../test-utilities.test.js'
+import {
+  lineAndColumnAtOffset,
+  snippetAtSpan,
+  type Span,
+} from './source-location.js'
+
+testCases(
+  ([source, offset]: readonly [string, number]) =>
+    lineAndColumnAtOffset(source, offset),
+  ([source, offset]) => `${JSON.stringify(source)} @ ${offset}`,
+)('lineAndColumnAtOffset', [
+  [['hello', 0], { line: 1, column: 1 }],
+  [['hello', 3], { line: 1, column: 4 }],
+  [['hello', 5], { line: 1, column: 6 }],
+  [['a\nb\nc', 2], { line: 2, column: 1 }],
+  [['a\nbc\nd', 4], { line: 2, column: 3 }],
+  [['line1\nline2', 6], { line: 2, column: 1 }],
+  // TODO: Perhaps `column` shouldn't go more than one character past the input,
+  // even with bogus offsets like this?
+  [['hello', 7], { line: 1, column: 8 }],
+])
+
+testCases(
+  ([source, span]: readonly [string, Span]) => snippetAtSpan(source, span),
+  ([source, span]) => `${JSON.stringify(source)} @ [${span[0]}, ${span[1]}]`,
+)('snippetAtSpan', [
+  [
+    ['hello', [0, 0]],
+    { line: 1, column: 1, lineText: 'hello', highlightLength: 1 },
+  ],
+  [
+    ['hello', [1, 3]],
+    { line: 1, column: 2, lineText: 'hello', highlightLength: 2 },
+  ],
+  [
+    ['a\nbb\nc', [3, 4]],
+    { line: 2, column: 2, lineText: 'bb', highlightLength: 1 },
+  ],
+  [
+    // A span crossing a newline is clamped to its first line.
+    ['ab\ncd', [1, 5]],
+    { line: 1, column: 2, lineText: 'ab', highlightLength: 1 },
+  ],
+  [
+    ['hello', [5, 5]],
+    { line: 1, column: 6, lineText: 'hello', highlightLength: 1 },
+  ],
+])

--- a/src/language/source-location.ts
+++ b/src/language/source-location.ts
@@ -1,0 +1,51 @@
+/**
+ * An `end`-inclusive character offset range (i.e. `[start, end)`) into a source
+ * string. A zero-width span (i.e. `start === end`) marks a single point.
+ */
+export type Span = readonly [start: number, end: number]
+
+/** `line` and `column` are 1-based. */
+export type LineAndColumn = {
+  readonly line: number
+  readonly column: number
+}
+
+/**
+ * Everything needed to quote and point at a `Span` on a single source line.
+ * `highlightLength` is the number of columns to underline, always at least 1
+ * and clamped to the end of the line (spans that cross a newline are truncated
+ * to their first line).
+ */
+export type SourceSnippet = LineAndColumn & {
+  readonly lineText: string
+  readonly highlightLength: number
+}
+
+export const lineAndColumnAtOffset = (
+  source: string,
+  offset: number,
+): LineAndColumn => {
+  const precedingText = source.slice(0, offset)
+  const lineStartOffset = precedingText.lastIndexOf('\n') + 1
+  return {
+    line: precedingText.split('\n').length,
+    column: offset - lineStartOffset + 1,
+  }
+}
+
+export const snippetAtSpan = (
+  source: string,
+  [start, end]: Span,
+): SourceSnippet => {
+  const { line, column } = lineAndColumnAtOffset(source, start)
+  const lineStartOffset = start - (column - 1)
+  const nextNewlineOffset = source.indexOf('\n', start)
+  const lineEndOffset =
+    nextNewlineOffset === -1 ? source.length : nextNewlineOffset
+  return {
+    line,
+    column,
+    lineText: source.slice(lineStartOffset, lineEndOffset),
+    highlightLength: Math.max(1, Math.min(end, lineEndOffset) - start),
+  }
+}

--- a/src/readme.test.ts
+++ b/src/readme.test.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import test, { suite } from 'node:test'
 import { parse } from './language/parsing/parser.js'
+import { lineAndColumnAtOffset } from './language/source-location.js'
 
 const repositoryRootDirectory = path.join(import.meta.dirname, '..')
 const readmePath = path.resolve(repositoryRootDirectory, 'README.md')
@@ -18,9 +19,6 @@ type RelativeLink = {
   readonly lineNumber: number
 }
 
-const lineNumberAtOffset = (source: string, offset: number): number =>
-  source.slice(0, offset).split('\n').length
-
 const fencedCodeBlocks = (
   source: string,
   codeBlockLanguage: string,
@@ -32,14 +30,14 @@ const fencedCodeBlocks = (
   return [...source.matchAll(fencedCodeBlockPattern)].map(match => ({
     content: match[1] ?? '',
     // The line after the opening fence is where code begins:
-    startingLineNumber: lineNumberAtOffset(source, match.index) + 1,
+    startingLineNumber: lineAndColumnAtOffset(source, match.index).line + 1,
   }))
 }
 
 const relativeLinks = (source: string): readonly RelativeLink[] => {
   return [...source.matchAll(relativeLinkPattern)].map(match => ({
     target: match[1] ?? '',
-    lineNumber: lineNumberAtOffset(source, match.index),
+    lineNumber: lineAndColumnAtOffset(source, match.index).line,
   }))
 }
 // This pattern matches links of the form `[text](./path)` or `[text](../path)`:


### PR DESCRIPTION
#### Before:
<img width="1074" height="262" alt="Screenshot 2026-06-25 at 12 56 04 PM" src="https://github.com/user-attachments/assets/0e57d296-8299-434c-a0d9-a9e69342bcd4" />

#### After:
<img width="1075" height="143" alt="Screenshot 2026-06-25 at 12 56 54 PM" src="https://github.com/user-attachments/assets/d0f8e1e4-9c55-4278-af9b-8c5d51f14eb3" />

For now this kind of diagnostic is limited to syntax errors. Friendly semantic errors will arrive in a future changeset.