### PR TITLE
Type system enhancements inspired by `option` ergonomics

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -624,6 +624,10 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [':option.none option.get_or_else 0', success('0')],
   [':option.make_some(value) option.get_or_else fallback', success('value')],
   [':option.none |> :option.get_or_else(fallback)', success('fallback')],
+  [
+    '((a: :atom.type) => (:option.make_some(:a) option.get_or_else other) ~ :atom.type)(hello)',
+    success('hello'),
+  ],
   [':option.is_some(:option.make_some(7))', success('true')],
   [':option.is_some(:option.none)', success('false')],
   [':option.is_none(:option.none)', success('true')],

--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -629,6 +629,10 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [':option.is_none(:option.none)', success('true')],
   [':option.is_none(:option.make_some(7))', success('false')],
   [
+    `:option.make_some(key) option.flat_map ((a: :atom.type) => { key: value } object.lookup :a)`,
+    success({ tag: 'some', value: 'value' }),
+  ],
+  [
     // Lookups should never target keyword expression properties.
     `{
       {

--- a/src/language/semantics/stdlib/option.ts
+++ b/src/language/semantics/stdlib/option.ts
@@ -11,6 +11,7 @@ import { types } from '../type-system.js'
 import {
   makeFunctionType,
   makeTypeParameter,
+  makeUnionType,
 } from '../type-system/type-formats.js'
 import {
   emptyContextForStdlibApplications,
@@ -156,10 +157,10 @@ export const option = {
   get_or_else: preludeFunctionArity2(
     ['option', 'get_or_else'],
     {
-      parameter: types.something,
+      parameter: B,
       return: makeFunctionType({
-        parameter: types.option(types.something),
-        return: types.something,
+        parameter: types.option(A),
+        return: makeUnionType([A, B]),
       }),
     },
     fallback =>

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -191,6 +191,29 @@ typeAssignabilitySuite('application types (not assignable)', [
   [[boolean, applicationBoolean], false],
 ])
 
+typeAssignabilitySuite('stuck application in a contravariant position', [
+  // A function which can handle arbitrary booleans satisfies a consumer of an
+  // unknown specific boolean.
+  [
+    [
+      makeFunctionType({ parameter: boolean, return: something }),
+      makeFunctionType({ parameter: applicationBoolean, return: something }),
+    ],
+    true,
+  ],
+
+  [
+    [
+      makeFunctionType({
+        parameter: makeUnionType(['true']),
+        return: something,
+      }),
+      makeFunctionType({ parameter: applicationBoolean, return: something }),
+    ],
+    false,
+  ],
+])
+
 typeAssignabilitySuite('opaque type from stuck type (assignable)', [
   [[makeUnionType([applicationBoolean]), atom], true],
   [[makeUnionType([indexedAccessBoolean]), atom], true],

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -1338,6 +1338,32 @@ typeAssignabilitySuite('union to type parameter (assignable)', [
   [[makeUnionType([extendsAnyAtom]), extendsAnyAtom], true],
 ])
 
+typeAssignabilitySuite(
+  'union with a broadly-constrained type-parameter member (assignable)',
+  [
+    [[makeUnionType([A, object]), something], true],
+    [
+      [makeUnionType([A, makeObjectType({}, { exact: true })]), something],
+      true,
+    ],
+    [
+      [
+        makeFunctionType({
+          parameter: something,
+          return: makeUnionType([A, makeObjectType({}, { exact: true })]),
+        }),
+        something,
+      ],
+      true,
+    ],
+  ],
+)
+
+typeAssignabilitySuite(
+  'union with a broadly-constrained type-parameter member (not assignable)',
+  [[[makeUnionType([A, 'x']), atom], false]],
+)
+
 typeAssignabilitySuite('union to type parameter (not assignable)', [
   // `1 | :nothing.type` is not assignable to `?a`
   [[makeUnionType(['1']), A], false],

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -313,7 +313,15 @@ export const isAssignable = ({
                       }
                     }
                   }
-                  return false
+                  // A type parameter member can be assignable to the target
+                  // union while matching no single member, e.g. a parameter
+                  // constrained to `something` is assignable to `something`
+                  // even though `something` is itself a union.
+                  return (
+                    typeof sourceMember !== 'string' &&
+                    sourceMember.kind === 'parameter' &&
+                    isAssignable({ source: sourceMember, target })
+                  )
                 })()
 
                 if (!sourceMemberIsAssignableToSomeMemberOfSupertype) {

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -21,6 +21,7 @@ import {
   something,
 } from './prelude-types.js'
 import {
+  makeApplicationType,
   makeFunctionType,
   makeIntrinsicApplicationType,
   makeObjectType,
@@ -148,8 +149,17 @@ const getTypesForTypeParametersSuite = testCases(
     `getting types for type parameters in \`${stringifyTypeForEndUser(parameterType)}\` from \`${stringifyTypeForEndUser(argumentType)}\``,
 )
 
+const stuckParameter = makeTypeParameter('stuck', { assignableTo: something })
+const stuckApplicationReturningOption = makeApplicationType(
+  makeFunctionType({ parameter: stuckParameter, return: option(something) }),
+  atom,
+  new Set([stuckParameter.identity]),
+)
+
 getTypesForTypeParametersSuite('getTypesForTypeParameters', [
   [[A, atom], new Map([[A, atom]])],
+
+  [[option(B), stuckApplicationReturningOption], new Map([[B, something]])],
 
   [[extendsAnyAtom, atom], new Map([[extendsAnyAtom, atom]])],
 

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -17,6 +17,7 @@ import {
   makeUnionType,
   matchTypeFormat,
   unionOfTypes,
+  type ApplicationType,
   type FunctionType,
   type ObjectType,
   type Type,
@@ -218,6 +219,17 @@ export const replaceAllTypeParametersWithTheirConstraints = (
         type,
       )
 
+const upperBoundOfStuckApplication = (application: ApplicationType): Type =>
+  application.function.kind === 'function' ?
+    supplyTypeArguments(
+      application.function.signature.return,
+      getTypesForTypeParameters({
+        parameterType: application.function.signature.parameter,
+        argumentType: application.argument,
+      }),
+    )
+  : replaceAllTypeParametersWithTheirConstraints(application)
+
 /**
  * Finds concrete types for the `TypeParameter`s in `parameter` by locating the
  * corresponding position for each in `argument`.
@@ -240,6 +252,11 @@ export const getTypesForTypeParameters = ({
     return getTypesForTypeParameters({
       parameterType,
       argumentType: replaceAllTypeParametersWithTheirConstraints(argumentType),
+    })
+  } else if (argumentType.kind === 'application') {
+    return getTypesForTypeParameters({
+      parameterType,
+      argumentType: upperBoundOfStuckApplication(argumentType),
     })
   } else {
     return matchTypeFormat(parameterType, {


### PR DESCRIPTION
An inference enhancement and a subtyping completeness improvement which were both motivated by trying to use functions from the `option` stdlib module in real programs. `option.get_or_else` is now able to have a generic signature, and `option.flat_map`/`option.map` can better deal with stuck applications in their mapping functions.