### PR TITLE
Generalize `ObjectType`'s `exact: boolean` into `excess: Type`

### DIFF
--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -9,6 +9,7 @@ import {
 import { types } from '../type-system.js'
 import { asUnionWithLiteralAtomMembers } from '../type-system/subtyping.js'
 import {
+  isNothing,
   makeObjectType,
   makeUnionType,
   unionOfTypes,
@@ -40,7 +41,7 @@ const computeFromPropertyReturnType = (
             ...keys.members
               .values()
               .map(key =>
-                makeObjectType({ [key]: valueType }, { exact: true }),
+                makeObjectType({ [key]: valueType }, { excess: types.nothing }),
               ),
           ]),
       },
@@ -65,14 +66,19 @@ const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
                 .filter(([key]) => object2Type.children[key] === undefined)
                 .map(([key, child]) => [
                   key,
-                  object2Type.exact ? child
+                  isNothing(object2Type.excess) ? child
                     // The property may exist as excess (with an unknown type).
                   : types.something,
                 ]),
             ),
             ...object2Type.children,
           },
-          { exact: object1Type.exact && object2Type.exact },
+          {
+            excess:
+              isNothing(object1Type.excess) && isNothing(object2Type.excess) ?
+                types.nothing
+              : types.something,
+          },
         )
       : types.object
   }
@@ -99,7 +105,7 @@ const lookupReturnType = ({
             tag: makeUnionType(['some']),
             value: unionOfTypes(possibleValueTypes),
           },
-          { exact: true },
+          { excess: types.nothing },
         ),
       ]),
     ...(mayBeNone ?
@@ -107,9 +113,9 @@ const lookupReturnType = ({
         makeObjectType(
           {
             tag: makeUnionType(['none']),
-            value: makeObjectType({}, { exact: true }),
+            value: makeObjectType({}, { excess: types.nothing }),
           },
-          { exact: true },
+          { excess: types.nothing },
         ),
       ]
     : []),
@@ -128,7 +134,7 @@ const literalLookupKeyCandidates = (
   : option.none
 
 // `lookup(key)(object)` returns `some(object[key])` when the key is definitely
-// present, `none` when definitely absent (e.g. an `exact` object lacking it),
+// present, `none` when definitely absent (e.g. a closed object lacking it),
 // otherwise a union covering all possible outcomes.
 const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
   const [keyType, objectType] = parameterTypes
@@ -149,7 +155,7 @@ const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
         })
         const someKeyMayBeAbsent =
           presentValueTypes.length !== possibleKeys.size
-        return someKeyMayBeAbsent && !objectType.exact ?
+        return someKeyMayBeAbsent && !isNothing(objectType.excess) ?
             // The key may exist as an excess property (with an unknown type).
             types.option(types.something)
           : lookupReturnType({
@@ -158,7 +164,7 @@ const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
             })
       },
       none: _ =>
-        objectType.exact ?
+        isNothing(objectType.excess) ?
           // Whatever the key turns out to be, it can only select one of the
           // object's own property values (or nothing).
           lookupReturnType({

--- a/src/language/semantics/stdlib/parameters.ts
+++ b/src/language/semantics/stdlib/parameters.ts
@@ -113,10 +113,13 @@ export const optionParameter = (
 })
 
 export const taggedParameter: Parameter<TaggedNode> = {
-  type: makeObjectType({
-    tag: types.atom,
-    value: types.something,
-  }),
+  type: makeObjectType(
+    {
+      tag: types.atom,
+      value: types.something,
+    },
+    { excess: types.something },
+  ),
   asExpected: value =>
     nodeIsTagged(value) ? option.makeSome(value) : option.none,
   expected: 'a tagged value',

--- a/src/language/semantics/stdlib/return-type-refiners.ts
+++ b/src/language/semantics/stdlib/return-type-refiners.ts
@@ -60,7 +60,10 @@ export const computeFromReturnType =
       )
     } else {
       return isAssignable({ source: argumentType, target: elementType }) ?
-          makeObjectType({ tag: makeUnionType(['some']), value: argumentType })
+          makeObjectType(
+            { tag: makeUnionType(['some']), value: argumentType },
+            { excess: types.something },
+          )
         : optionType(elementType)
     }
   }

--- a/src/language/semantics/type-system/genericize-function-parameter.ts
+++ b/src/language/semantics/type-system/genericize-function-parameter.ts
@@ -1,4 +1,5 @@
 import type { Atom } from '../../parsing.js'
+import { something } from './prelude-types.js'
 import {
   makeFunctionType,
   makeObjectType,
@@ -94,10 +95,13 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
             ] as const,
         )
         return {
+          // The annotation is an upper bound, so the rebuilt object admits
+          // arbitrary excess properties unconditionally.
           type: makeObjectType(
             Object.fromEntries(
               children.map(([key, child]) => [key, child.type]),
             ),
+            { excess: something },
           ),
           typeParametersBoundByFunction: new Set(
             children.flatMap(([_key, child]) => [

--- a/src/language/semantics/type-system/literal-type.ts
+++ b/src/language/semantics/type-system/literal-type.ts
@@ -6,7 +6,7 @@ import {
 } from '../expressions/hole-expression.js'
 import { readUnionExpression } from '../expressions/union-expression.js'
 import type { SemanticGraph } from '../semantic-graph.js'
-import { typesBySymbol } from './prelude-types.js'
+import { nothing, something, typesBySymbol } from './prelude-types.js'
 import { makeObjectType, unionOfTypes, type Type } from './type-formats.js'
 
 /**
@@ -75,7 +75,7 @@ export const typeFromSemanticGraph = (
               ),
               entries =>
                 makeObjectType(Object.fromEntries(entries), {
-                  exact: options.objectsAreExact,
+                  excess: options.objectsAreExact ? nothing : something,
                 }),
             ),
         ),

--- a/src/language/semantics/type-system/prelude-types.ts
+++ b/src/language/semantics/type-system/prelude-types.ts
@@ -6,6 +6,7 @@ import {
   makeTypeParameter,
   makeUnionType,
   type FunctionType,
+  type ObjectType,
   type Type,
   type UnionType,
 } from './type-formats.js'
@@ -49,12 +50,13 @@ export const naturalNumber = makeOpaqueType(naturalNumberTypeSymbol, {
   nearestOpaqueAssignableTo: () => optionAdt.makeSome(integer),
 })
 
-export const object = makeObjectType({})
-
-// `functionType` and `something` reference each other directly, so we need to
-// do a dance:
+// `functionType`, `object`, and `something` reference each other directly, so
+// we need to do a dance. Note that many type traversals rely on reference
+// equality of `something` to avoid infinite recursion/iteration.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 export const functionType: FunctionType = {} as FunctionType
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+export const object: ObjectType = {} as ObjectType
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 export const something: UnionType = {} as UnionType // the top type
 Object.assign(
@@ -63,6 +65,10 @@ Object.assign(
     parameter: nothing,
     return: something,
   }) satisfies FunctionType,
+)
+Object.assign(
+  object,
+  makeObjectType({}, { excess: something }) satisfies ObjectType,
 )
 Object.assign(
   something,
@@ -82,25 +88,40 @@ export const typesBySymbol = {
 
 export const option = (value: Type) =>
   makeUnionType([
-    makeObjectType({
-      tag: makeUnionType(['some']),
-      value,
-    }),
-    makeObjectType({
-      tag: makeUnionType(['none']),
-      value: makeObjectType({}),
-    }),
+    makeObjectType(
+      {
+        tag: makeUnionType(['some']),
+        value,
+      },
+      { excess: nothing },
+    ),
+    makeObjectType(
+      {
+        tag: makeUnionType(['none']),
+        value: makeObjectType({}, { excess: nothing }),
+      },
+      { excess: nothing },
+    ),
   ])
 
 const A = makeTypeParameter('a', { assignableTo: something })
 
-export const runtimeContext = makeObjectType({
-  arguments: makeObjectType({
-    lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
-  }),
-  environment: makeObjectType({
-    lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
-  }),
-  log: makeFunctionType({ parameter: A, return: A }),
-  program: makeObjectType({ start_time: atom }),
-})
+export const runtimeContext = makeObjectType(
+  {
+    arguments: makeObjectType(
+      {
+        lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
+      },
+      { excess: nothing },
+    ),
+    environment: makeObjectType(
+      {
+        lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
+      },
+      { excess: nothing },
+    ),
+    log: makeFunctionType({ parameter: A, return: A }),
+    program: makeObjectType({ start_time: atom }, { excess: nothing }),
+  },
+  { excess: nothing },
+)

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -58,10 +58,13 @@ const extendsExtendsAnyAtom = makeTypeParameter('u', {
 })
 
 const indexedAccessBoolean = makeIndexedAccessType(
-  makeObjectType({
-    a: makeUnionType(['true']),
-    b: makeUnionType(['false']),
-  }),
+  makeObjectType(
+    {
+      a: makeUnionType(['true']),
+      b: makeUnionType(['false']),
+    },
+    { excess: something },
+  ),
   makeTypeParameter('key', {
     assignableTo: makeUnionType(['a', 'b']),
   }),
@@ -105,17 +108,35 @@ testCases(
     makeUnionType([
       'a',
       atom,
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-      }),
-      makeObjectType({
-        a: makeUnionType(['b']),
-      }),
-      makeObjectType({
-        a: makeUnionType(['c']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
+      makeObjectType(
+        {
+          a: makeUnionType(['b']),
+        },
+        { excess: something },
+      ),
+      makeObjectType(
+        {
+          a: makeUnionType(['c']),
+        },
+        { excess: something },
+      ),
     ]),
     ':atom.type | { a: a | b | c }',
+  ],
+  [
+    // Members whose excess bounds disagree must not merge with each other.
+    makeUnionType([
+      makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
+      makeObjectType({ a: makeUnionType(['b']) }, { excess: nothing }),
+      makeObjectType({ a: makeUnionType(['c']) }, { excess: something }),
+    ]),
+    '{ a: a | b } | { a: c }',
   ],
 ])
 typeAssignabilitySuite('prelude types (assignable)', [
@@ -296,40 +317,58 @@ typeAssignabilitySuite('custom types (assignable)', [
   [[makeUnionType(['0', '-1']), integer], true],
   [
     [
-      makeObjectType({
-        a: makeUnionType(['a']),
-        b: object,
-      }),
-      makeObjectType({
-        a: atom,
-        b: object,
-      }),
-    ],
-    true,
-  ],
-  [
-    [
-      makeObjectType({
-        a: makeUnionType(['a']),
-        b: makeObjectType({ c: boolean }),
-        c: nullType,
-      }),
-      makeObjectType({
-        a: atom,
-        b: object,
-      }),
-    ],
-    true,
-  ],
-  [
-    [
-      makeObjectType({
-        a: makeUnionType(['a']),
-      }),
-      makeUnionType([
-        makeObjectType({
+      makeObjectType(
+        {
           a: makeUnionType(['a']),
-        }),
+          b: object,
+        },
+        { excess: something },
+      ),
+      makeObjectType(
+        {
+          a: atom,
+          b: object,
+        },
+        { excess: something },
+      ),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType(
+        {
+          a: makeUnionType(['a']),
+          b: makeObjectType({ c: boolean }, { excess: something }),
+          c: nullType,
+        },
+        { excess: something },
+      ),
+      makeObjectType(
+        {
+          a: atom,
+          b: object,
+        },
+        { excess: something },
+      ),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType(
+        {
+          a: makeUnionType(['a']),
+        },
+        { excess: something },
+      ),
+      makeUnionType([
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
       ]),
     ],
     true,
@@ -337,13 +376,19 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
       ]),
-      makeObjectType({
-        a: makeUnionType(['a']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a']),
+        },
+        { excess: something },
+      ),
     ],
     true,
   ],
@@ -351,16 +396,25 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b }` is assignable to `{ a: a | b }`
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
       ]),
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
     ],
     true,
   ],
@@ -368,16 +422,25 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b }` is assignable to `{ a: a | b | c }`
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
       ]),
-      makeObjectType({
-        a: makeUnionType(['a', 'b', 'c']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b', 'c']),
+        },
+        { excess: something },
+      ),
     ],
     true,
   ],
@@ -385,19 +448,28 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a, b: a } | { a: b, b: b }` is assignable to `{ a: a | b, b: a | b }`
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-          b: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-          b: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+            b: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+            b: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
       ]),
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-        b: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+          b: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
     ],
     true,
   ],
@@ -405,18 +477,27 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b } | c` is assignable to `{ a: a | b } | c`
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
         'c',
       ]),
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a', 'b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a', 'b']),
+          },
+          { excess: something },
+        ),
         'c',
       ]),
     ],
@@ -425,16 +506,25 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b }` is assignable to `{ a: a } | { a: b }`
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
       ]),
     ],
     true,
@@ -442,19 +532,31 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b }` is assignable to `{ a: a } | { a: b } | { a: c }`
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['c']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['c']),
+          },
+          { excess: something },
+        ),
       ]),
     ],
     true,
@@ -462,21 +564,36 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: { a: a | b } }` is assignable to `{ a: { a: a } | { a: b } }`
-      makeObjectType({
-        a: makeObjectType({
-          a: makeUnionType(['a', 'b']),
-        }),
-      }),
-      makeObjectType({
-        a: makeUnionType([
-          makeObjectType({
-            a: makeUnionType(['a']),
-          }),
-          makeObjectType({
-            a: makeUnionType(['b']),
-          }),
-        ]),
-      }),
+      makeObjectType(
+        {
+          a: makeObjectType(
+            {
+              a: makeUnionType(['a', 'b']),
+            },
+            { excess: something },
+          ),
+        },
+        { excess: something },
+      ),
+      makeObjectType(
+        {
+          a: makeUnionType([
+            makeObjectType(
+              {
+                a: makeUnionType(['a']),
+              },
+              { excess: something },
+            ),
+            makeObjectType(
+              {
+                a: makeUnionType(['b']),
+              },
+              { excess: something },
+            ),
+          ]),
+        },
+        { excess: something },
+      ),
     ],
     true,
   ],
@@ -484,15 +601,21 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b, b: c }` is assignable to `{ a: a | b }`
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-          b: makeUnionType(['c']),
-        }),
+        makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+            b: makeUnionType(['c']),
+          },
+          { excess: something },
+        ),
       ]),
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
     ],
     true,
   ],
@@ -500,18 +623,27 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a | b } | c` is assignable to `{ a: a } | { a: b } | c`
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a', 'b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a', 'b']),
+          },
+          { excess: something },
+        ),
         'c',
       ]),
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
         'c',
       ]),
     ],
@@ -520,15 +652,18 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b } | { b: a | b }` is assignable to `{ a: a } | { a: b } | { b: a } | { b: b }`
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-        b: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+          b: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }),
-        makeObjectType({ a: makeUnionType(['b']) }),
-        makeObjectType({ b: makeUnionType(['a']) }),
-        makeObjectType({ b: makeUnionType(['b']) }),
+        makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
+        makeObjectType({ a: makeUnionType(['b']) }, { excess: something }),
+        makeObjectType({ b: makeUnionType(['a']) }, { excess: something }),
+        makeObjectType({ b: makeUnionType(['b']) }, { excess: something }),
       ]),
     ],
     true,
@@ -537,18 +672,24 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b } | { b: a } | { b: b }` is assignable to `{ a: a | b } | { b: a | b }`
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }),
-        makeObjectType({ a: makeUnionType(['b']) }),
-        makeObjectType({ b: makeUnionType(['a']) }),
-        makeObjectType({ b: makeUnionType(['b']) }),
+        makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
+        makeObjectType({ a: makeUnionType(['b']) }, { excess: something }),
+        makeObjectType({ b: makeUnionType(['a']) }, { excess: something }),
+        makeObjectType({ b: makeUnionType(['b']) }, { excess: something }),
       ]),
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a', 'b']),
-        }),
-        makeObjectType({
-          b: makeUnionType(['a', 'b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a', 'b']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            b: makeUnionType(['a', 'b']),
+          },
+          { excess: something },
+        ),
       ]),
     ],
     true,
@@ -643,14 +784,17 @@ typeAssignabilitySuite('custom types (assignable)', [
     true,
   ],
   [
-    [makeObjectType({}, { exact: true }), makeObjectType({}, { exact: true })],
+    [
+      makeObjectType({}, { excess: nothing }),
+      makeObjectType({}, { excess: nothing }),
+    ],
     true,
   ],
   [
     [
-      // exact object types are assignable to inexact ones
-      makeObjectType({ a: makeUnionType(['a']) }, { exact: true }),
-      makeObjectType({}),
+      // Closed object types are assignable to open ones.
+      makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
+      makeObjectType({}, { excess: something }),
     ],
     true,
   ],
@@ -662,13 +806,13 @@ typeAssignabilitySuite('custom types (assignable)', [
   //     makeObjectType({
   //       a: makeUnionType(['a', 'b']),
   //       b: makeUnionType(['c']),
-  //     }),
+  //     }, { excess: something }),
   //     makeUnionType([
-  //       makeObjectType({ a: makeUnionType(['a']) }),
+  //       makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
   //       makeObjectType({
   //         a: makeUnionType(['b']),
   //         b: makeUnionType(['c']),
-  //       }),
+  //       }, { excess: something }),
   //     ]),
   //   ],
   //   true,
@@ -681,34 +825,49 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [[makeUnionType(['-0']), integer], false],
   [
     [
-      makeObjectType({
-        a: atom,
-        b: object,
-      }),
-      makeObjectType({
-        a: atom,
-        b: object,
-        c: boolean, // required property in target not present in source
-      }),
+      makeObjectType(
+        {
+          a: atom,
+          b: object,
+        },
+        { excess: something },
+      ),
+      makeObjectType(
+        {
+          a: atom,
+          b: object,
+          c: boolean, // required property in target not present in source
+        },
+        { excess: something },
+      ),
     ],
     false,
   ],
   [
     [
       // `{ a: a | b, b: a | b }` is not assignable to `{ a: a, b: a } | { a: b, b: b }`
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-        b: makeUnionType(['a', 'b']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+          b: makeUnionType(['a', 'b']),
+        },
+        { excess: something },
+      ),
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-          b: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-          b: makeUnionType(['b']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+            b: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+            b: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
       ]),
     ],
     false,
@@ -716,19 +875,28 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // `{ a: a, b: b }` is not assignable to `{ a: a, b: z } | { b: b, a: z }`
-      makeObjectType({
-        a: makeUnionType(['a']),
-        b: makeUnionType(['b']),
-      }),
-      makeUnionType([
-        makeObjectType({
+      makeObjectType(
+        {
           a: makeUnionType(['a']),
-          b: makeUnionType(['z']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['z']),
           b: makeUnionType(['b']),
-        }),
+        },
+        { excess: something },
+      ),
+      makeUnionType([
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+            b: makeUnionType(['z']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['z']),
+            b: makeUnionType(['b']),
+          },
+          { excess: something },
+        ),
       ]),
     ],
     false,
@@ -737,18 +905,27 @@ typeAssignabilitySuite('custom types (not assignable)', [
     [
       // `{ a: a } | { a: b, b: c }` is not assignable to `{ a: a | b, b: c }`
       makeUnionType([
-        makeObjectType({
-          a: makeUnionType(['a']),
-        }),
-        makeObjectType({
-          a: makeUnionType(['b']),
-          b: makeUnionType(['c']),
-        }),
+        makeObjectType(
+          {
+            a: makeUnionType(['a']),
+          },
+          { excess: something },
+        ),
+        makeObjectType(
+          {
+            a: makeUnionType(['b']),
+            b: makeUnionType(['c']),
+          },
+          { excess: something },
+        ),
       ]),
-      makeObjectType({
-        a: makeUnionType(['a', 'b']),
-        b: makeUnionType(['c']),
-      }),
+      makeObjectType(
+        {
+          a: makeUnionType(['a', 'b']),
+          b: makeUnionType(['c']),
+        },
+        { excess: something },
+      ),
     ],
     false,
   ],
@@ -816,38 +993,92 @@ typeAssignabilitySuite('custom types (not assignable)', [
     false,
   ],
   [
-    // inexact object types are not assignable to exact ones
-    [makeObjectType({}, { exact: false }), makeObjectType({}, { exact: true })],
+    [
+      // Open object types aren't assignable to closed ones.
+      makeObjectType({}, { excess: something }),
+      makeObjectType({}, { excess: nothing }),
+    ],
     false,
   ],
-  // FIXME: This test case currently fails!
-  // [
-  //   [
-  //     // exact objects with extra properties aren't assignable to exact objects
-  //     // lacking them
-  //     makeObjectType(
-  //       { a: makeUnionType(['a']), b: makeUnionType(['b']) },
-  //       { exact: true },
-  //     ),
-  //     makeObjectType({ a: makeUnionType(['a']) }, { exact: true }),
-  //   ],
-  //   false,
-  // ],
-  // FIXME: This test case currently fails!
-  // [
-  //   [
-  //     // similar to above, but with unions in the mix
-  //     makeObjectType(
-  //       { a: makeUnionType(['a']), b: makeUnionType(['b']) },
-  //       { exact: true },
-  //     ),
-  //     makeUnionType([
-  //       makeObjectType({ a: makeUnionType(['a']) }, { exact: true }),
-  //       makeObjectType({ b: makeUnionType(['b']) }, { exact: true }),
-  //     ]),
-  //   ],
-  //   false,
-  // ],
+  [
+    [
+      // Closed objects with extra properties aren't assignable to closed
+      // objects lacking them.
+      makeObjectType(
+        { a: makeUnionType(['a']), b: makeUnionType(['b']) },
+        { excess: nothing },
+      ),
+      makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
+    ],
+    false,
+  ],
+  [
+    [
+      // Similar to above, but with unions in the mix.
+      makeObjectType(
+        { a: makeUnionType(['a']), b: makeUnionType(['b']) },
+        { excess: nothing },
+      ),
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
+        makeObjectType({ b: makeUnionType(['b']) }, { excess: nothing }),
+      ]),
+    ],
+    false,
+  ],
+])
+
+typeAssignabilitySuite('bounded-excess object types', [
+  [
+    [
+      makeObjectType(
+        { a: makeUnionType(['a']), b: makeUnionType(['b']) },
+        { excess: nothing },
+      ),
+      makeObjectType({ a: makeUnionType(['a']) }, { excess: atom }),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType(
+        { a: makeUnionType(['a']), b: object },
+        { excess: nothing },
+      ),
+      makeObjectType({ a: makeUnionType(['a']) }, { excess: atom }),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({}, { excess: naturalNumber }),
+      makeObjectType({}, { excess: integer }),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({}, { excess: atom }),
+      makeObjectType({}, { excess: naturalNumber }),
+    ],
+    false,
+  ],
+  [[object, makeObjectType({}, { excess: atom })], false],
+  [[makeObjectType({}, { excess: atom }), object], true],
+  [
+    [
+      makeObjectType({}, { excess: nothing }),
+      makeObjectType({}, { excess: atom }),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({}, { excess: atom }),
+      makeObjectType({ a: atom }, { excess: something }),
+    ],
+    false,
+  ],
 ])
 
 typeAssignabilitySuite('generic function types (assignable)', [
@@ -912,7 +1143,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> :something.type`
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({ a: extendsAnyAtom }),
+        return: makeObjectType({ a: extendsAnyAtom }, { excess: something }),
       }),
       makeFunctionType({
         parameter: atom,
@@ -926,14 +1157,17 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `?a ~> { a: :a, b: :atom.type }` is assignable to `(?a: :atom.type) ~> { a: a }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({
-          a: A,
-          b: atom,
-        }),
+        return: makeObjectType(
+          {
+            a: A,
+            b: atom,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({ a: extendsAnyAtom }),
+        return: makeObjectType({ a: extendsAnyAtom }, { excess: something }),
       }),
     ],
     true,
@@ -943,11 +1177,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> { a: :atom.type }`
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({ a: extendsAnyAtom }),
+        return: makeObjectType({ a: extendsAnyAtom }, { excess: something }),
       }),
       makeFunctionType({
         parameter: atom,
-        return: makeObjectType({ a: atom }),
+        return: makeObjectType({ a: atom }, { excess: something }),
       }),
     ],
     true,
@@ -956,15 +1190,21 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ a: ?a } ~> :a` is assignable to `{ a: (?a: :atom.type) } ~> :a`
       makeFunctionType({
-        parameter: makeObjectType({
-          a: A,
-        }),
+        parameter: makeObjectType(
+          {
+            a: A,
+          },
+          { excess: something },
+        ),
         return: A,
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          a: extendsAnyAtom,
-        }),
+        parameter: makeObjectType(
+          {
+            a: extendsAnyAtom,
+          },
+          { excess: something },
+        ),
         return: extendsAnyAtom,
       }),
     ],
@@ -974,20 +1214,32 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ a: a } ~> { b: a }` is assignable to `{ a: (?a: :atom.type) } ~> { b: a }`
       makeFunctionType({
-        parameter: makeObjectType({
-          a: A,
-        }),
-        return: makeObjectType({
-          b: A,
-        }),
+        parameter: makeObjectType(
+          {
+            a: A,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            b: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          a: extendsAnyAtom,
-        }),
-        return: makeObjectType({
-          b: extendsAnyAtom,
-        }),
+        parameter: makeObjectType(
+          {
+            a: extendsAnyAtom,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            b: extendsAnyAtom,
+          },
+          { excess: something },
+        ),
       }),
     ],
     true,
@@ -1046,17 +1298,23 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `?a ~> { 0: :a, 1: :a }` is assignable to `(?a: :atom.type) ~> { 0: :a, 1: :atom.type }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({
-          0: A,
-          1: A,
-        }),
+        return: makeObjectType(
+          {
+            0: A,
+            1: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({
-          0: extendsAnyAtom,
-          1: atom,
-        }),
+        return: makeObjectType(
+          {
+            0: extendsAnyAtom,
+            1: atom,
+          },
+          { excess: something },
+        ),
       }),
     ],
     true,
@@ -1065,24 +1323,36 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }`
       makeFunctionType({
-        parameter: makeObjectType({
-          0: A,
-          1: B,
-        }),
-        return: makeObjectType({
-          0: B,
-          1: A,
-        }),
+        parameter: makeObjectType(
+          {
+            0: A,
+            1: B,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: B,
+            1: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          0: C,
-          1: D,
-        }),
-        return: makeObjectType({
-          0: D,
-          1: C,
-        }),
+        parameter: makeObjectType(
+          {
+            0: C,
+            1: D,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: D,
+            1: C,
+          },
+          { excess: something },
+        ),
       }),
     ],
     true,
@@ -1091,24 +1361,36 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: (?a: :atom.type), 1: (?b: a) } ~> { 0: :b, 1: ?a }`
       makeFunctionType({
-        parameter: makeObjectType({
-          0: A,
-          1: B,
-        }),
-        return: makeObjectType({
-          0: B,
-          1: A,
-        }),
+        parameter: makeObjectType(
+          {
+            0: A,
+            1: B,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: B,
+            1: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          0: extendsAnyAtom,
-          1: extendsSpecificAtom,
-        }),
-        return: makeObjectType({
-          0: extendsSpecificAtom,
-          1: extendsAnyAtom,
-        }),
+        parameter: makeObjectType(
+          {
+            0: extendsAnyAtom,
+            1: extendsSpecificAtom,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: extendsSpecificAtom,
+            1: extendsAnyAtom,
+          },
+          { excess: something },
+        ),
       }),
     ],
     true,
@@ -1117,24 +1399,36 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: ?b, 1: ?a }` is assignable to `{ 0: ?a, 1: (?b: :a) } ~> { 0: :b, 1: :a }`
       makeFunctionType({
-        parameter: makeObjectType({
-          0: B,
-          1: C,
-        }),
-        return: makeObjectType({
-          0: C,
-          1: B,
-        }),
+        parameter: makeObjectType(
+          {
+            0: B,
+            1: C,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: C,
+            1: B,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          0: A,
-          1: extendsA,
-        }),
-        return: makeObjectType({
-          0: extendsA,
-          1: A,
-        }),
+        parameter: makeObjectType(
+          {
+            0: A,
+            1: extendsA,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: extendsA,
+            1: A,
+          },
+          { excess: something },
+        ),
       }),
     ],
     true,
@@ -1143,28 +1437,40 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ a: ?a, b: ?b, c: :atom.type | :b } ~> { b: :a, a: :b, c: :a }` is assignable to `{ a: (?a: :atom.type), b: (?b: :a), c: :b } ~> { b: :a, a: :b | :a, c: :atom.type }`
       makeFunctionType({
-        parameter: makeObjectType({
-          a: A,
-          b: B,
-          c: makeUnionType([atom, B]),
-        }),
-        return: makeObjectType({
-          b: A,
-          a: B,
-          c: A,
-        }),
+        parameter: makeObjectType(
+          {
+            a: A,
+            b: B,
+            c: makeUnionType([atom, B]),
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            b: A,
+            a: B,
+            c: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          a: extendsAnyAtom,
-          b: extendsExtendsAnyAtom,
-          c: extendsExtendsAnyAtom,
-        }),
-        return: makeObjectType({
-          b: extendsAnyAtom,
-          a: makeUnionType([extendsAnyAtom, extendsExtendsAnyAtom]),
-          c: atom,
-        }),
+        parameter: makeObjectType(
+          {
+            a: extendsAnyAtom,
+            b: extendsExtendsAnyAtom,
+            c: extendsExtendsAnyAtom,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            b: extendsAnyAtom,
+            a: makeUnionType([extendsAnyAtom, extendsExtendsAnyAtom]),
+            c: atom,
+          },
+          { excess: something },
+        ),
       }),
     ],
     true,
@@ -1233,11 +1539,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
       // `?a ~> { a: :a }` is not assignable to `?a ~> { b: :a }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({ a: A }),
+        return: makeObjectType({ a: A }, { excess: something }),
       }),
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({ b: A }),
+        return: makeObjectType({ b: A }, { excess: something }),
       }),
     ],
     false,
@@ -1260,24 +1566,36 @@ typeAssignabilitySuite('generic function types (not assignable)', [
     [
       // `{ 0: ?a, 1: (?b: :a) } ~> { 0: :b, 1: :a }` is not assignable to `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }`
       makeFunctionType({
-        parameter: makeObjectType({
-          0: A,
-          1: extendsA,
-        }),
-        return: makeObjectType({
-          0: extendsA,
-          1: A,
-        }),
+        parameter: makeObjectType(
+          {
+            0: A,
+            1: extendsA,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: extendsA,
+            1: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          0: A,
-          1: B,
-        }),
-        return: makeObjectType({
-          0: B,
-          1: A,
-        }),
+        parameter: makeObjectType(
+          {
+            0: A,
+            1: B,
+          },
+          { excess: something },
+        ),
+        return: makeObjectType(
+          {
+            0: B,
+            1: A,
+          },
+          { excess: something },
+        ),
       }),
     ],
     false,
@@ -1317,15 +1635,21 @@ typeAssignabilitySuite('generic function types (not assignable)', [
     [
       // `{ a: ?a } ~> :a` is not assignable to `{ b: ?a } ~> :a`
       makeFunctionType({
-        parameter: makeObjectType({
-          a: A,
-        }),
+        parameter: makeObjectType(
+          {
+            a: A,
+          },
+          { excess: something },
+        ),
         return: A,
       }),
       makeFunctionType({
-        parameter: makeObjectType({
-          b: A,
-        }),
+        parameter: makeObjectType(
+          {
+            b: A,
+          },
+          { excess: something },
+        ),
         return: A,
       }),
     ],
@@ -1336,15 +1660,21 @@ typeAssignabilitySuite('generic function types (not assignable)', [
       // `?a ~> { a: :a }` is not assignable to `?a ~> { b: :a }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({
-          a: A,
-        }),
+        return: makeObjectType(
+          {
+            a: A,
+          },
+          { excess: something },
+        ),
       }),
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({
-          b: A,
-        }),
+        return: makeObjectType(
+          {
+            b: A,
+          },
+          { excess: something },
+        ),
       }),
     ],
     false,
@@ -1371,14 +1701,14 @@ typeAssignabilitySuite(
   [
     [[makeUnionType([A, object]), something], true],
     [
-      [makeUnionType([A, makeObjectType({}, { exact: true })]), something],
+      [makeUnionType([A, makeObjectType({}, { excess: nothing })]), something],
       true,
     ],
     [
       [
         makeFunctionType({
           parameter: something,
-          return: makeUnionType([A, makeObjectType({}, { exact: true })]),
+          return: makeUnionType([A, makeObjectType({}, { excess: nothing })]),
         }),
         something,
       ],

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -820,6 +820,34 @@ typeAssignabilitySuite('custom types (not assignable)', [
     [makeObjectType({}, { exact: false }), makeObjectType({}, { exact: true })],
     false,
   ],
+  // FIXME: This test case currently fails!
+  // [
+  //   [
+  //     // exact objects with extra properties aren't assignable to exact objects
+  //     // lacking them
+  //     makeObjectType(
+  //       { a: makeUnionType(['a']), b: makeUnionType(['b']) },
+  //       { exact: true },
+  //     ),
+  //     makeObjectType({ a: makeUnionType(['a']) }, { exact: true }),
+  //   ],
+  //   false,
+  // ],
+  // FIXME: This test case currently fails!
+  // [
+  //   [
+  //     // similar to above, but with unions in the mix
+  //     makeObjectType(
+  //       { a: makeUnionType(['a']), b: makeUnionType(['b']) },
+  //       { exact: true },
+  //     ),
+  //     makeUnionType([
+  //       makeObjectType({ a: makeUnionType(['a']) }, { exact: true }),
+  //       makeObjectType({ b: makeUnionType(['b']) }, { exact: true }),
+  //     ]),
+  //   ],
+  //   false,
+  // ],
 ])
 
 typeAssignabilitySuite('generic function types (assignable)', [

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -1,6 +1,7 @@
 import type { Option } from '@matt.kantor/option'
 import option from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
+import { something } from './prelude-types.js'
 import {
   makeObjectType,
   makeUnionType,
@@ -231,33 +232,37 @@ export const isAssignable = ({
               )
             },
             object: target => {
-              if (target.exact && !source.exact) {
-                // Inexact object types aren't assignable to exact ones.
-                return false
-              } else {
-                // Make sure all properties in the target are present and valid
-                // in the source (recursively). Values may have additional
-                // properties beyond what is required by the target and still be
-                // assignable to it.
-                for (const [key, typePropertyValue] of Object.entries(
-                  target.children,
-                )) {
-                  if (source.children[key] === undefined) {
-                    return false
-                  } else {
-                    // Recursively check the property:
-                    if (
-                      !isAssignable({
-                        source: source.children[key],
-                        target: typePropertyValue,
-                      })
-                    ) {
-                      return false
-                    }
-                  }
-                }
-                return true
-              }
+              // Every property required by the target must be present and valid
+              // in the source (recursively).
+              const requiredPropertiesAreSatisfied = Object.entries(
+                target.children,
+              ).every(([key, targetChild]) => {
+                const sourceChild = source.children[key]
+                return (
+                  sourceChild !== undefined &&
+                  isAssignable({ source: sourceChild, target: targetChild })
+                )
+              })
+              // Source properties beyond the target's children, along with
+              // whatever excess the source itself admits, must fit within the
+              // target's excess bound.
+              const excessPropertiesAreSatisfied =
+                target.excess === something ||
+                (Object.entries(source.children).every(
+                  ([key, sourceChild]) =>
+                    target.children[key] !== undefined ||
+                    isAssignable({
+                      source: sourceChild,
+                      target: target.excess,
+                    }),
+                ) &&
+                  isAssignable({
+                    source: source.excess,
+                    target: target.excess,
+                  }))
+              return (
+                requiredPropertiesAreSatisfied && excessPropertiesAreSatisfied
+              )
             },
             opaque: target => target.isAssignableFrom(source),
             parameter: _target => false, // an object type is never directly assignable to a type parameter
@@ -425,80 +430,88 @@ export const asUnionWithLiteralAtomMembers = (
  * simplified to `{ a: 'a' | 'b' | 'c' } | atom`.
  */
 export const simplifyUnionType = (typeToSimplify: UnionType): UnionType => {
-  const reducibleSubsets = new Map<
-    string,
-    {
-      readonly keys: readonly string[]
-      readonly typesToMerge: Set<ObjectType>
-    }
-  >()
-  for (const type of typeToSimplify.members) {
-    if (typeof type !== 'string' && type.kind === 'object') {
-      const keys = Object.keys(type.children)
+  const members = [...typeToSimplify.members]
 
-      // Object types with a single key are always mergeable with other object
-      // types containing the same single key. For example `{ a: 'a' } | { a:
-      // 'b' }` can become `{ a: 'a' | 'b' }`.
-      //
-      // TODO: Handle cases where there is more than one key but property types
-      // are compatible. For example `{ a: 'a', b: 'b' } | { a: 'b', b: 'b' }`
-      // can become `{ a: 'a' | 'b', b: 'b' }`.
-      const fingerprint = keys[0]
-      if (keys.length === 1 && fingerprint !== undefined) {
-        const objectTypesWithThisFingerprint = reducibleSubsets.get(
-          fingerprint,
-        ) ?? { keys, typesToMerge: new Set() }
-        reducibleSubsets.set(fingerprint, {
-          keys,
-          typesToMerge: objectTypesWithThisFingerprint.typesToMerge.add(type),
-        })
-      }
-    }
+  // Object types with a single key are mergeable with other object types
+  // containing the same single key (as long as their excess bounds agree).
+  // For example `{ a: 'a' } | { a: 'b' }` can become `{ a: 'a' | 'b' }`.
+  //
+  // TODO: Handle cases where there is more than one key but property types
+  // are compatible. For example `{ a: 'a', b: 'b' } | { a: 'b', b: 'b' }`
+  // can become `{ a: 'a' | 'b', b: 'b' }`.
+  const isObjectType = (member: Atom | Exclude<Type, UnionType>) =>
+    typeof member !== 'string' && member.kind === 'object'
+  const isMergeable = (member: ObjectType) =>
+    Object.keys(member.children).length === 1
+
+  const excessBoundsAgree = (first: Type, second: Type): boolean =>
+    isAssignable({ source: first, target: second }) &&
+    isAssignable({ source: second, target: first })
+
+  type MergeGroup = {
+    readonly key: string
+    readonly excess: Type
+    readonly typesToMerge: readonly ObjectType[]
   }
 
-  const canonicalizedTargetMembers = new Set<Atom | Exclude<Type, UnionType>>(
-    typeToSimplify.members,
-  )
-
-  // Reduce `reducibleSubsets` by merging all candidate, updating
-  // `canonicalizedTargetMembers`. Merge algorithm:
-  //  - for each reducible subset of object types:
-  //    - for each shared key within that subset:
-  //      - get the key's property type from every member of `typesToMerge`
-  //      - create a union allowing any of those types
-  //    - create single object type where each property has the appropriate
-  //      union type
-  for (const { keys, typesToMerge } of reducibleSubsets.values()) {
-    const mergedObjectTypeChildren = Object.fromEntries(
-      keys.map(key => {
-        const typesForThisProperty = typesToMerge.values().flatMap(type => {
-          const propertyType = type.children[key]
-          return (
-            propertyType === undefined ? []
-            : propertyType.kind === 'union' ?
-              [...propertyType.members] // flatten any existing unions in property types
-            : [propertyType]
+  const mergeGroups = members
+    .filter(isObjectType)
+    .filter(isMergeable)
+    .reduce<readonly MergeGroup[]>((groups, objectType) => {
+      const [key] = Object.keys(objectType.children)
+      const groupIndex =
+        key === undefined ? -1 : (
+          groups.findIndex(
+            group =>
+              group.key === key &&
+              excessBoundsAgree(group.excess, objectType.excess),
           )
-        })
-        const propertyTypeAsUnion = excludeRedundantUnionTypeMembers(
-          makeUnionType(typesForThisProperty),
         )
-        return [key, propertyTypeAsUnion] as const
-      }),
+      return (
+        key === undefined ? groups
+        : groupIndex === -1 ?
+          [
+            ...groups,
+            { key, excess: objectType.excess, typesToMerge: [objectType] },
+          ]
+        : groups.map((group, index) =>
+            index === groupIndex ?
+              { ...group, typesToMerge: [...group.typesToMerge, objectType] }
+            : group,
+          )
+      )
+    }, [])
+
+  // Merge each group into a single object type whose sole required property is
+  // the union of every group member's sole property type.
+  const mergedObjectTypes = mergeGroups.map(({ key, excess, typesToMerge }) => {
+    const typesForTheProperty = typesToMerge.flatMap(objectType => {
+      const propertyType = objectType.children[key]
+      return (
+        propertyType === undefined ? []
+        : propertyType.kind === 'union' ?
+          [...propertyType.members] // flatten any existing unions in property types
+        : [propertyType]
+      )
+    })
+    return makeObjectType(
+      {
+        [key]: excludeRedundantUnionTypeMembers(
+          makeUnionType(typesForTheProperty),
+        ),
+      },
+      { excess },
     )
-    const mergedObjectType = makeObjectType(mergedObjectTypeChildren)
-
-    // Remove all `typesToMerge` from `canonicalizedTargetMembers`.
-    for (const typeWhichHasBeenMerged of typesToMerge) {
-      canonicalizedTargetMembers.delete(typeWhichHasBeenMerged)
-    }
-    canonicalizedTargetMembers.add(mergedObjectType)
-  }
-
-  return excludeRedundantUnionTypeMembers({
-    kind: 'union',
-    members: canonicalizedTargetMembers,
   })
+
+  return excludeRedundantUnionTypeMembers(
+    makeUnionType([
+      ...members.filter(
+        member => !isObjectType(member) || !isMergeable(member),
+      ),
+      ...mergedObjectTypes,
+    ]),
+  )
 }
 
 const excludeRedundantUnionTypeMembers = (type: UnionType) => {

--- a/src/language/semantics/type-system/type-formats.ts
+++ b/src/language/semantics/type-system/type-formats.ts
@@ -114,19 +114,21 @@ export type ObjectType = {
   readonly kind: 'object'
   readonly children: Readonly<Record<Atom, Type>>
   /**
-   * When `true`, every inhabitant of this type has exactly the specified keys
-   * and can't be subtyped by objects with additional properties.
+   * An upper bound on the values of properties *not* explicitly required by
+   * `children`. The bottom type (an empty union) means inhabitants have exactly
+   * the specified keys; the top type admits arbitrary excess properties;
+   * anything in between bounds what excess property values may be.
    */
-  readonly exact: boolean
+  readonly excess: Type
 }
 
 export const makeObjectType = <Children extends Readonly<Record<Atom, Type>>>(
   children: Children,
-  options: { readonly exact: boolean } = { exact: false },
+  options: { readonly excess: Type },
 ): ObjectType & { readonly children: Children } => ({
   kind: 'object',
   children,
-  exact: options.exact,
+  excess: options.excess,
 })
 
 export type OpaqueType = {

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -479,7 +479,10 @@ const inferTypeImplementation = (
             return either.flatMap(inferThen(), thenType =>
               either.map(inferElse(), elseType =>
                 makeIndexedAccessType(
-                  makeObjectType({ false: elseType, true: thenType }),
+                  makeObjectType(
+                    { false: elseType, true: thenType },
+                    { excess: types.something },
+                  ),
                   conditionType,
                 ),
               ),
@@ -572,7 +575,7 @@ const inferTypeImplementation = (
         makeObjectType(Object.fromEntries(entries), {
           // Expressions will have different keys after elaboration, otherwise
           // this is a literal object where all properties are known.
-          exact: !isExpression(node),
+          excess: isExpression(node) ? types.something : types.nothing,
         }),
     ),
   )

--- a/src/language/semantics/type-system/type-key-path.ts
+++ b/src/language/semantics/type-system/type-key-path.ts
@@ -154,7 +154,7 @@ export const updateTypeAtKeyPathIfValid = (
                   operation,
                 ),
               },
-              { exact: type.exact },
+              { excess: type.excess },
             )
           }
         } else {

--- a/src/language/semantics/type-system/type-parameter-analysis.ts
+++ b/src/language/semantics/type-system/type-parameter-analysis.ts
@@ -51,11 +51,18 @@ const containedTypeParametersImplementation = (
           ]),
         ),
       object: type =>
-        Object.entries(type.children)
-          .map(([key, child]) =>
+        [
+          ...Object.entries(type.children).map(([key, child]) =>
             containedTypeParametersImplementation(child, [...root, key]),
-          )
-          .reduce(mergeTypeParametersByKeyPath, new Map()),
+          ),
+          // Excess bounds may also contain type parameters (which need to be
+          // visible here for stuckness detection). There's no way to talk about
+          // them in `TypeKeyPath`, so they're currently (imprecisely) reported
+          // at the object's own key path.
+          // TODO: Should there be a `TypeKeyPath` symbol to allow addressing
+          // excess bounds explicitly?
+          containedTypeParametersImplementation(type.excess, root),
+        ].reduce(mergeTypeParametersByKeyPath, new Map()),
       application: type =>
         mergeTypeParametersByKeyPath(
           containedTypeParametersImplementation(type.function, root),
@@ -130,6 +137,9 @@ const findKeyPathsToTypeParameterImplementation = (
           ),
         ]),
       object: type =>
+        // Note that this is asymmetric with `containedTypeParameters` in that
+        // it doesn't explore excess bounds. If they ever become explicitly
+        // addressable in `TypeKeyPath` then that should change.
         Object.entries(type.children)
           .map(([key, child]) =>
             findKeyPathsToTypeParameterImplementation(

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -32,6 +32,7 @@ import {
   type TypeParameter,
 } from './type-formats.js'
 import { nestedIndexedAccess } from './type-key-path.js'
+import { containedTypeParameters } from './type-parameter-analysis.js'
 import {
   applyKeyPathToType,
   applyTypeToArgumentType,
@@ -65,8 +66,8 @@ applyKeyPathSuite('applyKeyPathToType with empty key path', [
   [[nothing, []], stringifyTypeForEndUser(nothing)],
   [[something, []], stringifyTypeForEndUser(something)],
   [
-    [makeObjectType({ a: atom }), []],
-    stringifyTypeForEndUser(makeObjectType({ a: atom })),
+    [makeObjectType({ a: atom }, { excess: something }), []],
+    stringifyTypeForEndUser(makeObjectType({ a: atom }, { excess: something })),
   ],
   [
     [makeFunctionType({ parameter: atom, return: something }), []],
@@ -78,24 +79,30 @@ applyKeyPathSuite('applyKeyPathToType with empty key path', [
 
 applyKeyPathSuite('applyKeyPathToType with object types', [
   [
-    [makeObjectType({ a: atom, b: integer }), ['a']],
+    [makeObjectType({ a: atom, b: integer }, { excess: something }), ['a']],
     stringifyTypeForEndUser(atom),
   ],
   [
-    [makeObjectType({ a: atom, b: integer }), ['b']],
+    [makeObjectType({ a: atom, b: integer }, { excess: something }), ['b']],
     stringifyTypeForEndUser(integer),
   ],
-  [[makeObjectType({ a: atom }), ['z']], '(none)'],
+  [[makeObjectType({ a: atom }, { excess: something }), ['z']], '(none)'],
   [
     [
-      makeObjectType({
-        a: makeObjectType({ b: makeUnionType(['hello']) }),
-      }),
+      makeObjectType(
+        {
+          a: makeObjectType(
+            { b: makeUnionType(['hello']) },
+            { excess: something },
+          ),
+        },
+        { excess: something },
+      ),
       ['a', 'b'],
     ],
     stringifyTypeForEndUser(makeUnionType(['hello'])),
   ],
-  [[makeObjectType({ a: atom }), ['a', 'b']], '(none)'],
+  [[makeObjectType({ a: atom }, { excess: something }), ['a', 'b']], '(none)'],
 ])
 
 applyKeyPathSuite('applyKeyPathToType with non-object types', [
@@ -109,8 +116,8 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
   [
     [
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['x']) }),
-        makeObjectType({ a: makeUnionType(['y']) }),
+        makeObjectType({ a: makeUnionType(['x']) }, { excess: something }),
+        makeObjectType({ a: makeUnionType(['y']) }, { excess: something }),
       ]),
       ['a'],
     ],
@@ -118,14 +125,10 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
   ],
   [
     [
-      makeUnionType([makeObjectType({ a: makeUnionType(['x']) }), 'some_atom']),
-      ['a'],
-    ],
-    '(none)',
-  ],
-  [
-    [
-      makeUnionType([makeObjectType({ b: atom }), makeObjectType({ c: atom })]),
+      makeUnionType([
+        makeObjectType({ a: makeUnionType(['x']) }, { excess: something }),
+        'some_atom',
+      ]),
       ['a'],
     ],
     '(none)',
@@ -133,7 +136,17 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
   [
     [
       makeUnionType([
-        makeObjectType({ a: integer }),
+        makeObjectType({ b: atom }, { excess: something }),
+        makeObjectType({ c: atom }, { excess: something }),
+      ]),
+      ['a'],
+    ],
+    '(none)',
+  ],
+  [
+    [
+      makeUnionType([
+        makeObjectType({ a: integer }, { excess: something }),
         makeFunctionType({ parameter: atom, return: atom }),
       ]),
       ['a'],
@@ -143,14 +156,20 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
 ])
 
 applyKeyPathSuite('applyKeyPathToType with bottom types', [
-  [[makeObjectType({ a: nothing }), ['a']], stringifyTypeForEndUser(nothing)],
-  [[makeObjectType({ a: nothing }), ['a', 'b']], '(none)'],
+  [
+    [makeObjectType({ a: nothing }, { excess: something }), ['a']],
+    stringifyTypeForEndUser(nothing),
+  ],
+  [
+    [makeObjectType({ a: nothing }, { excess: something }), ['a', 'b']],
+    '(none)',
+  ],
   [[nothing, ['a']], '(none)'],
   [
     [
       makeUnionType([
-        makeObjectType({ a: nothing }),
-        makeObjectType({ a: atom }),
+        makeObjectType({ a: nothing }, { excess: something }),
+        makeObjectType({ a: atom }, { excess: something }),
       ]),
       ['a'],
     ],
@@ -162,10 +181,13 @@ const keyAssignableToAOrB = makeTypeParameter('key', {
   assignableTo: makeUnionType(['a', 'b']),
 })
 const stuckAccessWithCommonXProperty = makeIndexedAccessType(
-  makeObjectType({
-    a: makeObjectType({ x: atom }),
-    b: makeObjectType({ x: integer }),
-  }),
+  makeObjectType(
+    {
+      a: makeObjectType({ x: atom }, { excess: something }),
+      b: makeObjectType({ x: integer }, { excess: something }),
+    },
+    { excess: something },
+  ),
   keyAssignableToAOrB,
 )
 
@@ -180,10 +202,13 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
   [
     [
       makeIndexedAccessType(
-        makeObjectType({
-          a: makeObjectType({ x: atom }),
-          b: makeObjectType({}),
-        }),
+        makeObjectType(
+          {
+            a: makeObjectType({ x: atom }, { excess: something }),
+            b: makeObjectType({}, { excess: something }),
+          },
+          { excess: something },
+        ),
         keyAssignableToAOrB,
       ),
       ['x'],
@@ -193,7 +218,7 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
   [
     [
       makeIndexedAccessType(
-        makeObjectType({ x: atom, a: atom, b: atom }),
+        makeObjectType({ x: atom, a: atom, b: atom }, { excess: something }),
         keyAssignableToAOrB,
       ),
       ['x'],
@@ -204,7 +229,16 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
 
 applyKeyPathSuite('applyKeyPathToType with degenerate stuck types', [
   [[makeApplicationType(atom, atom, new Set()), ['x']], '(none)'],
-  [[makeIndexedAccessType(makeObjectType({ x: atom }), atom), ['x']], '(none)'],
+  [
+    [
+      makeIndexedAccessType(
+        makeObjectType({ x: atom }, { excess: something }),
+        atom,
+      ),
+      ['x'],
+    ],
+    '(none)',
+  ],
 ])
 
 const getTypesForTypeParametersSuite = testCases(
@@ -232,10 +266,13 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [[something, atom], new Map()],
 
-  [[makeObjectType({ a: A }), atom], new Map()],
+  [[makeObjectType({ a: A }, { excess: something }), atom], new Map()],
 
   [
-    [makeObjectType({ a: A, b: B }), makeObjectType({ a: atom, b: integer })],
+    [
+      makeObjectType({ a: A, b: B }, { excess: something }),
+      makeObjectType({ a: atom, b: integer }, { excess: something }),
+    ],
     new Map([
       [A, atom],
       [B, integer],
@@ -264,7 +301,10 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
   ],
 
   [
-    [makeObjectType({ a: A, b: A }), makeObjectType({ a: atom, b: integer })],
+    [
+      makeObjectType({ a: A, b: A }, { excess: something }),
+      makeObjectType({ a: atom, b: integer }, { excess: something }),
+    ],
     // The first occurrence should be used in situations like this. In real code
     // this will likely result in a type error later.
     new Map([[A, atom]]),
@@ -308,6 +348,36 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
       [B, naturalNumber],
     ]),
   ],
+
+  [
+    [
+      makeObjectType({}, { excess: A }),
+      makeObjectType(
+        { a: makeUnionType(['1']), b: makeUnionType(['2']) },
+        { excess: nothing },
+      ),
+    ],
+    new Map([[A, makeUnionType(['1', '2'])]]),
+  ],
+
+  [[makeObjectType({}, { excess: A }), object], new Map([[A, something]])],
+
+  [
+    [
+      makeObjectType({}, { excess: A }),
+      makeObjectType({}, { excess: nothing }),
+    ],
+    new Map([[A, nothing]]),
+  ],
+
+  [
+    // Bindings from required properties take precedence over excess bindings.
+    [
+      makeObjectType({ a: A }, { excess: A }),
+      makeObjectType({ a: atom, b: integer }, { excess: nothing }),
+    ],
+    new Map([[A, atom]]),
+  ],
 ])
 
 const enumerateInhabitantsSuite = testCases(
@@ -332,26 +402,29 @@ enumerateInhabitantsSuite('enumerateInhabitants', [
 
   [makeFunctionType({ parameter: atom, return: atom }), optionAdt.none],
 
-  // The `object` type is inexact (any object inhabits it).
+  // The `object` type is open (any object inhabits it).
   [object, optionAdt.none],
 
   [
-    makeObjectType({}, { exact: true }),
+    makeObjectType({}, { excess: nothing }),
     optionAdt.makeSome([objectNodeFromOrderedEntries([])]),
   ],
 
   [
-    makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+    makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
     optionAdt.makeSome([objectNodeFromOrderedEntries([['a', '1']])]),
   ],
 
-  // Object types default to being inexact.
-  [makeObjectType({ a: makeUnionType(['1']) }), optionAdt.none],
+  // An open object type admits unlisted properties, so it is not enumerable.
+  [
+    makeObjectType({ a: makeUnionType(['1']) }, { excess: something }),
+    optionAdt.none,
+  ],
 
   [
     makeObjectType(
       { a: makeUnionType(['1', '2']), b: makeUnionType(['x']) },
-      { exact: true },
+      { excess: nothing },
     ),
     optionAdt.makeSome([
       objectNodeFromOrderedEntries([
@@ -365,12 +438,12 @@ enumerateInhabitantsSuite('enumerateInhabitants', [
     ]),
   ],
 
-  [makeObjectType({ a: atom }, { exact: true }), optionAdt.none],
+  [makeObjectType({ a: atom }, { excess: nothing }), optionAdt.none],
 
   [
     makeObjectType(
-      { a: makeObjectType({ b: makeUnionType(['1']) }, { exact: true }) },
-      { exact: true },
+      { a: makeObjectType({ b: makeUnionType(['1']) }, { excess: nothing }) },
+      { excess: nothing },
     ),
     optionAdt.makeSome([
       objectNodeFromOrderedEntries([
@@ -381,15 +454,15 @@ enumerateInhabitantsSuite('enumerateInhabitants', [
 
   [
     makeObjectType(
-      { a: makeObjectType({ b: makeUnionType(['1']) }) },
-      { exact: true },
+      { a: makeObjectType({ b: makeUnionType(['1']) }, { excess: something }) },
+      { excess: nothing },
     ),
     optionAdt.none,
   ],
 
   [
     makeUnionType([
-      makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+      makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
       'z',
     ]),
     optionAdt.makeSome([objectNodeFromOrderedEntries([['a', '1']]), 'z']),
@@ -420,7 +493,7 @@ const intrinsicReductionSuite = testCases(
   (typeArgument: Type) =>
     supplyTypeArgument(
       makeIntrinsicApplicationType(
-        [A, makeObjectType({ b: makeUnionType(['2']) }, { exact: true })],
+        [A, makeObjectType({ b: makeUnionType(['2']) }, { excess: nothing })],
         describeReducedArguments,
         computeUpperBound,
       ),
@@ -433,7 +506,7 @@ const intrinsicReductionSuite = testCases(
 
 intrinsicReductionSuite('intrinsic application reduction over object types', [
   [
-    makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+    makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
     makeUnionType(['{ { a: 1 }, { b: 2 } }']),
   ],
 
@@ -441,19 +514,19 @@ intrinsicReductionSuite('intrinsic application reduction over object types', [
 
   [
     makeUnionType([
-      makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
-      makeObjectType({ a: makeUnionType(['2']) }, { exact: true }),
+      makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
+      makeObjectType({ a: makeUnionType(['2']) }, { excess: nothing }),
     ]),
     makeUnionType(['{ { a: 1 }, { b: 2 } }', '{ { a: 2 }, { b: 2 } }']),
   ],
 
-  // An inexact object type isn't enumerable, so the application stays stuck.
+  // An open object type is not enumerable, so the application stays stuck.
   [
-    makeObjectType({ a: makeUnionType(['1']) }),
+    makeObjectType({ a: makeUnionType(['1']) }, { excess: something }),
     makeIntrinsicApplicationType(
       [
-        makeObjectType({ a: makeUnionType(['1']) }),
-        makeObjectType({ b: makeUnionType(['2']) }, { exact: true }),
+        makeObjectType({ a: makeUnionType(['1']) }, { excess: something }),
+        makeObjectType({ b: makeUnionType(['2']) }, { excess: nothing }),
       ],
       describeReducedArguments,
       computeUpperBound,
@@ -465,17 +538,17 @@ const genericizationConstraintSuite = testCases(
   (annotation: Type) =>
     genericizeFunctionParameterAnnotation('x', annotation).type,
   annotation =>
-    `genericizing \`x: ${stringifyTypeForEndUser(annotation)}\` strips exactness`,
+    `genericizing \`x: ${stringifyTypeForEndUser(annotation)}\` opens closed objects`,
 )
 
 genericizationConstraintSuite(
-  'genericization produces inexact object constraints',
+  'genericization produces open object constraints',
   [
     [
       // The constraint is an upper bound for its instantiations (which should
-      // admit subtypes), so it must not be exact.
+      // admit subtypes), so it must not be closed.
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['1']) }, { exact: true }),
+        makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
       ]),
       parameterType => {
         assert(parameterType.kind === 'parameter')
@@ -483,7 +556,7 @@ genericizationConstraintSuite(
         assert(constraint.kind === 'union')
         const [member] = constraint.members
         assert(typeof member === 'object' && member.kind === 'object')
-        assert.deepEqual(member.exact, false)
+        assert.deepEqual(member.excess, something)
       },
     ],
   ],
@@ -517,10 +590,13 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType({
-        a: integer,
-        b: atom,
-      }),
+      makeObjectType(
+        {
+          a: integer,
+          b: atom,
+        },
+        { excess: something },
+      ),
     ],
     '{ a: (?"x.a": :integer.type), b: (?"x.b": :atom.type) }',
   ],
@@ -528,9 +604,12 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType({
-        a: makeObjectType({ b: atom }),
-      }),
+      makeObjectType(
+        {
+          a: makeObjectType({ b: atom }, { excess: something }),
+        },
+        { excess: something },
+      ),
     ],
     '{ a: { b: (?"x.a.b": :atom.type) } }',
   ],
@@ -538,19 +617,22 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType({
-        callback: makeFunctionType({ parameter: atom, return: integer }),
-      }),
+      makeObjectType(
+        {
+          callback: makeFunctionType({ parameter: atom, return: integer }),
+        },
+        { excess: something },
+      ),
     ],
     '{ callback: (?"x.callback.#parameter": :atom.type) ~> (?"x.callback.#return": :integer.type) }',
   ],
 
-  [['empty', makeObjectType({})], '(?empty: {})'],
+  [['empty', makeObjectType({}, { excess: something })], '(?empty: {})'],
 
   [['identity', makeFunctionType({ parameter: A, return: A })], '?a ~> :a'],
 
   [
-    ['wrap', makeObjectType({ value: A })],
+    ['wrap', makeObjectType({ value: A }, { excess: something })],
     `{ value: ${stringifyTypeForEndUser(A)} }`,
   ],
 ])
@@ -602,4 +684,44 @@ applyTypeToArgumentTypeSuite('applyTypeToArgumentType', [
 
   [[object, integer], 'none'],
   [[integer, atom], 'none'],
+])
+
+const supplyTypeArgumentSuite = testCases(
+  ([type, typeParameter, typeArgument]: readonly [
+    type: Type,
+    typeParameter: TypeParameter,
+    typeArgument: Type,
+  ]) => supplyTypeArgument(type, typeParameter, typeArgument),
+  ([type, typeParameter, typeArgument]) =>
+    `supplying \`${stringifyTypeForEndUser(typeArgument)}\` for \`${typeParameter.name}\` in \`${stringifyTypeForEndUser(type)}\``,
+)
+
+supplyTypeArgumentSuite('supplying type arguments within excess bounds', [
+  [
+    [makeObjectType({}, { excess: A }), A, atom],
+    makeObjectType({}, { excess: atom }),
+  ],
+
+  [[object, A, atom], object],
+])
+
+const containedTypeParametersSuite = testCases(
+  (type: Type) => [
+    ...containedTypeParameters(type)
+      .values()
+      .flatMap(({ typeParameters }) =>
+        [...typeParameters.members].map(typeParameter => typeParameter.name),
+      ),
+  ],
+  type =>
+    `finding the type parameters contained in \`${stringifyTypeForEndUser(type)}\``,
+)
+
+containedTypeParametersSuite('containedTypeParameters over excess bounds', [
+  [makeObjectType({}, { excess: A }), ['a']],
+
+  [makeObjectType({ x: B }, { excess: A }), ['b', 'a']],
+
+  [object, []],
+  [something, []],
 ])

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -7,6 +7,7 @@ import type { SemanticGraph } from '../semantic-graph.js'
 import { nothing, something } from './prelude-types.js'
 import { isAssignable } from './subtyping.js'
 import {
+  isNothing,
   makeApplicationType,
   makeFunctionType,
   makeIndexedAccessType,
@@ -270,23 +271,54 @@ export const getTypesForTypeParameters = ({
           ])
         : new Map(),
 
-      object: parameterType =>
-        argumentType.kind === 'object' ?
-          Object.entries(parameterType.children)
-            .map(([key, childParameter]) => {
-              const childArgument = argumentType.children[key]
-              return childArgument === undefined ?
-                  new Map<TypeParameter, Type>()
-                : getTypesForTypeParameters({
-                    parameterType: childParameter,
-                    argumentType: childArgument,
-                  })
-            })
-            .reduce(
-              (types, typesFromChild) => new Map([...typesFromChild, ...types]),
-              new Map<TypeParameter, Type>(),
+      object: parameterType => {
+        if (argumentType.kind !== 'object') {
+          return new Map()
+        } else {
+          // Type parameters in excess bounds unify against everything the
+          // argument could hold beyond the parameter's required properties.
+          const bindingsFromExcess = (): ReadonlyMap<TypeParameter, Type> => {
+            const unmatchedArgumentChildTypes = Object.entries(
+              argumentType.children,
             )
-        : new Map(),
+              .filter(
+                ([key, _child]) => parameterType.children[key] === undefined,
+              )
+              .map(([_key, child]) => child)
+            return getTypesForTypeParameters({
+              parameterType: parameterType.excess,
+              argumentType: unionOfTypes([
+                ...unmatchedArgumentChildTypes,
+                ...(isNothing(argumentType.excess) ?
+                  []
+                : [argumentType.excess]),
+              ]),
+            })
+          }
+          return [
+            ...Object.entries(parameterType.children).map(
+              ([key, childParameter]) => {
+                const childArgument = argumentType.children[key]
+                return childArgument === undefined ?
+                    new Map<TypeParameter, Type>()
+                  : getTypesForTypeParameters({
+                      parameterType: childParameter,
+                      argumentType: childArgument,
+                    })
+              },
+            ),
+            containedTypeParameters(parameterType.excess).size === 0 ?
+              new Map<TypeParameter, Type>()
+              // Excess bindings come last so type parameters prefer binding to
+              // required properties instead of excess (when the same type
+              // parameter appears in both places).
+            : bindingsFromExcess(),
+          ].reduce(
+            (types, typesFromChild) => new Map([...typesFromChild, ...types]),
+            new Map<TypeParameter, Type>(),
+          )
+        }
+      },
 
       opaque: _ => new Map(),
 
@@ -471,9 +503,9 @@ const cartesianProduct = <Element>(lists: readonly (readonly Element[])[]) =>
 
 /**
  * Enumerate every value inhabiting the given finitely-sized `type`, or return
- * `none` if `type` has infinite inhabitants. Literal atom types, exact object
- * types whose property types are enumerable, and unions of enumerable types are
- * enumerable.
+ * `none` if `type` has infinite inhabitants. Literal atom types, closed object
+ * types (no excess properties) whose property types are enumerable, and unions
+ * of enumerable types are enumerable.
  */
 export const enumerateInhabitants = (
   type: Type,
@@ -489,7 +521,7 @@ export const enumerateInhabitants = (
       opaque: _ => option.none,
       parameter: _ => option.none,
       object: type =>
-        !type.exact ?
+        !isNothing(type.excess) ?
           option.none
         : option.map(
             option.sequence(
@@ -595,7 +627,9 @@ export const supplyTypeArgument = (
             typeArgument,
           )
         }
-        return makeObjectType(substitutedChildren, { exact: type.exact })
+        return makeObjectType(substitutedChildren, {
+          excess: supplyTypeArgument(type.excess, typeParameter, typeArgument),
+        })
       },
       application: type =>
         reduceApplication(
@@ -682,9 +716,10 @@ export const supplyTypeArguments = (
     )
 
 /**
- * Recursively clear `exact` from every object type within `type`. Used when a
- * type is adopted from a user-written type position (e.g. parameter type
- * annotations), where subtyping means wider values may inhabit it.
+ * Recursively widen every closed (`excess: nothing`) object type to an open
+ * one; any other excess bound is preserved as written. Used when a type is
+ * adopted from a user-written type position (e.g. parameter type annotations),
+ * where subtyping means wider values may inhabit it.
  *
  * Type parameters are kept by reference (their identities matter), so their
  * constraints are not adjusted here; make sure constraints are inexact while
@@ -725,7 +760,7 @@ export const recursivelyInexact = (type: Type): Type =>
               recursivelyInexact(child),
             ]),
           ),
-          { exact: false },
+          { excess: isNothing(type.excess) ? something : type.excess },
         ),
       opaque: type => type,
       parameter: type => type,


### PR DESCRIPTION
Object types now enforce an allowed upper bound of excess property types, as a generalization of the exactness boolean. `exact: false` in the old encoding is now `excess: something`, and `exact: true` is now `excess: nothing`. Other constraints are now expressible in the type system (e.g. "an object whose property values are all atoms").

This moves things more in the direction of [row polymorphism](https://en.wikipedia.org/wiki/Row_polymorphism). It's also a bit like [index signatures](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures) in TypeScript.

There's currently no syntax for object types with custom `excess` constraints (it's an internal concept, like `exact` was), and unparsing still displays all object types as plain literals.