### PR TITLE
Improve completeness & correctness of indexing into stuck types

### DIFF
--- a/src/language/compiling/compiler.test.ts
+++ b/src/language/compiling/compiler.test.ts
@@ -1411,6 +1411,69 @@ testCases(
 
   [
     `{
+      lookup: (key: a | b) => ({ a: { x: true }, b: { x: false } }.:key).x
+      :lookup(@runtime { _ => a }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      lookup: (keys: { a | b, x | y }) =>
+        ({ a: { x: true, y: false }, b: { x: false, y: false } }.(:keys.0)).(:keys.1)
+      :lookup(@runtime { _ => { a, x } }) ~ true
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      choose: (c: :boolean.type) => (@if { :c, { x: yes }, { x: no } }).x
+      :choose(@runtime { _ => true }) ~ yes
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      f: (k: :atom.type) => (@if { :atom.equals(a)(:k), { x: yes }, { x: no } }).x
+      :f(@runtime { _ => a }) ~ yes
+    }`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+
+  [
+    `{
+      lookup: (key: a | b) => ({ x: 1, a: 2, b: 3 }.:key).x
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
+      lookup: (key: a | b) => ({ a: { x: true }, b: {} }.:key).x
+    }`,
+    result => {
+      assert(either.isLeft(result))
+      assert('kind' in result.value)
+      assert.deepEqual(result.value.kind, 'typeMismatch')
+    },
+  ],
+
+  [
+    `{
       not: (a: :boolean.type) => @if { :a, false, true }
       :not(@runtime { _ => false }) ~ false
     }`,

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -202,6 +202,11 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
   ],
 ])
 
+applyKeyPathSuite('applyKeyPathToType with degenerate stuck types', [
+  [[makeApplicationType(atom, atom, new Set()), ['x']], '(none)'],
+  [[makeIndexedAccessType(makeObjectType({ x: atom }), atom), ['x']], '(none)'],
+])
+
 const getTypesForTypeParametersSuite = testCases(
   ([parameterType, argumentType]: readonly [
     parameterType: Type,

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -23,6 +23,7 @@ import {
 import {
   makeApplicationType,
   makeFunctionType,
+  makeIndexedAccessType,
   makeIntrinsicApplicationType,
   makeObjectType,
   makeTypeParameter,
@@ -30,6 +31,7 @@ import {
   type Type,
   type TypeParameter,
 } from './type-formats.js'
+import { nestedIndexedAccess } from './type-key-path.js'
 import {
   applyKeyPathToType,
   applyTypeToArgumentType,
@@ -153,6 +155,50 @@ applyKeyPathSuite('applyKeyPathToType with bottom types', [
       ['a'],
     ],
     stringifyTypeForEndUser(atom),
+  ],
+])
+
+const keyAssignableToAOrB = makeTypeParameter('key', {
+  assignableTo: makeUnionType(['a', 'b']),
+})
+const stuckAccessWithCommonXProperty = makeIndexedAccessType(
+  makeObjectType({
+    a: makeObjectType({ x: atom }),
+    b: makeObjectType({ x: integer }),
+  }),
+  keyAssignableToAOrB,
+)
+
+applyKeyPathSuite('applyKeyPathToType with indexed access types', [
+  [
+    [stuckAccessWithCommonXProperty, ['x']],
+    stringifyTypeForEndUser(
+      nestedIndexedAccess(stuckAccessWithCommonXProperty, ['x']),
+    ),
+  ],
+  [[stuckAccessWithCommonXProperty, ['z']], '(none)'],
+  [
+    [
+      makeIndexedAccessType(
+        makeObjectType({
+          a: makeObjectType({ x: atom }),
+          b: makeObjectType({}),
+        }),
+        keyAssignableToAOrB,
+      ),
+      ['x'],
+    ],
+    '(none)',
+  ],
+  [
+    [
+      makeIndexedAccessType(
+        makeObjectType({ x: atom, a: atom, b: atom }),
+        keyAssignableToAOrB,
+      ),
+      ['x'],
+    ],
+    '(none)',
   ],
 ])
 

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -18,6 +18,8 @@ import {
   unionOfTypes,
   type ApplicationType,
   type FunctionType,
+  type IndexedAccessType,
+  type IntrinsicApplicationType,
   type ObjectType,
   type Type,
   type TypeParameter,
@@ -78,38 +80,26 @@ export const applyKeyPathToType = (
       }
     }
   } else {
+    // Indexing into a stuck type stays stuck, provided the key path is valid
+    // for the type's upper bound (which accounts for every type the stuck
+    // type could resolve to). Otherwise the property definitely doesn't
+    // exist. If the upper bound is itself still stuck, no progress can be
+    // made and the property can't be confirmed to exist.
+    const applyKeyPathToStuckType = (
+      stuckType: ApplicationType | IndexedAccessType | IntrinsicApplicationType,
+    ): Option<Type> => {
+      const upperBound = replaceAllTypeParametersWithTheirConstraints(stuckType)
+      return upperBound.kind === stuckType.kind ?
+          option.none
+        : option.map(
+            applyKeyPathToType(upperBound, keyPath),
+            _typeAtKeyPathInUpperBound =>
+              nestedIndexedAccess(stuckType, [firstKey, ...remainingKeyPath]),
+          )
+    }
     return matchTypeFormat<Option<Type>>(type, {
-      application: applicationType =>
-        // Indexing into a stuck application stays stuck, provided the key path
-        // is valid for the application's upper bound. Otherwise the property
-        // definitely doesn't exist.
-        option.map(
-          applyKeyPathToType(
-            replaceAllTypeParametersWithTheirConstraints(applicationType),
-            keyPath,
-          ),
-          _typeAtKeyPathInUpperBound =>
-            nestedIndexedAccess(applicationType, [
-              firstKey,
-              ...remainingKeyPath,
-            ]),
-        ),
-      intrinsicApplication: intrinsicApplicationType =>
-        // As with `ApplicationType`s, indexing stays stuck while the key path
-        // is valid for the upper bound. Otherwise the property doesn't exist.
-        option.map(
-          applyKeyPathToType(
-            replaceAllTypeParametersWithTheirConstraints(
-              intrinsicApplicationType,
-            ),
-            keyPath,
-          ),
-          _typeAtKeyPathInUpperBound =>
-            nestedIndexedAccess(intrinsicApplicationType, [
-              firstKey,
-              ...remainingKeyPath,
-            ]),
-        ),
+      application: applyKeyPathToStuckType,
+      intrinsicApplication: applyKeyPathToStuckType,
       function: type => {
         if (typeof firstKey === 'string') {
           // Functions do not have properties.
@@ -153,17 +143,7 @@ export const applyKeyPathToType = (
           return option.none
         }
       },
-      indexedAccess: type =>
-        // As with other stuck types, indexing stays stuck while the key path is
-        // valid for the upper bound. Otherwise the property doesn't exist.
-        option.map(
-          applyKeyPathToType(
-            replaceAllTypeParametersWithTheirConstraints(type),
-            keyPath,
-          ),
-          _typeAtKeyPathInUpperBound =>
-            nestedIndexedAccess(type, [firstKey, ...remainingKeyPath]),
-        ),
+      indexedAccess: applyKeyPathToStuckType,
       opaque: _type => option.none,
       parameter: type => {
         if (typeof firstKey === 'string') {

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -154,7 +154,16 @@ export const applyKeyPathToType = (
         }
       },
       indexedAccess: type =>
-        applyKeyPathToType(type.object, [firstKey, ...remainingKeyPath]),
+        // As with other stuck types, indexing stays stuck while the key path is
+        // valid for the upper bound. Otherwise the property doesn't exist.
+        option.map(
+          applyKeyPathToType(
+            replaceAllTypeParametersWithTheirConstraints(type),
+            keyPath,
+          ),
+          _typeAtKeyPathInUpperBound =>
+            nestedIndexedAccess(type, [firstKey, ...remainingKeyPath]),
+        ),
       opaque: _type => option.none,
       parameter: type => {
         if (typeof firstKey === 'string') {


### PR DESCRIPTION
Indexing into stuck indexed access types is now possible if the given key definitely exists on every possible type the stuck type could resolve to, and a few related soundness holes have been closed.