### PR TITLE
Report semantic errors in a friendlier way

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ used in non-prototype versions.
 ### Current State
 
 Enough pieces exist to write basic runnable programs, but the standard library
-is anemic, documentation is lacking, and error messages are horrible.
+is anemic and documentation is lacking.
 
 The current runtime is an interpreter, but the plan is to eventually add one or
 more backends to allow building native executables.

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -1,11 +1,11 @@
 import either from '@matt.kantor/either'
 import option from '@matt.kantor/option'
 import assert from 'node:assert'
-import { compile } from './language/compiling.js'
 import { parse } from './language/parsing/parser.js'
 import { evaluate } from './language/runtime.js'
 import * as orderedRecord from './ordered-record.js'
 import {
+  compileWithoutSpans,
   parseAndCompileAndRun,
   testCases,
   toSyntaxTree,
@@ -23,7 +23,7 @@ const endToEnd = (input: string) => {
     unparseAndRoundtrip,
   )
 
-  const program = either.flatMap(syntaxTree, compile)
+  const program = either.flatMap(syntaxTree, compileWithoutSpans)
   const runtimeOutputFromRoundtrippingProgram = either.flatMap(
     program,
     unparseAndRoundtrip,

--- a/src/language/cli/1.ts
+++ b/src/language/cli/1.ts
@@ -3,6 +3,8 @@ import { handleInput } from './input.js'
 import { handleOutput } from './output.js'
 
 const main = (process: NodeJS.Process): Promise<undefined> =>
-  handleOutput(process, () => handleInput(process, compile))
+  handleOutput(process, () =>
+    handleInput(process, input => compile(input, new Map())),
+  )
 
 await main(process)

--- a/src/language/cli/please.test.ts
+++ b/src/language/cli/please.test.ts
@@ -49,13 +49,27 @@ suite('please CLI error reporting', () => {
     )
   })
 
-  test('degrades to a plain header when the error has no span', async () => {
+  test('frames a type mismatch error with an underline', async () => {
     const { stdout, stderr, code } = await runPlease('1 ~ :boolean.type', [
       '--no-color',
     ])
     assert.equal(code, 1)
     assert.equal(stdout, '')
-    assert.match(stderr, /^Error: the value `1`/)
+    assert.match(stderr, /^Error: /)
+    assert.ok(stderr.includes('\n<stdin>:1:1\n'))
+    assert.ok(stderr.includes('\n1 │ 1 ~ :boolean.type\n'))
+    assert.ok(stderr.includes('\n  │ ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔\n'))
+  })
+
+  test('underlines a sub-expression error on a later line', async () => {
+    const source = '{\n  greeting: :nope\n  other: 2\n}'
+    const { stdout, stderr, code } = await runPlease(source, ['--no-color'])
+    assert.equal(code, 1)
+    assert.equal(stdout, '')
+    assert.match(stderr, /^Error: property `nope` not found\n/)
+    assert.ok(stderr.includes('\n<stdin>:2:13\n'))
+    assert.ok(stderr.includes('\n2 │   greeting: :nope\n'))
+    assert.ok(stderr.includes('\n  │             ▔▔▔▔▔\n'))
   })
 
   test('exits zero and writes output for a valid program', async () => {

--- a/src/language/cli/please.ts
+++ b/src/language/cli/please.ts
@@ -1,7 +1,7 @@
 import either from '@matt.kantor/either'
 import { stripVTControlCharacters } from 'node:util'
 import { compile } from '../compiling.js'
-import { parse } from '../parsing/parser.js'
+import { parseWithSpans } from '../parsing/parser.js'
 import { evaluate } from '../runtime.js'
 import { prettyPlz } from '../unparsing.js'
 import { readString } from './input.js'
@@ -15,9 +15,9 @@ const main = async (process: NodeJS.Process): Promise<undefined> => {
     process,
     () => {
       // TODO: Cache intermediate representations to the filesystem.
-      const syntaxTree = parse(sourceCode)
-      const program = either.flatMap(syntaxTree, tree =>
-        compile(tree, new Map()),
+      const program = either.flatMap(
+        parseWithSpans(sourceCode),
+        ({ tree, spans }) => compile(tree, spans),
       )
       return either.flatMap(program, evaluate)
     },

--- a/src/language/cli/please.ts
+++ b/src/language/cli/please.ts
@@ -16,7 +16,9 @@ const main = async (process: NodeJS.Process): Promise<undefined> => {
     () => {
       // TODO: Cache intermediate representations to the filesystem.
       const syntaxTree = parse(sourceCode)
-      const program = either.flatMap(syntaxTree, compile)
+      const program = either.flatMap(syntaxTree, tree =>
+        compile(tree, new Map()),
+      )
       return either.flatMap(program, evaluate)
     },
     prettyPlz,

--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -2,13 +2,16 @@ import either, { type Either } from '@matt.kantor/either'
 import assert from 'node:assert'
 import * as orderedRecord from '../../ordered-record.js'
 import { withPhantomData } from '../../phantom-data.js'
-import { testCases, toSyntaxTree } from '../../test-utilities.test.js'
+import {
+  compileWithoutSpans,
+  testCases,
+  toSyntaxTree,
+} from '../../test-utilities.test.js'
 import type { JsonValue } from '../../utility-types.js'
 import type { ElaborationError } from '../errors.js'
 import type { Molecule } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
 import type { Output } from '../semantics.js'
-import { compile } from './compiler.js'
 
 const success = (
   expectedOutput: JsonValue | Molecule,
@@ -22,7 +25,7 @@ const success = (
   )
 
 const canonicalizeAndCompile = (input: JsonValue) =>
-  compile(toSyntaxTree(input))
+  compileWithoutSpans(toSyntaxTree(input))
 
 testCases(
   canonicalizeAndCompile,
@@ -194,7 +197,8 @@ testCases(
   ],
 ])
 
-const parseAndCompile = (input: string) => either.flatMap(parse(input), compile)
+const parseAndCompile = (input: string) =>
+  either.flatMap(parse(input), compileWithoutSpans)
 
 testCases(
   parseAndCompile,

--- a/src/language/compiling/compiler.ts
+++ b/src/language/compiling/compiler.ts
@@ -1,12 +1,13 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { CompilationError } from '../errors.js'
-import type { SyntaxTree } from '../parsing.js'
+import type { ExpressionSpansByLocation, SyntaxTree } from '../parsing.js'
 import { elaborate, serialize, type Output } from '../semantics.js'
 import { keywordHandlers } from './semantics/keywords.js'
 
 export const compile = (
   syntaxTree: SyntaxTree,
+  spans: ExpressionSpansByLocation,
 ): Either<CompilationError, Output> => {
-  const semanticGraphResult = elaborate(syntaxTree, keywordHandlers)
+  const semanticGraphResult = elaborate(syntaxTree, keywordHandlers, spans)
   return either.flatMap(semanticGraphResult, serialize)
 }

--- a/src/language/compiling/error-spans.test.ts
+++ b/src/language/compiling/error-spans.test.ts
@@ -1,0 +1,52 @@
+import either from '@matt.kantor/either'
+import assert from 'node:assert'
+import test, { suite } from 'node:test'
+import { toSyntaxTree } from '../../test-utilities.test.js'
+import { parseWithSpans } from '../parsing/parser.js'
+import type { Span } from '../source-location.js'
+import { compile } from './compiler.js'
+
+const compileErrorSpan = (source: string): Span | undefined => {
+  const parsed = parseWithSpans(source)
+  if (either.isLeft(parsed)) {
+    throw new Error(`unexpected parse error: ${parsed.value.message}`)
+  } else {
+    const result = compile(parsed.value.tree, parsed.value.spans)
+    if (either.isRight(result)) {
+      throw new Error('expected a compilation error but compilation succeeded')
+    } else {
+      return result.value.span
+    }
+  }
+}
+
+suite('compile attaches source spans to elaboration errors', () => {
+  test('unknown lookup spans the lookup expression', () => {
+    assert.deepEqual(compileErrorSpan(':nonexistent'), [0, 12])
+  })
+
+  test('type mismatch spans the checked expression', () => {
+    const source = '1 ~ :boolean.type'
+    assert.deepEqual(compileErrorSpan(source), [0, source.length])
+  })
+
+  test('unknown keyword spans the keyword expression', () => {
+    assert.deepEqual(compileErrorSpan('@bogus'), [0, 6])
+  })
+
+  test('an error inside an object spans the offending sub-expression', () => {
+    const source = '{ ok: 1, bad: :missing }'
+    assert.deepEqual(compileErrorSpan(source), [14, 22])
+    assert.equal(source.slice(14, 22), ':missing')
+  })
+
+  test('omits the span when compiled with no spans', () => {
+    const lookupNonexistentKey = toSyntaxTree({
+      0: '@lookup',
+      1: { key: 'nonexistent' },
+    })
+    const resultWithoutSpans = compile(lookupNonexistentKey, new Map())
+    assert(either.isLeft(resultWithoutSpans))
+    assert.equal(resultWithoutSpans.value.span, undefined)
+  })
+})

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -1,7 +1,11 @@
 import either from '@matt.kantor/either'
 import assert from 'node:assert'
 import { stripVTControlCharacters } from 'node:util'
-import { testCases, toSyntaxTree } from '../../test-utilities.test.js'
+import {
+  compileWithoutSpans,
+  testCases,
+  toSyntaxTree,
+} from '../../test-utilities.test.js'
 import type { JsonValue } from '../../utility-types.js'
 import { parseJson } from '../parsing.js'
 import { parse } from '../parsing/parser.js'
@@ -14,7 +18,6 @@ import {
   unparse,
   type Notation,
 } from '../unparsing.js'
-import { compile } from './compiler.js'
 
 const unparsers = (rawValue: JsonValue) => {
   const value = toSyntaxTree(rawValue)
@@ -34,28 +37,40 @@ const unparsers = (rawValue: JsonValue) => {
     inlinePlz: either.flatMap(
       either.flatMap(unparsedInlinePlz, parse),
       roundtrippedValue => {
-        assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
+        assert.deepEqual(
+          compileWithoutSpans(roundtrippedValue).value,
+          compileWithoutSpans(value).value,
+        )
         return unparsedInlinePlz
       },
     ).value,
     sugarFreeInlinePlz: either.flatMap(
       either.flatMap(unparsedSugarFreeInlinePlz, parse),
       roundtrippedValue => {
-        assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
+        assert.deepEqual(
+          compileWithoutSpans(roundtrippedValue).value,
+          compileWithoutSpans(value).value,
+        )
         return unparsedSugarFreeInlinePlz
       },
     ).value,
     prettyPlz: either.flatMap(
       either.flatMap(unparsedPrettyPlz, parse),
       roundtrippedValue => {
-        assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
+        assert.deepEqual(
+          compileWithoutSpans(roundtrippedValue).value,
+          compileWithoutSpans(value).value,
+        )
         return unparsedPrettyPlz
       },
     ).value,
     sugarFreePrettyPlz: either.flatMap(
       either.flatMap(unparsedSugarFreePrettyPlz, parse),
       roundtrippedValue => {
-        assert.deepEqual(compile(roundtrippedValue).value, compile(value).value)
+        assert.deepEqual(
+          compileWithoutSpans(roundtrippedValue).value,
+          compileWithoutSpans(value).value,
+        )
         return unparsedSugarFreePrettyPlz
       },
     ).value,

--- a/src/language/errors.ts
+++ b/src/language/errors.ts
@@ -9,6 +9,7 @@ export type BadSyntax = {
 export type Bug = {
   readonly kind: 'bug'
   readonly message: string
+  readonly span?: Span
 }
 
 export type DependencyUnavailable = {
@@ -19,31 +20,37 @@ export type DependencyUnavailable = {
 export type InvalidExpressionError = {
   readonly kind: 'invalidExpression'
   readonly message: string
+  readonly span?: Span
 }
 
 export type InvalidSyntaxTreeError = {
   readonly kind: 'invalidSyntaxTree'
   readonly message: string
+  readonly span?: Span
 }
 
 export type Panic = {
   readonly kind: 'panic'
   readonly message: string
+  readonly span?: Span
 }
 
 export type UnserializableValueError = {
   readonly kind: 'unserializableValue'
   readonly message: string
+  readonly span?: Span
 }
 
 export type TypeMismatchError = {
   readonly kind: 'typeMismatch'
   readonly message: string
+  readonly span?: Span
 }
 
 export type UnknownKeywordError = {
   readonly kind: 'unknownKeyword'
   readonly message: string
+  readonly span?: Span
 }
 
 export type ElaborationError =

--- a/src/language/parsing.ts
+++ b/src/language/parsing.ts
@@ -1,4 +1,5 @@
 export type { Atom } from './parsing/atom.js'
 export type { Molecule } from './parsing/expression.js'
 export { parseJson } from './parsing/json.js'
+export type { ExpressionSpansByLocation } from './parsing/spans.js'
 export type { SyntaxTree } from './parsing/syntax-tree.js'

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -36,6 +36,7 @@ import {
   optionallySurroundedByParentheses,
   surroundedByParentheses,
 } from './parentheses.js'
+import { recordExpressionSpan } from './spans.js'
 import { optionalTrivia, trivia, triviaExceptNewlines } from './trivia.js'
 
 // `interface` (not `type`) is used to avoid a circular reference error.
@@ -250,25 +251,27 @@ const propertyDelimiter = oneOf([
 
 const argument = surroundedByParentheses(lazy(() => expression))
 
-const dottedKeyPathKey = oneOf([
-  // (a)
-  // (1 + 1)
-  // (:a.b.c)
-  // (:f(x)(y))
-  surroundedByParentheses(lazy(() => expression)),
+const dottedKeyPathKey = recordExpressionSpan(
+  oneOf([
+    // (a)
+    // (1 + 1)
+    // (:a.b.c)
+    // (:f(x)(y))
+    surroundedByParentheses(lazy(() => expression)),
 
-  // :a
-  map(sequence([colon, atomRequiringDotQuotation]), ([_colon, key]) =>
-    molecule([
-      ['0', '@lookup'],
-      ['1', molecule([['key', key]])],
-    ]),
-  ),
+    // :a
+    map(sequence([colon, atomRequiringDotQuotation]), ([_colon, key]) =>
+      molecule([
+        ['0', '@lookup'],
+        ['1', molecule([['key', key]])],
+      ]),
+    ),
 
-  // 1
-  // "a.b"
-  atomRequiringDotQuotation,
-])
+    // 1
+    // "a.b"
+    atomRequiringDotQuotation,
+  ]),
+)
 
 const compactDottedKeyPathComponent = map(
   sequence([dot, dottedKeyPathKey]),
@@ -359,35 +362,37 @@ const infixOperator = sequence([
   compactTrailingIndexesAndArguments,
 ])
 
-const compactExpression: Parser<Molecule | Atom> = oneOf([
-  // (a)
-  // (1 + 1)
-  // (a => :b)(c)
-  // ({ a: 1 } |> :identity).a
-  map(
-    sequence([
-      surroundedByParentheses(lazy(() => expression)),
-      compactTrailingIndexesAndArguments,
-    ]),
-    ([expression, trailingIndexesAndArguments]) =>
-      trailingIndexesAndArgumentsToExpression(
-        expression,
-        trailingIndexesAndArguments,
-      ),
-  ),
-  // :a.b
-  // :a.b(1).c
-  // :f(x)
-  // :a.b(1)(2)
-  lazy(() => precededByColonThenAtom),
-  // @runtime { x => :x }
-  // @panic
-  lazy(() => precededByAtSign),
-  // {}
-  lazy(() => precededByOpeningBrace),
-  // 1
-  atom,
-])
+const compactExpression: Parser<Molecule | Atom> = recordExpressionSpan(
+  oneOf([
+    // (a)
+    // (1 + 1)
+    // (a => :b)(c)
+    // ({ a: 1 } |> :identity).a
+    map(
+      sequence([
+        surroundedByParentheses(lazy(() => expression)),
+        compactTrailingIndexesAndArguments,
+      ]),
+      ([expression, trailingIndexesAndArguments]) =>
+        trailingIndexesAndArgumentsToExpression(
+          expression,
+          trailingIndexesAndArguments,
+        ),
+    ),
+    // :a.b
+    // :a.b(1).c
+    // :f(x)
+    // :a.b(1)(2)
+    lazy(() => precededByColonThenAtom),
+    // @runtime { x => :x }
+    // @panic
+    lazy(() => precededByAtSign),
+    // {}
+    lazy(() => precededByOpeningBrace),
+    // 1
+    atom,
+  ]),
+)
 
 // ~> a
 // ~> {}
@@ -711,16 +716,18 @@ const parenthesizedHole = surroundedByParentheses(
   ),
 )
 
-const expressionWhichMayHaveTrailingExpressions = oneOf([
-  parenthesizedHole,
-  precededByOpeningParenthesis,
-  precededByOpeningBrace,
-  precededByAtSign,
-  precededByColonThenAtom,
-  hole,
-  precededByAtomThenFunctionArrow,
-  atom,
-])
+const expressionWhichMayHaveTrailingExpressions = recordExpressionSpan(
+  oneOf([
+    parenthesizedHole,
+    precededByOpeningParenthesis,
+    precededByOpeningBrace,
+    precededByAtSign,
+    precededByColonThenAtom,
+    hole,
+    precededByAtomThenFunctionArrow,
+    atom,
+  ]),
+)
 
 const trailingInfixExpression = (initialExpression: string | Molecule) =>
   map(trailingInfixTokens, trailingInfixTokens =>
@@ -752,12 +759,12 @@ const trailingExpressionsExceptUnion = (initialExpression: string | Molecule) =>
     trailingCheckExpression(initialExpression),
   ] as const
 
-export const expression: Parser<Atom | Molecule> = flatMap(
-  expressionWhichMayHaveTrailingExpressions,
-  initialExpression =>
+export const expression: Parser<Atom | Molecule> = recordExpressionSpan(
+  flatMap(expressionWhichMayHaveTrailingExpressions, initialExpression =>
     oneOf([
       ...trailingExpressionsExceptUnion(initialExpression),
       trailingUnionExpression(initialExpression),
       map(nothing, _ => initialExpression),
     ]),
+  ),
 )

--- a/src/language/parsing/parser.ts
+++ b/src/language/parsing/parser.ts
@@ -1,7 +1,8 @@
 import either, { type Either } from '@matt.kantor/either'
 import parsing from '@matt.kantor/parsing'
 import type { ParseError } from '../errors.js'
-import { type SyntaxTree, syntaxTreeParser } from './syntax-tree.js'
+import { spansFromSyntaxTree, type ExpressionSpansByLocation } from './spans.js'
+import { syntaxTreeParser, type SyntaxTree } from './syntax-tree.js'
 
 export const parse = (input: string): Either<ParseError, SyntaxTree> =>
   either.mapLeft(
@@ -18,3 +19,16 @@ export const parse = (input: string): Either<ParseError, SyntaxTree> =>
       }
     },
   )
+
+export type SyntaxTreeWithSpans = {
+  readonly tree: SyntaxTree
+  readonly spans: ExpressionSpansByLocation
+}
+
+export const parseWithSpans = (
+  input: string,
+): Either<ParseError, SyntaxTreeWithSpans> =>
+  either.map(parse(input), tree => ({
+    tree,
+    spans: spansFromSyntaxTree(tree),
+  }))

--- a/src/language/parsing/spans.test.ts
+++ b/src/language/parsing/spans.test.ts
@@ -1,0 +1,48 @@
+import either from '@matt.kantor/either'
+import assert from 'node:assert'
+import test, { suite } from 'node:test'
+import { stringifyKeyPathForInternalUse } from '../semantics.js'
+import { parseWithSpans } from './parser.js'
+import type { ExpressionSpansByLocation } from './spans.js'
+
+const spansOf = (source: string): ExpressionSpansByLocation => {
+  const result = parseWithSpans(source)
+  if (either.isLeft(result)) {
+    throw new Error(`unexpected parse error: ${result.value.message}`)
+  } else {
+    return result.value.spans
+  }
+}
+
+suite('parseWithSpans', () => {
+  test('records the whole-program span at the empty key path', () => {
+    assert.deepEqual(
+      spansOf(':nonexistent').get(stringifyKeyPathForInternalUse([])),
+      [0, 12],
+    )
+  })
+
+  test('keys nested expression spans by their key path', () => {
+    const source = '{ a: :b, b: 42 }'
+    const spans = spansOf(source)
+    assert.deepEqual(spans.get(stringifyKeyPathForInternalUse(['a'])), [5, 7])
+    assert.equal(source.slice(5, 7), ':b')
+    assert.deepEqual(spans.get(stringifyKeyPathForInternalUse([])), [
+      0,
+      source.length,
+    ])
+  })
+
+  test('excludes leading trivia from the program span', () => {
+    const source = '// c\n{ a: 1 }'
+    assert.deepEqual(spansOf(source).get(stringifyKeyPathForInternalUse([])), [
+      5,
+      source.length,
+    ])
+    assert.equal(source.slice(5), '{ a: 1 }')
+  })
+
+  test('does not record spans for atoms', () => {
+    assert.equal(spansOf('42').size, 0)
+  })
+})

--- a/src/language/parsing/spans.ts
+++ b/src/language/parsing/spans.ts
@@ -1,0 +1,70 @@
+import either from '@matt.kantor/either'
+import type { Parser } from '@matt.kantor/parsing'
+import {
+  stringifyKeyPathForInternalUse,
+  type KeyPathStringifiedForInternalUse,
+} from '../semantics.js'
+import type { Span } from '../source-location.js'
+import type { Atom } from './atom.js'
+import type { Molecule } from './expression.js'
+
+/**
+ * Maps parsed expressions' key paths to their source spans.
+ */
+export type ExpressionSpansByLocation = ReadonlyMap<
+  KeyPathStringifiedForInternalUse,
+  Span
+>
+
+// Each parsed molecule's source span is stashed in here (by identity) while
+// parsing. The `WeakMap` allows entries to be garbage-collected once their
+// syntax tree is no longer needed.
+const spanByMolecule = new WeakMap<Molecule, Span>()
+
+/**
+ * Wrap the given parser so every nesting level records the spans of produced
+ * molecules as a side effect.
+ */
+export const recordExpressionSpan =
+  (parser: Parser<Atom | Molecule>): Parser<Atom | Molecule> =>
+  (input, offset = 0n) =>
+    either.map(parser(input, offset), success => {
+      // Atoms are strings and can't key a `WeakMap`; only molecules get spans.
+      if (typeof success.output !== 'string') {
+        // Side effect: keep track of the span.
+        spanByMolecule.set(success.output, [
+          Number(offset),
+          Number(success.offset),
+        ])
+      }
+      return success
+    })
+
+export const spansFromSyntaxTree = (
+  tree: Atom | Molecule,
+): ExpressionSpansByLocation => new Map(spanEntriesWithinSubtree(tree, []))
+
+const spanEntriesWithinSubtree = (
+  node: Atom | Molecule,
+  keyPath: readonly Atom[],
+): readonly (readonly [KeyPathStringifiedForInternalUse, Span])[] => {
+  if (typeof node === 'string') {
+    return []
+  } else {
+    const spanForThisMolecule = spanByMolecule.get(node)
+    const entryForThisMolecule =
+      spanForThisMolecule === undefined ? undefined : (
+        ([
+          stringifyKeyPathForInternalUse(keyPath),
+          spanForThisMolecule,
+        ] as const)
+      )
+    const entriesForChildren = node.entries.flatMap(([key, value]) =>
+      spanEntriesWithinSubtree(value, [...keyPath, key]),
+    )
+
+    return entryForThisMolecule === undefined ? entriesForChildren : (
+        [entryForThisMolecule, ...entriesForChildren]
+      )
+  }
+}

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -77,7 +77,9 @@ export {
   arrayToMolecule,
   keyPathFromObjectNode,
   stringifyKeyPathForEndUser,
+  stringifyKeyPathForInternalUse,
   type KeyPath,
+  type KeyPathStringifiedForInternalUse,
 } from './semantics/key-path.js'
 export { isKeyword, type Keyword } from './semantics/keyword.js'
 export {

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -3,8 +3,18 @@ import option from '@matt.kantor/option'
 import { withPhantomData, type WithPhantomData } from '../../phantom-data.js'
 import type { Writable } from '../../utility-types.js'
 import type { ElaborationError, InvalidSyntaxTreeError } from '../errors.js'
-import type { Atom, Molecule, SyntaxTree } from '../parsing.js'
-import { asSemanticGraph, type Type } from '../semantics.js'
+import type {
+  Atom,
+  ExpressionSpansByLocation,
+  Molecule,
+  SyntaxTree,
+} from '../parsing.js'
+import {
+  asSemanticGraph,
+  stringifyKeyPathForInternalUse,
+  type Type,
+} from '../semantics.js'
+import type { Span } from '../source-location.js'
 import {
   isExpression,
   isKeywordExpressionWithArgument,
@@ -56,6 +66,12 @@ export type ExpressionContext = {
     FunctionParameterTypeInfo
   >
   /**
+   * Source spans for the program being elaborated, keyed by stringified key
+   * path (matching `location`). This is used to attach spans to errors. It's
+   * absent when elaborating from a sourceless origin.
+   */
+  readonly sourceSpans?: ExpressionSpansByLocation | undefined
+  /**
    * `location` is typically both the origin for `@lookup`s and the prefix for
    * cache keys, but a few inference sites run with `location` pointing at a
    * scope other than the node's true position (e.g. function parameter
@@ -90,6 +106,7 @@ export type KeywordHandlers = Readonly<Record<Keyword, KeywordHandler>>
 export const elaborate = (
   program: SyntaxTree,
   keywordHandlers: KeywordHandlers,
+  spans?: ExpressionSpansByLocation,
 ): Either<ElaborationError, ElaboratedSemanticGraph> =>
   elaborateWithContext(program, {
     keywordHandlers,
@@ -98,6 +115,7 @@ export const elaborate = (
     mutableFunctionParameterCache: new Map(),
     program:
       typeof program === 'string' ? program : objectNodeFromMolecule(program),
+    sourceSpans: spans,
   })
 
 export const elaborateWithContext = (
@@ -318,7 +336,7 @@ const handleObjectNodeWhichMayBeAExpression = (
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> => {
   const possibleKeyword = node[0]
-  return (
+  return attachSpanIfAbsent(
     isKeyword(possibleKeyword) ?
       context.keywordHandlers[possibleKeyword](
         withProperty(node, '0', possibleKeyword),
@@ -331,9 +349,47 @@ const handleObjectNodeWhichMayBeAExpression = (
       })
     : either.makeRight(
         withProperty(node, '0', unescapeKeywordSigil(possibleKeyword)),
-      )
+      ),
+    context,
   )
 }
+
+/**
+ * Attach the current location's source span to a freshly-produced error,
+ * leaving any already-attached (deeper, more specific) span untouched so the
+ * innermost one wins.
+ */
+const attachSpanIfAbsent = (
+  result: Either<ElaborationError, SemanticGraph>,
+  context: ExpressionContext,
+): Either<ElaborationError, SemanticGraph> =>
+  either.mapLeft(result, error => {
+    if (error.span !== undefined) {
+      return error
+    } else {
+      const span = spanForLocation(context.sourceSpans, context.location)
+      if (span === undefined) {
+        return error
+      } else {
+        return { ...error, span }
+      }
+    }
+  })
+
+/**
+ * Resolve a location to its source span, walking up to the nearest enclosing
+ * expression when the exact node has no recorded span.
+ */
+const spanForLocation = (
+  spans: ExpressionSpansByLocation | undefined,
+  location: KeyPath,
+): Span | undefined =>
+  spans === undefined ? undefined : (
+    (spans.get(stringifyKeyPathForInternalUse(location)) ??
+    (location.length === 0 ?
+      undefined
+    : spanForLocation(spans, location.slice(0, -1))))
+  )
 
 const handleAtomWhichMayNotBeAKeyword = (
   atom: Atom,

--- a/src/language/semantics/key-path.ts
+++ b/src/language/semantics/key-path.ts
@@ -1,5 +1,6 @@
 import either, { type Either } from '@matt.kantor/either'
 import * as orderedRecord from '../../ordered-record.js'
+import { withPhantomData, type WithPhantomData } from '../../phantom-data.js'
 import type { InvalidExpressionError } from '../errors.js'
 import type { Atom, Molecule } from '../parsing.js'
 import { inlinePlz, unparse } from '../unparsing.js'
@@ -9,11 +10,25 @@ import { stringifySemanticGraphForEndUser } from './semantic-graph.js'
 export type KeyPath = readonly Atom[]
 export type NonEmptyKeyPath = readonly [Atom, ...KeyPath]
 
+declare const _isKeyPathStringifiedForInternalUse: unique symbol
+type IsKeyPathStringifiedForInternalUse = {
+  readonly [_isKeyPathStringifiedForInternalUse]: true
+}
+export type KeyPathStringifiedForInternalUse = WithPhantomData<
+  string,
+  IsKeyPathStringifiedForInternalUse
+>
+
 export const stringifyKeyPathForEndUser = (keyPath: KeyPath): string =>
   either.match(unparse(arrayToMolecule(keyPath), inlinePlz), {
     right: stringifiedOutput => stringifiedOutput,
     left: error => `(unserializable key path: ${error.message})`,
   })
+
+export const stringifyKeyPathForInternalUse = (
+  keyPath: KeyPath,
+): KeyPathStringifiedForInternalUse =>
+  withPhantomData<IsKeyPathStringifiedForInternalUse>()(JSON.stringify(keyPath))
 
 export const arrayToMolecule = (
   keyPath: readonly (Molecule | Atom)[],

--- a/src/test-utilities.test.ts
+++ b/src/test-utilities.test.ts
@@ -73,9 +73,12 @@ export const toSyntaxTree = (input: JsonValue): SyntaxTree =>
       Object.entries(input).map(([key, value]) => [key, toSyntaxTree(value)]),
     )
 
+export const compileWithoutSpans = (syntaxTree: SyntaxTree) =>
+  compile(syntaxTree, new Map())
+
 export const parseAndCompileAndRun = (input: string): ProgramResult => {
   const syntaxTree = parse(input)
-  const program = either.flatMap(syntaxTree, compile)
+  const program = either.flatMap(syntaxTree, compileWithoutSpans)
   const runtimeOutput = either.flatMap(program, evaluate)
   return runtimeOutput
 }


### PR DESCRIPTION
Here's an example of what they look like now:
<img width="933" height="143" alt="Screenshot 2026-06-25 at 6 08 54 PM" src="https://github.com/user-attachments/assets/ee97dec4-ae0f-4991-817e-36414062186f" />

Follows up on the promise in #223.