### PR TITLE
Improve behavior of `:atom.split("")`

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -300,6 +300,13 @@ testCases(endToEnd, code => code)('end-to-end tests', [
   [`{} atom.join "-"`, success('')],
   [`"a,b,c" atom.split ","`, success({ 0: 'a', 1: 'b', 2: 'c' })],
   [`("a,b,c" atom.split ",") atom.join "-"`, success('a-b-c')],
+  [`hello atom.split ""`, success({ 0: 'h', 1: 'e', 2: 'l', 3: 'l', 4: 'o' })],
+  [`"a👾b" atom.split ""`, success({ 0: 'a', 1: '👾', 2: 'b' })],
+  [`:atom.length("a👾b") ~ 3`, success('3')],
+  [`"" atom.split ""`, success({})],
+  [`"🇺🇸" atom.split ""`, success({ 0: '🇺', 1: '🇸' })],
+  [`"a👾b" atom.split 👾`, success({ 0: 'a', 1: 'b' })],
+  [`("a👾b" atom.split "") atom.join ""`, success('a👾b')],
   [
     `{ a: { nested: x } } atom.join ", "`,
     result => {

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -130,9 +130,12 @@ export const atom = {
       either.makeRight(subject =>
         either.makeRight(
           objectNodeFromOrderedEntries(
-            subject
-              .split(separator)
-              .map((part, index) => [String(index), part]),
+            // `String.prototype.split` with an empty separator splits by UTF-16
+            // code units; spread iterates codepoints, agreeing with `length`.
+            // eslint-disable-next-line @typescript-eslint/no-misused-spread
+            (separator === '' ? [...subject] : subject.split(separator)).map(
+              (part, index) => [String(index), part],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
It previously could break up surrogate pairs. See <https://stackoverflow.com/a/34717402/3625>.