### PR TITLE
Point semantic analysis diagnostics at offending sub-expressions

### DIFF
--- a/src/language/cli/please.test.ts
+++ b/src/language/cli/please.test.ts
@@ -61,6 +61,18 @@ suite('please CLI error reporting', () => {
     assert.ok(stderr.includes('\n  │ ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔\n'))
   })
 
+  test('underlines the offending argument of a function call', async () => {
+    const { stdout, stderr, code } = await runPlease(':boolean.not({})', [
+      '--no-color',
+    ])
+    assert.equal(code, 1)
+    assert.equal(stdout, '')
+    assert.match(stderr, /^Error: argument with type `{}`/)
+    assert.ok(stderr.includes('\n<stdin>:1:14\n'))
+    assert.ok(stderr.includes('\n1 │ :boolean.not({})\n'))
+    assert.ok(stderr.includes('\n  │              ▔▔\n'))
+  })
+
   test('underlines a sub-expression error on a later line', async () => {
     const source = '{\n  greeting: :nope\n  other: 2\n}'
     const { stdout, stderr, code } = await runPlease(source, ['--no-color'])

--- a/src/language/compiling/error-spans.test.ts
+++ b/src/language/compiling/error-spans.test.ts
@@ -25,9 +25,18 @@ suite('compile attaches source spans to elaboration errors', () => {
     assert.deepEqual(compileErrorSpan(':nonexistent'), [0, 12])
   })
 
-  test('type mismatch spans the checked expression', () => {
-    const source = '1 ~ :boolean.type'
-    assert.deepEqual(compileErrorSpan(source), [0, source.length])
+  test('type mismatch blames the checked value', () => {
+    const source = '{} ~ :boolean.type'
+    assert.deepEqual(compileErrorSpan(source), [0, 2])
+    assert.equal(source.slice(0, 2), '{}')
+  })
+
+  test('missing property blames the first absent key in a chain', () => {
+    const source1 = '{}.(1 + 1).(1 + 1).(1 + 1)'
+    assert.deepEqual(compileErrorSpan(source1), [3, 10])
+
+    const source2 = '{2: {}}.(1 + 1).(1 + 1).(1 + 1)'
+    assert.deepEqual(compileErrorSpan(source2), [16, 23])
   })
 
   test('unknown keyword spans the keyword expression', () => {

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -3,6 +3,7 @@ import option, { type Option } from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
   applicableFunctionSignatures,
+  attachSpanIfAbsent,
   containedTypeParameters,
   containsAnyUnelaboratedNodes,
   getTypesForTypeParameters,
@@ -188,23 +189,43 @@ export const applyKeywordHandler: KeywordHandler = (
       const functionToApply = applyExpression[1].function
       const argument = applyExpression[1].argument
 
+      const subContextForFunction = {
+        ...context,
+        location: [...context.location, '1', 'function'],
+      }
+      const subContextForArgument = {
+        ...context,
+        location: [...context.location, '1', 'argument'],
+      }
+
       const argumentTypeCheck = either.flatMap(
-        inferType(functionToApply, {
-          ...context,
-          location: [...context.location, '1', 'function'],
-        }),
+        attachSpanIfAbsent(
+          inferType(functionToApply, subContextForFunction),
+          subContextForFunction,
+        ),
         functionType =>
           either.flatMap(
-            inferType(argument, {
-              ...context,
-              location: [...context.location, '1', 'argument'],
-            }),
+            attachSpanIfAbsent(
+              inferType(argument, subContextForArgument),
+              subContextForArgument,
+            ),
             argumentType =>
-              checkApplication(
-                argument,
-                functionType,
-                argumentType,
-                rigidTypeParameterIdentities(context),
+              either.flatMapLeft(
+                checkApplication(
+                  argument,
+                  functionType,
+                  argumentType,
+                  rigidTypeParameterIdentities(context),
+                ),
+                error =>
+                  // A `typeMismatch` here means the argument didn't fit the
+                  // parameter, so blame the argument specifically.
+                  error.kind === 'typeMismatch' ?
+                    attachSpanIfAbsent(
+                      either.makeLeft(error),
+                      subContextForArgument,
+                    )
+                  : either.makeLeft(error),
               ),
           ),
       )

--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -199,18 +199,18 @@ export const applyKeywordHandler: KeywordHandler = (
       }
 
       const argumentTypeCheck = either.flatMap(
-        attachSpanIfAbsent(
+        either.mapLeft(
           inferType(functionToApply, subContextForFunction),
-          subContextForFunction,
+          attachSpanIfAbsent(subContextForFunction),
         ),
         functionType =>
           either.flatMap(
-            attachSpanIfAbsent(
+            either.mapLeft(
               inferType(argument, subContextForArgument),
-              subContextForArgument,
+              attachSpanIfAbsent(subContextForArgument),
             ),
             argumentType =>
-              either.flatMapLeft(
+              either.mapLeft(
                 checkApplication(
                   argument,
                   functionType,
@@ -221,11 +221,8 @@ export const applyKeywordHandler: KeywordHandler = (
                   // A `typeMismatch` here means the argument didn't fit the
                   // parameter, so blame the argument specifically.
                   error.kind === 'typeMismatch' ?
-                    attachSpanIfAbsent(
-                      either.makeLeft(error),
-                      subContextForArgument,
-                    )
-                  : either.makeLeft(error),
+                    attachSpanIfAbsent(subContextForArgument)(error)
+                  : error,
               ),
           ),
       )

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -35,15 +35,15 @@ const check = ({
     location: [...context.location, '1', 'type'],
   }
   return either.flatMap(
-    attachSpanIfAbsent(
+    either.mapLeft(
       inferType(value, subContextForValue),
-      subContextForValue,
+      attachSpanIfAbsent(subContextForValue),
     ),
     valueAsType =>
       either.flatMap(
-        attachSpanIfAbsent(
+        either.mapLeft(
           inferType(type, subContextForType),
-          subContextForType,
+          attachSpanIfAbsent(subContextForType),
         ),
         typeAsType => {
           // `@check` targets are upper bounds; they allow width subtyping.
@@ -51,14 +51,13 @@ const check = ({
           return isAssignable({ source: valueAsType, target: targetType }) ?
               either.makeRight(value)
               // The value is what failed the check, so blame it specifically.
-            : attachSpanIfAbsent<SemanticGraph>(
-                either.makeLeft({
+            : either.makeLeft(
+                attachSpanIfAbsent(subContextForValue)({
                   kind: 'typeMismatch',
                   message: `the value \`${stringifySemanticGraphForEndUser(
                     value,
                   )}\` ${isSingletonType(valueAsType) ? '' : `(inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) `}is not assignable to the type \`${stringifyTypeForEndUser(targetType)}\``,
                 }),
-                subContextForValue,
               )
         },
       ),

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -1,6 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  attachSpanIfAbsent,
   isAssignable,
   readCheckExpression,
   stringifySemanticGraphForEndUser,
@@ -24,39 +25,45 @@ const check = ({
   readonly value: SemanticGraph
   readonly type: SemanticGraph
   readonly context: ExpressionContext
-}): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(
-    inferType(value, {
-      ...context,
-      location: [...context.location, '1', 'value'],
-    }),
+}): Either<ElaborationError, SemanticGraph> => {
+  const subContextForValue = {
+    ...context,
+    location: [...context.location, '1', 'value'],
+  }
+  const subContextForType = {
+    ...context,
+    location: [...context.location, '1', 'type'],
+  }
+  return either.flatMap(
+    attachSpanIfAbsent(
+      inferType(value, subContextForValue),
+      subContextForValue,
+    ),
     valueAsType =>
       either.flatMap(
-        inferType(type, {
-          ...context,
-          location: [...context.location, '1', 'type'],
-        }),
+        attachSpanIfAbsent(
+          inferType(type, subContextForType),
+          subContextForType,
+        ),
         typeAsType => {
           // `@check` targets are upper bounds; they allow width subtyping.
           const targetType = recursivelyInexact(typeAsType)
-          if (
-            isAssignable({
-              source: valueAsType,
-              target: targetType,
-            })
-          ) {
-            return either.makeRight(value)
-          } else {
-            return either.makeLeft({
-              kind: 'typeMismatch',
-              message: `the value \`${stringifySemanticGraphForEndUser(
-                value,
-              )}\` ${isSingletonType(valueAsType) ? '' : `(inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) `}is not assignable to the type \`${stringifyTypeForEndUser(targetType)}\``,
-            })
-          }
+          return isAssignable({ source: valueAsType, target: targetType }) ?
+              either.makeRight(value)
+              // The value is what failed the check, so blame it specifically.
+            : attachSpanIfAbsent<SemanticGraph>(
+                either.makeLeft({
+                  kind: 'typeMismatch',
+                  message: `the value \`${stringifySemanticGraphForEndUser(
+                    value,
+                  )}\` ${isSingletonType(valueAsType) ? '' : `(inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) `}is not assignable to the type \`${stringifyTypeForEndUser(targetType)}\``,
+                }),
+                subContextForValue,
+              )
         },
       ),
   )
+}
 
 export const checkKeywordHandler: KeywordHandler = (
   expression: Expression,

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -41,14 +41,8 @@ const checkKeyPathExistsInType = (
       )
       return firstUnresolvableComponentIndex === -1 ?
           either.makeRight(undefined)
-        : attachSpanIfAbsent<undefined>(
-            either.makeLeft({
-              kind: 'typeMismatch',
-              message: `property \`${stringifyTypeKeyPathForEndUser(
-                keyPath.slice(0, firstUnresolvableComponentIndex + 1),
-              )}\` does not exist on type \`${stringifyTypeForEndUser(objectType)}\``,
-            }),
-            {
+        : either.makeLeft(
+            attachSpanIfAbsent({
               ...context,
               location: [
                 ...context.location,
@@ -56,7 +50,12 @@ const checkKeyPathExistsInType = (
                 'query',
                 String(firstUnresolvableComponentIndex),
               ],
-            },
+            })({
+              kind: 'typeMismatch',
+              message: `property \`${stringifyTypeKeyPathForEndUser(
+                keyPath.slice(0, firstUnresolvableComponentIndex + 1),
+              )}\` does not exist on type \`${stringifyTypeForEndUser(objectType)}\``,
+            }),
           )
     },
   )
@@ -89,20 +88,19 @@ export const indexKeywordHandler: KeywordHandler = (
                 applyTypeKeyPathToSemanticGraph(object, typeKeyPath),
                 {
                   none: _ =>
-                    attachSpanIfAbsent<SemanticGraph>(
-                      // This error is less specific than the one from
-                      // `checkKeyPathExistsInType`, but since that's used for
-                      // static analysis this isn't expected to ever surface.
-                      either.makeLeft({
+                    // This error is less specific than the one from
+                    // `checkKeyPathExistsInType`, but since that's used for
+                    // static analysis this isn't expected to ever surface.
+                    either.makeLeft(
+                      attachSpanIfAbsent({
+                        ...context,
+                        location: [...context.location, '1', 'query'],
+                      })({
                         kind: 'typeMismatch',
                         message: `property \`${stringifyTypeKeyPathForEndUser(
                           typeKeyPath,
                         )}\` not found`,
                       }),
-                      {
-                        ...context,
-                        location: [...context.location, '1', 'query'],
-                      },
                     ),
                   some: either.makeRight,
                 },

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -3,6 +3,7 @@ import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
   applyKeyPathToType,
+  attachSpanIfAbsent,
   containsAnyUnelaboratedNodes,
   inferType,
   readIndexExpression,
@@ -14,6 +15,7 @@ import {
 } from '../../../semantics.js'
 import { applyTypeKeyPathToSemanticGraph } from '../../../semantics/semantic-graph.js'
 import {
+  isNothing,
   stringifyTypeKeyPathForEndUser,
   typeKeyPathFromObjectNode,
   type TypeKeyPath,
@@ -30,17 +32,32 @@ const checkKeyPathExistsInType = (
       location: [...context.location, '1', 'object'],
     }),
     objectType => {
-      const typeAtKeyPath = applyKeyPathToType(objectType, keyPath)
-      return (
-          typeAtKeyPath.kind === 'union' && typeAtKeyPath.members.size === 0
-        ) ?
-          either.makeLeft({
-            kind: 'typeMismatch',
-            message: `property \`${stringifyTypeKeyPathForEndUser(
-              keyPath,
-            )}\` does not exist on type \`${stringifyTypeForEndUser(objectType)}\``,
-          })
-        : either.makeRight(undefined)
+      // `-1` if the entire `keyPath` is resolvable.
+      const firstUnresolvableComponentIndex = keyPath.findIndex(
+        (_component, endIndex) =>
+          isNothing(
+            applyKeyPathToType(objectType, keyPath.slice(0, endIndex + 1)),
+          ),
+      )
+      return firstUnresolvableComponentIndex === -1 ?
+          either.makeRight(undefined)
+        : attachSpanIfAbsent<undefined>(
+            either.makeLeft({
+              kind: 'typeMismatch',
+              message: `property \`${stringifyTypeKeyPathForEndUser(
+                keyPath.slice(0, firstUnresolvableComponentIndex + 1),
+              )}\` does not exist on type \`${stringifyTypeForEndUser(objectType)}\``,
+            }),
+            {
+              ...context,
+              location: [
+                ...context.location,
+                '1',
+                'query',
+                String(firstUnresolvableComponentIndex),
+              ],
+            },
+          )
     },
   )
 
@@ -71,13 +88,22 @@ export const indexKeywordHandler: KeywordHandler = (
             : option.match(
                 applyTypeKeyPathToSemanticGraph(object, typeKeyPath),
                 {
-                  none: () =>
-                    either.makeLeft({
-                      kind: 'typeMismatch',
-                      message: `property \`${stringifyTypeKeyPathForEndUser(
-                        typeKeyPath,
-                      )}\` not found`,
-                    }),
+                  none: _ =>
+                    attachSpanIfAbsent<SemanticGraph>(
+                      // This error is less specific than the one from
+                      // `checkKeyPathExistsInType`, but since that's used for
+                      // static analysis this isn't expected to ever surface.
+                      either.makeLeft({
+                        kind: 'typeMismatch',
+                        message: `property \`${stringifyTypeKeyPathForEndUser(
+                          typeKeyPath,
+                        )}\` not found`,
+                      }),
+                      {
+                        ...context,
+                        location: [...context.location, '1', 'query'],
+                      },
+                    ),
                   some: either.makeRight,
                 },
               ),

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -1,4 +1,5 @@
 export {
+  attachSpanIfAbsent,
   elaborate,
   elaborateWithContext,
   type ElaboratedSemanticGraph,

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -336,7 +336,7 @@ const handleObjectNodeWhichMayBeAExpression = (
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> => {
   const possibleKeyword = node[0]
-  return attachSpanIfAbsent(
+  const result =
     isKeyword(possibleKeyword) ?
       context.keywordHandlers[possibleKeyword](
         withProperty(node, '0', possibleKeyword),
@@ -349,9 +349,9 @@ const handleObjectNodeWhichMayBeAExpression = (
       })
     : either.makeRight(
         withProperty(node, '0', unescapeKeywordSigil(possibleKeyword)),
-      ),
-    context,
-  )
+      )
+
+  return either.mapLeft(result, attachSpanIfAbsent(context))
 }
 
 /**
@@ -359,11 +359,9 @@ const handleObjectNodeWhichMayBeAExpression = (
  * leaving any already-attached (deeper, more specific) span untouched so the
  * innermost one wins.
  */
-export const attachSpanIfAbsent = <Value>(
-  result: Either<ElaborationError, Value>,
-  context: ExpressionContext,
-): Either<ElaborationError, Value> =>
-  either.mapLeft(result, error => {
+export const attachSpanIfAbsent =
+  (context: ExpressionContext) =>
+  (error: ElaborationError): ElaborationError => {
     if (error.span !== undefined) {
       return error
     } else {
@@ -374,7 +372,7 @@ export const attachSpanIfAbsent = <Value>(
         return { ...error, span }
       }
     }
-  })
+  }
 
 /**
  * Resolve a location to its source span, walking up to the nearest enclosing

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -359,10 +359,10 @@ const handleObjectNodeWhichMayBeAExpression = (
  * leaving any already-attached (deeper, more specific) span untouched so the
  * innermost one wins.
  */
-const attachSpanIfAbsent = (
-  result: Either<ElaborationError, SemanticGraph>,
+export const attachSpanIfAbsent = <Value>(
+  result: Either<ElaborationError, Value>,
   context: ExpressionContext,
-): Either<ElaborationError, SemanticGraph> =>
+): Either<ElaborationError, Value> =>
   either.mapLeft(result, error => {
     if (error.span !== undefined) {
       return error

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -2,6 +2,7 @@ export { typeFromSemanticGraph } from './type-system/literal-type.js'
 export * as types from './type-system/prelude-types.js'
 export { isAssignable } from './type-system/subtyping.js'
 export {
+  isNothing,
   makeTypeParameter,
   type ApplicationType,
   type FunctionType,

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -316,6 +316,9 @@ export const unionOfTypes = (types: readonly Type[]): Type =>
       ),
     )
 
+export const isNothing = (type: Type) =>
+  type.kind === 'union' && type.members.size === 0
+
 export type Type =
   | ApplicationType
   | FunctionType

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -7,6 +7,7 @@ import type { SemanticGraph } from '../semantic-graph.js'
 import { nothing, something } from './prelude-types.js'
 import { isAssignable } from './subtyping.js'
 import {
+  isNothing,
   makeApplicationType,
   makeFunctionType,
   makeIndexedAccessType,
@@ -723,6 +724,3 @@ export const recursivelyInexact = (type: Type): Type =>
         ),
     })
   )
-
-const isNothing = (type: Type) =>
-  type.kind === 'union' && type.members.size === 0


### PR DESCRIPTION
Some keyword expression errors now blame specific children instead of underlining the whole expression:

- `@check` underlines the checked value
- `@apply` underlines the argument (only for argument-type mismatches; non-callable callees still underline the whole expression)
- `@index` underlines the specific key that's missing