### PR TITLE
Generalize `ObjectType`'s `excess: Type` further

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -903,4 +903,12 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     }.0`,
     success('it works'),
   ],
+  [
+    `:match({ a: (v: :integer.type) => :v })({ tag: a, value: hello })`,
+    typeMismatch,
+  ],
+  [
+    `:match({ a: (v: :integer.type) => :v + 1 })({ tag: a, value: 41 })`,
+    success('42'),
+  ],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../semantics.js'
 import {
   inferType,
-  recursivelyInexact,
+  inferTypeOfTypeAnnotation,
 } from '../../../semantics/type-system.js'
 import { isSingletonType } from '../../../semantics/type-system/type-substitution.js'
 
@@ -42,24 +42,21 @@ const check = ({
     valueAsType =>
       either.flatMap(
         either.mapLeft(
-          inferType(type, subContextForType),
+          inferTypeOfTypeAnnotation(type, subContextForType),
           attachSpanIfAbsent(subContextForType),
         ),
-        typeAsType => {
-          // `@check` targets are upper bounds; they allow width subtyping.
-          const targetType = recursivelyInexact(typeAsType)
-          return isAssignable({ source: valueAsType, target: targetType }) ?
-              either.makeRight(value)
-              // The value is what failed the check, so blame it specifically.
-            : either.makeLeft(
-                attachSpanIfAbsent(subContextForValue)({
-                  kind: 'typeMismatch',
-                  message: `the value \`${stringifySemanticGraphForEndUser(
-                    value,
-                  )}\` ${isSingletonType(valueAsType) ? '' : `(inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) `}is not assignable to the type \`${stringifyTypeForEndUser(targetType)}\``,
-                }),
-              )
-        },
+        targetType =>
+          isAssignable({ source: valueAsType, target: targetType }) ?
+            either.makeRight(value)
+            // The value is what failed the check, so blame it specifically.
+          : either.makeLeft(
+              attachSpanIfAbsent(subContextForValue)({
+                kind: 'typeMismatch',
+                message: `the value \`${stringifySemanticGraphForEndUser(
+                  value,
+                )}\` ${isSingletonType(valueAsType) ? '' : `(inferred to have type \`${stringifyTypeForEndUser(valueAsType)}\`) `}is not assignable to the type \`${stringifyTypeForEndUser(targetType)}\``,
+              }),
+            ),
       ),
   )
 }

--- a/src/language/semantics/stdlib/atom.ts
+++ b/src/language/semantics/stdlib/atom.ts
@@ -3,8 +3,12 @@ import {
   objectNodeFromOrderedEntries,
   orderedEntriesOfObjectNode,
 } from '../object-node.js'
-import { types } from '../type-system.js'
-import { anyValue, atomParameter, objectParameter } from './parameters.js'
+import { makeObjectType, types } from '../type-system.js'
+import {
+  anyValue,
+  atomParameter,
+  objectOfAtomsParameter,
+} from './parameters.js'
 import { computeFromReturnType } from './return-type-refiners.js'
 import { preludeFunction } from './stdlib-utilities.js'
 
@@ -102,7 +106,7 @@ export const atom = {
 
   join: preludeFunction(
     ['atom', 'join'],
-    [atomParameter, objectParameter],
+    [atomParameter, objectOfAtomsParameter],
     types.atom,
     separator =>
       either.makeRight(list =>
@@ -125,7 +129,7 @@ export const atom = {
   split: preludeFunction(
     ['atom', 'split'],
     [atomParameter, atomParameter],
-    types.object,
+    makeObjectType({}, [{ keys: types.atom, values: types.atom }]),
     separator =>
       either.makeRight(subject =>
         either.makeRight(

--- a/src/language/semantics/stdlib/global-functions.ts
+++ b/src/language/semantics/stdlib/global-functions.ts
@@ -29,6 +29,7 @@ import {
   taggedParameter,
 } from './parameters.js'
 import {
+  applyValidatingParameterType,
   emptyContextForStdlibApplications,
   preludeFunction,
 } from './stdlib-utilities.js'
@@ -153,7 +154,7 @@ export const globalFunctions = {
             }),
           some: relevantCase =>
             isFunctionNode(relevantCase) ?
-              relevantCase(argument.value, emptyContextForStdlibApplications)
+              applyValidatingParameterType(relevantCase, argument.value)
             : either.makeRight(relevantCase),
         }),
       ),

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -14,7 +14,11 @@ import {
   unionOfTypes,
   type Type,
 } from '../type-system.js'
-import { asUnionWithLiteralAtomMembers } from '../type-system/subtyping.js'
+import {
+  asUnionWithLiteralAtomMembers,
+  effectiveExcessClauses,
+  excessBoundForKey,
+} from '../type-system/subtyping.js'
 import { anyValue, atomParameter, objectParameter } from './parameters.js'
 import { computeFromReturnType } from './return-type-refiners.js'
 import { preludeFunction } from './stdlib-utilities.js'
@@ -41,7 +45,9 @@ const computeFromPropertyReturnType = (
             ...keys.members
               .values()
               .map(key =>
-                makeObjectType({ [key]: valueType }, { excess: types.nothing }),
+                makeObjectType({ [key]: valueType }, [
+                  { keys: types.atom, values: types.nothing },
+                ]),
               ),
           ]),
       },
@@ -55,35 +61,50 @@ const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
     throw new Error(
       '`overlay` function did not receive two arguments. This is a bug!',
     )
+  } else if (object2Type.kind === 'object' && object1Type.kind === 'object') {
+    const object1Excess = effectiveExcessClauses(object1Type.excess)
+    const object2Excess = effectiveExcessClauses(object2Type.excess)
+    return makeObjectType(
+      {
+        ...Object.fromEntries(
+          Object.entries(object1Type.children)
+            .filter(([key]) => object2Type.children[key] === undefined)
+            .map(([key, child]) => {
+              const object2Bound = excessBoundForKey(key, object2Type.excess)
+              return [
+                key,
+                isBottomType(object2Bound) ? child
+                  // The property may exist unlisted in `object2`, in which case
+                  // its value overwrites `object1`'s.
+                : unionOfTypes([child, object2Bound]),
+              ]
+            }),
+        ),
+        ...object2Type.children,
+      },
+      // Unlisted properties of the result come from either operand's clauses.
+      // Which clause applies to which key isn't tracked here, so the result
+      // gets a single clause bounding every key, or stays fully open when
+      // either operand admits arbitrary values somewhere.
+      (
+        object1Excess.some(clause => clause.values === types.something) ||
+          object2Excess.some(clause => clause.values === types.something)
+      ) ?
+        []
+      : [
+          {
+            keys: types.atom,
+            values: unionOfTypes([
+              ...object1Excess.map(clause => clause.values),
+              ...object2Excess.map(clause => clause.values),
+            ]),
+          },
+        ],
+    )
   } else {
     // TODO: Consider also supporting type parameters/stuck types via their
     // upper bounds.
-    return object2Type.kind === 'object' && object1Type.kind === 'object' ?
-        makeObjectType(
-          {
-            ...Object.fromEntries(
-              Object.entries(object1Type.children)
-                .filter(([key]) => object2Type.children[key] === undefined)
-                .map(([key, child]) => [
-                  key,
-                  isBottomType(object2Type.excess) ? child
-                    // The property may exist as excess (with an unknown type).
-                  : types.something,
-                ]),
-            ),
-            ...object2Type.children,
-          },
-          {
-            excess:
-              (
-                isBottomType(object1Type.excess) &&
-                isBottomType(object2Type.excess)
-              ) ?
-                types.nothing
-              : types.something,
-          },
-        )
-      : types.object
+    return types.object
   }
 }
 
@@ -108,7 +129,7 @@ const lookupReturnType = ({
             tag: makeUnionType(['some']),
             value: unionOfTypes(possibleValueTypes),
           },
-          { excess: types.nothing },
+          [{ keys: types.atom, values: types.nothing }],
         ),
       ]),
     ...(mayBeNone ?
@@ -116,9 +137,11 @@ const lookupReturnType = ({
         makeObjectType(
           {
             tag: makeUnionType(['none']),
-            value: makeObjectType({}, { excess: types.nothing }),
+            value: makeObjectType({}, [
+              { keys: types.atom, values: types.nothing },
+            ]),
           },
-          { excess: types.nothing },
+          [{ keys: types.atom, values: types.nothing }],
         ),
       ]
     : []),
@@ -158,23 +181,45 @@ const computeLookupReturnType = (parameterTypes: readonly Type[]): Type => {
         })
         const someKeyMayBeAbsent =
           presentValueTypes.length !== possibleKeys.size
-        return someKeyMayBeAbsent && !isBottomType(objectType.excess) ?
-            // The key may exist as an excess property (with an unknown type).
+        const absentKeyBounds = [...possibleKeys]
+          .filter(key => objectType.children[key] === undefined)
+          .map(key => excessBoundForKey(key, objectType.excess))
+        return (
+          !someKeyMayBeAbsent ?
+            lookupReturnType({
+              possibleValueTypes: presentValueTypes,
+              mayBeNone: false,
+            })
+            // A key not among the children may exist as an unlisted property,
+            // whose value is bounded by the last clause matching the key.
+          : absentKeyBounds.some(bound => bound === types.something) ?
             types.option(types.something)
           : lookupReturnType({
-              possibleValueTypes: presentValueTypes,
-              mayBeNone: someKeyMayBeAbsent,
+              possibleValueTypes: [
+                ...presentValueTypes,
+                ...absentKeyBounds.filter(bound => !isBottomType(bound)),
+              ],
+              mayBeNone: true,
+            })
+        )
+      },
+      none: _ => {
+        // Whatever the key turns out to be, it can only select one of the
+        // object's own property values, an unlisted property's value (bounded
+        // by the object's excess clauses), or nothing.
+        const objectExcess = effectiveExcessClauses(objectType.excess)
+        return objectExcess.some(clause => clause.values === types.something) ?
+            types.option(types.something)
+          : lookupReturnType({
+              possibleValueTypes: [
+                ...Object.values(objectType.children),
+                ...objectExcess
+                  .map(clause => clause.values)
+                  .filter(clauseValues => !isBottomType(clauseValues)),
+              ],
+              mayBeNone: true,
             })
       },
-      none: _ =>
-        isBottomType(objectType.excess) ?
-          // Whatever the key turns out to be, it can only select one of the
-          // object's own property values (or nothing).
-          lookupReturnType({
-            possibleValueTypes: Object.values(objectType.children),
-            mayBeNone: true,
-          })
-        : types.option(types.something),
     })
   }
 }

--- a/src/language/semantics/stdlib/object.ts
+++ b/src/language/semantics/stdlib/object.ts
@@ -19,6 +19,7 @@ import {
   effectiveExcessClauses,
   excessBoundForKey,
 } from '../type-system/subtyping.js'
+import { replaceAllTypeParametersWithTheirConstraints } from '../type-system/type-substitution.js'
 import { anyValue, atomParameter, objectParameter } from './parameters.js'
 import { computeFromReturnType } from './return-type-refiners.js'
 import { preludeFunction } from './stdlib-utilities.js'
@@ -39,7 +40,10 @@ const computeFromPropertyReturnType = (
         asUnionWithLiteralAtomMembers(keyType)
       : option.none,
       {
-        none: _ => types.object,
+        // The key isn't statically known, but every property value is the
+        // supplied one.
+        none: _ =>
+          makeObjectType({}, [{ keys: types.atom, values: valueType }]),
         some: keys =>
           unionOfTypes([
             ...keys.members
@@ -56,7 +60,15 @@ const computeFromPropertyReturnType = (
 }
 
 const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
-  const [object2Type, object1Type] = parameterTypes
+  const [rawObject2Type, rawObject1Type] = parameterTypes
+  const object2Type =
+    rawObject2Type === undefined ? rawObject2Type : (
+      replaceAllTypeParametersWithTheirConstraints(rawObject2Type)
+    )
+  const object1Type =
+    rawObject1Type === undefined ? rawObject1Type : (
+      replaceAllTypeParametersWithTheirConstraints(rawObject1Type)
+    )
   if (object2Type === undefined || object1Type === undefined) {
     throw new Error(
       '`overlay` function did not receive two arguments. This is a bug!',
@@ -102,8 +114,6 @@ const computeOverlayReturnType = (parameterTypes: readonly Type[]): Type => {
         ],
     )
   } else {
-    // TODO: Consider also supporting type parameters/stuck types via their
-    // upper bounds.
     return types.object
   }
 }

--- a/src/language/semantics/stdlib/parameters.ts
+++ b/src/language/semantics/stdlib/parameters.ts
@@ -1,7 +1,11 @@
 import option, { type Option } from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
 import { isFunctionNode, type FunctionNode } from '../function-node.js'
-import { isObjectNode, type ObjectNode } from '../object-node.js'
+import {
+  isObjectNode,
+  orderedEntriesOfObjectNode,
+  type ObjectNode,
+} from '../object-node.js'
 import type { SemanticGraph } from '../semantic-graph.js'
 import {
   makeObjectType,
@@ -63,6 +67,20 @@ export const objectParameter: Parameter<ObjectNode> = {
   asExpected: value =>
     isObjectNode(value) ? option.makeSome(value) : option.none,
   expected: 'an object',
+}
+
+export const objectOfAtomsParameter: Parameter<ObjectNode> = {
+  type: makeObjectType({}, [{ keys: types.atom, values: types.atom }]),
+  asExpected: value =>
+    (
+      isObjectNode(value) &&
+      orderedEntriesOfObjectNode(value).every(
+        ([_key, value]) => typeof value === 'string',
+      )
+    ) ?
+      option.makeSome(value)
+    : option.none,
+  expected: 'an object whose property values are atoms',
 }
 
 export const booleanParameter: Parameter<BooleanNode> = {

--- a/src/language/semantics/stdlib/parameters.ts
+++ b/src/language/semantics/stdlib/parameters.ts
@@ -113,13 +113,10 @@ export const optionParameter = (
 })
 
 export const taggedParameter: Parameter<TaggedNode> = {
-  type: makeObjectType(
-    {
-      tag: types.atom,
-      value: types.something,
-    },
-    { excess: types.something },
-  ),
+  type: makeObjectType({
+    tag: types.atom,
+    value: types.something,
+  }),
   asExpected: value =>
     nodeIsTagged(value) ? option.makeSome(value) : option.none,
   expected: 'a tagged value',

--- a/src/language/semantics/stdlib/return-type-refiners.ts
+++ b/src/language/semantics/stdlib/return-type-refiners.ts
@@ -60,10 +60,7 @@ export const computeFromReturnType =
       )
     } else {
       return isAssignable({ source: argumentType, target: elementType }) ?
-          makeObjectType(
-            { tag: makeUnionType(['some']), value: argumentType },
-            { excess: types.something },
-          )
+          makeObjectType({ tag: makeUnionType(['some']), value: argumentType })
         : optionType(elementType)
     }
   }

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -19,6 +19,8 @@ import type { ObjectNode } from '../object-node.js'
 import { nodeTag } from '../semantic-graph-node-tag.js'
 import {
   containsAnyUnelaboratedNodes,
+  stringifySemanticGraphForEndUser,
+  stringifyTypeForEndUser,
   type SemanticGraph,
 } from '../semantic-graph.js'
 import {
@@ -29,9 +31,11 @@ import {
   type Type,
 } from '../type-system.js'
 import { typeFromSemanticGraph } from '../type-system/literal-type.js'
+import { isAssignable } from '../type-system/subtyping.js'
 import { containedTypeParameters } from '../type-system/type-parameter-analysis.js'
 import {
   getTypesForTypeParameters,
+  replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArguments,
 } from '../type-system/type-substitution.js'
 import type {
@@ -52,6 +56,34 @@ const handleUnavailableDependencies =
       return f(argument, emptyContextForStdlibApplications)
     }
   }
+
+/**
+ * Validate an `argument` against the parameter type of a `functionNode`'s
+ * signature, then apply it if valid. Applications occurring from the standard
+ * library don't get the normal `@apply` static analysis, so use this instead.
+ */
+export const applyValidatingParameterType = (
+  functionNode: FunctionNode,
+  argument: SemanticGraph,
+): Either<FunctionNodeCallError, SemanticGraph> =>
+  either.flatMap(
+    typeFromSemanticGraph(argument, { objectsAreExact: true }),
+    argumentType => {
+      // Values are never directly assignable to (rigid) type parameters, so
+      // validate against the parameter's bound instead.
+      const parameterBound = replaceAllTypeParametersWithTheirConstraints(
+        functionNode.signature.parameter,
+      )
+      return isAssignable({ source: argumentType, target: parameterBound }) ?
+          functionNode(argument, emptyContextForStdlibApplications)
+        : either.makeLeft({
+            kind: 'typeMismatch',
+            message: `the value \`${stringifySemanticGraphForEndUser(
+              argument,
+            )}\` is not assignable to the function's parameter type \`${stringifyTypeForEndUser(parameterBound)}\``,
+          })
+    },
+  )
 
 /**
  * Use with function calls from the standard library (which conceptually occur

--- a/src/language/semantics/type-system.ts
+++ b/src/language/semantics/type-system.ts
@@ -13,6 +13,7 @@ export * from './type-system/type-formats/type.js'
 export * from './type-system/type-formats/union-type.js'
 export {
   inferType,
+  inferTypeOfTypeAnnotation,
   resolveParameterTypes,
   rigidTypeParameterIdentities,
 } from './type-system/type-inference.js'
@@ -34,7 +35,6 @@ export {
   applicableFunctionSignatures,
   applyKeyPathToType,
   getTypesForTypeParameters,
-  recursivelyInexact,
   replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArgument,
   supplyTypeArguments,

--- a/src/language/semantics/type-system/genericize-function-parameter.ts
+++ b/src/language/semantics/type-system/genericize-function-parameter.ts
@@ -1,5 +1,4 @@
 import type { Atom } from '../../parsing.js'
-import { something } from './prelude-types.js'
 import { makeFunctionType } from './type-formats/function-type.js'
 import { matchTypeFormat } from './type-formats/match-type-format.js'
 import { makeObjectType } from './type-formats/object-type.js'
@@ -11,7 +10,6 @@ import {
   stringifyTypeKeyPathForEndUser,
   type TypeKeyPath,
 } from './type-key-path.js'
-import { recursivelyInexact } from './type-substitution.js'
 
 export type GenericizedFunctionParameterAnnotation = {
   readonly type: Type
@@ -93,13 +91,11 @@ const genericizeFunctionParameterAnnotationAtKeyPath = (
             ] as const,
         )
         return {
-          // The annotation is an upper bound, so the rebuilt object admits
-          // arbitrary excess properties unconditionally.
           type: makeObjectType(
             Object.fromEntries(
               children.map(([key, child]) => [key, child.type]),
             ),
-            { excess: something },
+            type.excess,
           ),
           typeParametersBoundByFunction: new Set(
             children.flatMap(([_key, child]) => [
@@ -126,10 +122,7 @@ const genericizeLeaf =
   (leafType: Type): GenericizedFunctionParameterAnnotation => {
     const typeParameter = makeTypeParameter(
       synthesizeTypeParameterName(parameterName, keyPath),
-      {
-        // The constraint is an upper bound, so it can't be exact.
-        assignableTo: recursivelyInexact(leafType),
-      },
+      { assignableTo: leafType },
     )
     return {
       type: typeParameter,

--- a/src/language/semantics/type-system/literal-type.ts
+++ b/src/language/semantics/type-system/literal-type.ts
@@ -6,10 +6,11 @@ import {
 } from '../expressions/hole-expression.js'
 import { readUnionExpression } from '../expressions/union-expression.js'
 import type { SemanticGraph } from '../semantic-graph.js'
-import { nothing, something, typesBySymbol } from './prelude-types.js'
+import { atom, nothing, typesBySymbol } from './prelude-types.js'
 import { makeObjectType } from './type-formats/object-type.js'
 import type { Type } from './type-formats/type.js'
 import { unionOfTypes } from './type-formats/union-type.js'
+
 /**
  * Attempt to interpret `node` as a `Type` in a very basic way:
  * - `Atom`s become singleton `UnionType`s.
@@ -75,9 +76,12 @@ export const typeFromSemanticGraph = (
                 ),
               ),
               entries =>
-                makeObjectType(Object.fromEntries(entries), {
-                  excess: options.objectsAreExact ? nothing : something,
-                }),
+                makeObjectType(
+                  Object.fromEntries(entries),
+                  options.objectsAreExact ?
+                    [{ keys: atom, values: nothing }]
+                  : [],
+                ),
             ),
         ),
     })

--- a/src/language/semantics/type-system/prelude-types/transparent-types.ts
+++ b/src/language/semantics/type-system/prelude-types/transparent-types.ts
@@ -1,3 +1,4 @@
+import type { Atom } from '../../../parsing.js'
 import { somethingTypeSymbol } from '../prelude-types.js'
 import {
   makeFunctionType,
@@ -16,12 +17,12 @@ export const nullType = makeUnionType(['null'])
 
 export const boolean = makeUnionType(['false', 'true'])
 
-// `functionType`, `object`, and `something` reference each other directly, so
-// we need to do a dance.
+export const object: ObjectType = makeObjectType({})
+
+// `functionType` and `something` reference each other directly, so we need to
+// do a dance.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 export const functionType = {} as FunctionType
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-export const object = {} as ObjectType
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
 export const something = {} as UnionType & {
   readonly identity: typeof somethingTypeSymbol
@@ -34,51 +35,36 @@ Object.assign(
   }) satisfies FunctionType,
 )
 Object.assign(
-  object,
-  makeObjectType({}, { excess: something }) satisfies ObjectType,
-)
-Object.assign(
   something,
   makeUnionType([functionType, atom, object]) satisfies UnionType,
   { identity: somethingTypeSymbol },
 )
 
+const makeExactObjectType = <Children extends Readonly<Record<Atom, Type>>>(
+  children: Children,
+) => makeObjectType(children, [{ keys: atom, values: nothing }])
+
 export const option = (value: Type) =>
   makeUnionType([
-    makeObjectType(
-      {
-        tag: makeUnionType(['some']),
-        value,
-      },
-      { excess: nothing },
-    ),
-    makeObjectType(
-      {
-        tag: makeUnionType(['none']),
-        value: makeObjectType({}, { excess: nothing }),
-      },
-      { excess: nothing },
-    ),
+    makeExactObjectType({
+      tag: makeUnionType(['some']),
+      value,
+    }),
+    makeExactObjectType({
+      tag: makeUnionType(['none']),
+      value: makeExactObjectType({}),
+    }),
   ])
 
 const A = makeTypeParameter('a', { assignableTo: something })
 
-export const runtimeContext = makeObjectType(
-  {
-    arguments: makeObjectType(
-      {
-        lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
-      },
-      { excess: nothing },
-    ),
-    environment: makeObjectType(
-      {
-        lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
-      },
-      { excess: nothing },
-    ),
-    log: makeFunctionType({ parameter: A, return: A }),
-    program: makeObjectType({ start_time: atom }, { excess: nothing }),
-  },
-  { excess: nothing },
-)
+export const runtimeContext = makeExactObjectType({
+  arguments: makeExactObjectType({
+    lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
+  }),
+  environment: makeExactObjectType({
+    lookup: makeFunctionType({ parameter: atom, return: option(atom) }),
+  }),
+  log: makeFunctionType({ parameter: A, return: A }),
+  program: makeExactObjectType({ start_time: atom }),
+})

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -30,6 +30,8 @@ const typeAssignabilitySuite = testCases(
     `assignability of \`${stringifyTypeForEndUser(source)}\` to \`${stringifyTypeForEndUser(target)}\``,
 )
 
+const exactEmptyObject = makeObjectType({}, [{ keys: atom, values: nothing }])
+
 const A = makeTypeParameter('a', { assignableTo: something })
 const B = makeTypeParameter('b', { assignableTo: something })
 const C = makeTypeParameter('c', { assignableTo: something })
@@ -58,13 +60,10 @@ const extendsExtendsAnyAtom = makeTypeParameter('u', {
 })
 
 const indexedAccessBoolean = makeIndexedAccessType(
-  makeObjectType(
-    {
-      a: makeUnionType(['true']),
-      b: makeUnionType(['false']),
-    },
-    { excess: something },
-  ),
+  makeObjectType({
+    a: makeUnionType(['true']),
+    b: makeUnionType(['false']),
+  }),
   makeTypeParameter('key', {
     assignableTo: makeUnionType(['a', 'b']),
   }),
@@ -108,33 +107,28 @@ testCases(
     makeUnionType([
       'a',
       atom,
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
-      makeObjectType(
-        {
-          a: makeUnionType(['b']),
-        },
-        { excess: something },
-      ),
-      makeObjectType(
-        {
-          a: makeUnionType(['c']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+      }),
+      makeObjectType({
+        a: makeUnionType(['b']),
+      }),
+      makeObjectType({
+        a: makeUnionType(['c']),
+      }),
     ]),
     ':atom.type | { a: a | b | c }',
   ],
   [
     // Members whose excess bounds disagree must not merge with each other.
     makeUnionType([
-      makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
-      makeObjectType({ a: makeUnionType(['b']) }, { excess: nothing }),
-      makeObjectType({ a: makeUnionType(['c']) }, { excess: something }),
+      makeObjectType({ a: makeUnionType(['a']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({ a: makeUnionType(['b']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({ a: makeUnionType(['c']) }),
     ]),
     '{ a: a | b } | { a: c }',
   ],
@@ -317,58 +311,40 @@ typeAssignabilitySuite('custom types (assignable)', [
   [[makeUnionType(['0', '-1']), integer], true],
   [
     [
-      makeObjectType(
-        {
-          a: makeUnionType(['a']),
-          b: object,
-        },
-        { excess: something },
-      ),
-      makeObjectType(
-        {
-          a: atom,
-          b: object,
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a']),
+        b: object,
+      }),
+      makeObjectType({
+        a: atom,
+        b: object,
+      }),
     ],
     true,
   ],
   [
     [
-      makeObjectType(
-        {
-          a: makeUnionType(['a']),
-          b: makeObjectType({ c: boolean }, { excess: something }),
-          c: nullType,
-        },
-        { excess: something },
-      ),
-      makeObjectType(
-        {
-          a: atom,
-          b: object,
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a']),
+        b: makeObjectType({ c: boolean }),
+        c: nullType,
+      }),
+      makeObjectType({
+        a: atom,
+        b: object,
+      }),
     ],
     true,
   ],
   [
     [
-      makeObjectType(
-        {
-          a: makeUnionType(['a']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a']),
+      }),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
       ]),
     ],
     true,
@@ -376,19 +352,13 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-      ]),
-      makeObjectType(
-        {
+        makeObjectType({
           a: makeUnionType(['a']),
-        },
-        { excess: something },
-      ),
+        }),
+      ]),
+      makeObjectType({
+        a: makeUnionType(['a']),
+      }),
     ],
     true,
   ],
@@ -396,25 +366,16 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b }` is assignable to `{ a: a | b }`
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+        }),
       ]),
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+      }),
     ],
     true,
   ],
@@ -422,25 +383,16 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b }` is assignable to `{ a: a | b | c }`
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+        }),
       ]),
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b', 'c']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b', 'c']),
+      }),
     ],
     true,
   ],
@@ -448,28 +400,19 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a, b: a } | { a: b, b: b }` is assignable to `{ a: a | b, b: a | b }`
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-            b: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-            b: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+          b: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['b']),
+        }),
       ]),
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-          b: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['a', 'b']),
+      }),
     ],
     true,
   ],
@@ -477,27 +420,18 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b } | c` is assignable to `{ a: a | b } | c`
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+        }),
         'c',
       ]),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a', 'b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a', 'b']),
+        }),
         'c',
       ]),
     ],
@@ -506,25 +440,16 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b }` is assignable to `{ a: a } | { a: b }`
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+      }),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+        }),
       ]),
     ],
     true,
@@ -532,31 +457,19 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b }` is assignable to `{ a: a } | { a: b } | { a: c }`
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+      }),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['c']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['c']),
+        }),
       ]),
     ],
     true,
@@ -564,36 +477,21 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: { a: a | b } }` is assignable to `{ a: { a: a } | { a: b } }`
-      makeObjectType(
-        {
-          a: makeObjectType(
-            {
-              a: makeUnionType(['a', 'b']),
-            },
-            { excess: something },
-          ),
-        },
-        { excess: something },
-      ),
-      makeObjectType(
-        {
-          a: makeUnionType([
-            makeObjectType(
-              {
-                a: makeUnionType(['a']),
-              },
-              { excess: something },
-            ),
-            makeObjectType(
-              {
-                a: makeUnionType(['b']),
-              },
-              { excess: something },
-            ),
-          ]),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeObjectType({
+          a: makeUnionType(['a', 'b']),
+        }),
+      }),
+      makeObjectType({
+        a: makeUnionType([
+          makeObjectType({
+            a: makeUnionType(['a']),
+          }),
+          makeObjectType({
+            a: makeUnionType(['b']),
+          }),
+        ]),
+      }),
     ],
     true,
   ],
@@ -601,21 +499,15 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b, b: c }` is assignable to `{ a: a | b }`
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-            b: makeUnionType(['c']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({ a: makeUnionType(['a']) }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['c']),
+        }),
       ]),
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+      }),
     ],
     true,
   ],
@@ -623,27 +515,18 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a | b } | c` is assignable to `{ a: a } | { a: b } | c`
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a', 'b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a', 'b']),
+        }),
         'c',
       ]),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+        }),
         'c',
       ]),
     ],
@@ -652,18 +535,15 @@ typeAssignabilitySuite('custom types (assignable)', [
   [
     [
       // `{ a: a | b } | { b: a | b }` is assignable to `{ a: a } | { a: b } | { b: a } | { b: b }`
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-          b: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['a', 'b']),
+      }),
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
-        makeObjectType({ a: makeUnionType(['b']) }, { excess: something }),
-        makeObjectType({ b: makeUnionType(['a']) }, { excess: something }),
-        makeObjectType({ b: makeUnionType(['b']) }, { excess: something }),
+        makeObjectType({ a: makeUnionType(['a']) }),
+        makeObjectType({ a: makeUnionType(['b']) }),
+        makeObjectType({ b: makeUnionType(['a']) }),
+        makeObjectType({ b: makeUnionType(['b']) }),
       ]),
     ],
     true,
@@ -672,24 +552,18 @@ typeAssignabilitySuite('custom types (assignable)', [
     [
       // `{ a: a } | { a: b } | { b: a } | { b: b }` is assignable to `{ a: a | b } | { b: a | b }`
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
-        makeObjectType({ a: makeUnionType(['b']) }, { excess: something }),
-        makeObjectType({ b: makeUnionType(['a']) }, { excess: something }),
-        makeObjectType({ b: makeUnionType(['b']) }, { excess: something }),
+        makeObjectType({ a: makeUnionType(['a']) }),
+        makeObjectType({ a: makeUnionType(['b']) }),
+        makeObjectType({ b: makeUnionType(['a']) }),
+        makeObjectType({ b: makeUnionType(['b']) }),
       ]),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a', 'b']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            b: makeUnionType(['a', 'b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a', 'b']),
+        }),
+        makeObjectType({
+          b: makeUnionType(['a', 'b']),
+        }),
       ]),
     ],
     true,
@@ -783,18 +657,14 @@ typeAssignabilitySuite('custom types (assignable)', [
     ],
     true,
   ],
-  [
-    [
-      makeObjectType({}, { excess: nothing }),
-      makeObjectType({}, { excess: nothing }),
-    ],
-    true,
-  ],
+  [[exactEmptyObject, exactEmptyObject], true],
   [
     [
       // Closed object types are assignable to open ones.
-      makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
-      makeObjectType({}, { excess: something }),
+      makeObjectType({ a: makeUnionType(['a']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({}),
     ],
     true,
   ],
@@ -806,13 +676,13 @@ typeAssignabilitySuite('custom types (assignable)', [
   //     makeObjectType({
   //       a: makeUnionType(['a', 'b']),
   //       b: makeUnionType(['c']),
-  //     }, { excess: something }),
+  //     }, []),
   //     makeUnionType([
-  //       makeObjectType({ a: makeUnionType(['a']) }, { excess: something }),
+  //       makeObjectType({ a: makeUnionType(['a']) }),
   //       makeObjectType({
   //         a: makeUnionType(['b']),
   //         b: makeUnionType(['c']),
-  //       }, { excess: something }),
+  //       }, []),
   //     ]),
   //   ],
   //   true,
@@ -825,20 +695,17 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [[makeUnionType(['-0']), integer], false],
   [
     [
-      makeObjectType(
-        {
-          a: atom,
-          b: object,
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: atom,
+        b: object,
+      }),
       makeObjectType(
         {
           a: atom,
           b: object,
           c: boolean, // required property in target not present in source
         },
-        { excess: something },
+        [],
       ),
     ],
     false,
@@ -846,28 +713,19 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // `{ a: a | b, b: a | b }` is not assignable to `{ a: a, b: a } | { a: b, b: b }`
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
-          b: makeUnionType(['a', 'b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['a', 'b']),
+      }),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-            b: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-            b: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+          b: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
+          b: makeUnionType(['b']),
+        }),
       ]),
     ],
     false,
@@ -875,28 +733,19 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // `{ a: a, b: b }` is not assignable to `{ a: a, b: z } | { b: b, a: z }`
-      makeObjectType(
-        {
-          a: makeUnionType(['a']),
-          b: makeUnionType(['b']),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeUnionType(['a']),
+        b: makeUnionType(['b']),
+      }),
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-            b: makeUnionType(['z']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['z']),
-            b: makeUnionType(['b']),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeUnionType(['a']),
+          b: makeUnionType(['z']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['z']),
+          b: makeUnionType(['b']),
+        }),
       ]),
     ],
     false,
@@ -905,27 +754,18 @@ typeAssignabilitySuite('custom types (not assignable)', [
     [
       // `{ a: a } | { a: b, b: c }` is not assignable to `{ a: a | b, b: c }`
       makeUnionType([
-        makeObjectType(
-          {
-            a: makeUnionType(['a']),
-          },
-          { excess: something },
-        ),
-        makeObjectType(
-          {
-            a: makeUnionType(['b']),
-            b: makeUnionType(['c']),
-          },
-          { excess: something },
-        ),
-      ]),
-      makeObjectType(
-        {
-          a: makeUnionType(['a', 'b']),
+        makeObjectType({
+          a: makeUnionType(['a']),
+        }),
+        makeObjectType({
+          a: makeUnionType(['b']),
           b: makeUnionType(['c']),
-        },
-        { excess: something },
-      ),
+        }),
+      ]),
+      makeObjectType({
+        a: makeUnionType(['a', 'b']),
+        b: makeUnionType(['c']),
+      }),
     ],
     false,
   ],
@@ -995,8 +835,8 @@ typeAssignabilitySuite('custom types (not assignable)', [
   [
     [
       // Open object types aren't assignable to closed ones.
-      makeObjectType({}, { excess: something }),
-      makeObjectType({}, { excess: nothing }),
+      makeObjectType({}),
+      exactEmptyObject,
     ],
     false,
   ],
@@ -1005,10 +845,15 @@ typeAssignabilitySuite('custom types (not assignable)', [
       // Closed objects with extra properties aren't assignable to closed
       // objects lacking them.
       makeObjectType(
-        { a: makeUnionType(['a']), b: makeUnionType(['b']) },
-        { excess: nothing },
+        {
+          a: makeUnionType(['a']),
+          b: makeUnionType(['b']),
+        },
+        [{ keys: atom, values: nothing }],
       ),
-      makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
+      makeObjectType({ a: makeUnionType(['a']) }, [
+        { keys: atom, values: nothing },
+      ]),
     ],
     false,
   ],
@@ -1016,66 +861,275 @@ typeAssignabilitySuite('custom types (not assignable)', [
     [
       // Similar to above, but with unions in the mix.
       makeObjectType(
-        { a: makeUnionType(['a']), b: makeUnionType(['b']) },
-        { excess: nothing },
+        {
+          a: makeUnionType(['a']),
+          b: makeUnionType(['b']),
+        },
+        [{ keys: atom, values: nothing }],
       ),
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['a']) }, { excess: nothing }),
-        makeObjectType({ b: makeUnionType(['b']) }, { excess: nothing }),
+        makeObjectType({ a: makeUnionType(['a']) }, [
+          { keys: atom, values: nothing },
+        ]),
+        makeObjectType({ b: makeUnionType(['b']) }, [
+          { keys: atom, values: nothing },
+        ]),
       ]),
     ],
     false,
   ],
 ])
 
-typeAssignabilitySuite('bounded-excess object types', [
+typeAssignabilitySuite('excess clauses (default clause only)', [
   [
     [
       makeObjectType(
-        { a: makeUnionType(['a']), b: makeUnionType(['b']) },
-        { excess: nothing },
+        {
+          a: makeUnionType(['a']),
+          b: makeUnionType(['b']),
+        },
+        [{ keys: atom, values: nothing }],
       ),
-      makeObjectType({ a: makeUnionType(['a']) }, { excess: atom }),
+      makeObjectType({ a: makeUnionType(['a']) }, [
+        { keys: atom, values: atom },
+      ]),
     ],
     true,
   ],
   [
     [
-      makeObjectType(
-        { a: makeUnionType(['a']), b: object },
-        { excess: nothing },
-      ),
-      makeObjectType({ a: makeUnionType(['a']) }, { excess: atom }),
+      makeObjectType({ a: makeUnionType(['a']), b: object }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({ a: makeUnionType(['a']) }, [
+        { keys: atom, values: atom },
+      ]),
     ],
     false,
   ],
   [
     [
-      makeObjectType({}, { excess: naturalNumber }),
-      makeObjectType({}, { excess: integer }),
+      makeObjectType({}, [{ keys: atom, values: naturalNumber }]),
+      makeObjectType({}, [{ keys: atom, values: integer }]),
     ],
     true,
   ],
   [
     [
-      makeObjectType({}, { excess: atom }),
-      makeObjectType({}, { excess: naturalNumber }),
+      makeObjectType({}, [{ keys: atom, values: atom }]),
+      makeObjectType({}, [{ keys: atom, values: naturalNumber }]),
     ],
     false,
   ],
-  [[object, makeObjectType({}, { excess: atom })], false],
-  [[makeObjectType({}, { excess: atom }), object], true],
+  [[object, makeObjectType({}, [{ keys: atom, values: atom }])], false],
+  [[makeObjectType({}, [{ keys: atom, values: atom }]), object], true],
+  [
+    [exactEmptyObject, makeObjectType({}, [{ keys: atom, values: atom }])],
+    true,
+  ],
   [
     [
-      makeObjectType({}, { excess: nothing }),
-      makeObjectType({}, { excess: atom }),
+      makeObjectType({}, [{ keys: atom, values: atom }]),
+      makeObjectType({ a: atom }),
+    ],
+    false,
+  ],
+])
+
+typeAssignabilitySuite('excess clauses', [
+  [
+    [
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: naturalNumber, values: naturalNumber },
+      ]),
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: naturalNumber, values: integer },
+      ]),
     ],
     true,
   ],
   [
     [
-      makeObjectType({}, { excess: atom }),
-      makeObjectType({ a: atom }, { excess: something }),
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: integer, values: integer },
+        { keys: naturalNumber, values: integer },
+      ]),
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: integer, values: integer },
+      ]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({}, [{ keys: naturalNumber, values: naturalNumber }]),
+      makeObjectType({}),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: naturalNumber, values: naturalNumber },
+      ]),
+      makeObjectType({}, [{ keys: atom, values: atom }]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({}),
+      makeObjectType({}, [{ keys: naturalNumber, values: atom }]),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({}, [{ keys: atom, values: atom }]),
+      makeObjectType({}, [
+        { keys: atom, values: atom },
+        { keys: naturalNumber, values: integer },
+      ]),
+    ],
+    false,
+  ],
+  [
+    [
+      exactEmptyObject,
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: naturalNumber, values: atom },
+      ]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({ 5: integer }, [{ keys: atom, values: nothing }]),
+      makeObjectType({}, [
+        { keys: atom, values: nothing },
+        { keys: naturalNumber, values: integer },
+      ]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({ 5: atom }, [{ keys: atom, values: nothing }]),
+      makeObjectType({}, [{ keys: naturalNumber, values: integer }]),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({}),
+      makeObjectType({}, [{ keys: atom, values: something }]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({}, [{ keys: atom, values: something }]),
+      makeObjectType({}),
+    ],
+    true,
+  ],
+  [
+    [makeObjectType({}), makeObjectType({}, [{ keys: atom, values: atom }])],
+    false,
+  ],
+  [
+    [
+      makeObjectType({ c: atom }, [{ keys: atom, values: nothing }]),
+      makeObjectType({}, [
+        { keys: makeUnionType(['a', 'b']), values: nothing },
+      ]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({ a: atom }, [{ keys: atom, values: nothing }]),
+      makeObjectType({}, [
+        { keys: makeUnionType(['a', 'b']), values: nothing },
+      ]),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({}, [
+        { keys: makeUnionType(['a', 'b']), values: nothing },
+      ]),
+      exactEmptyObject,
+    ],
+    false,
+  ],
+  // Overlapping clauses: a key inhabiting several domains is bounded by the
+  // last matching clause, not an earlier more-permissive one.
+  [
+    [
+      makeObjectType({ a: makeUnionType(['hello']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({}, [
+        { keys: atom, values: atom },
+        { keys: makeUnionType(['a', 'b']), values: integer },
+      ]),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({ c: makeUnionType(['hello']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({}, [
+        { keys: atom, values: atom },
+        { keys: makeUnionType(['a', 'b']), values: integer },
+      ]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType({ a: makeUnionType(['hello']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({ a: atom }, [
+        { keys: makeUnionType(['a', 'b']), values: nothing },
+      ]),
+    ],
+    true,
+  ],
+  [
+    [
+      makeObjectType(
+        {
+          a: makeUnionType(['hello']),
+          b: makeUnionType(['x']),
+        },
+        [{ keys: atom, values: nothing }],
+      ),
+      makeObjectType({ a: atom }, [
+        { keys: makeUnionType(['a', 'b']), values: nothing },
+      ]),
+    ],
+    false,
+  ],
+  [
+    [
+      makeObjectType({ a: makeUnionType(['hello']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({ a: integer }, [
+        { keys: makeUnionType(['a']), values: atom },
+      ]),
     ],
     false,
   ],
@@ -1143,7 +1197,7 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> :something.type`
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({ a: extendsAnyAtom }, { excess: something }),
+        return: makeObjectType({ a: extendsAnyAtom }),
       }),
       makeFunctionType({
         parameter: atom,
@@ -1157,17 +1211,14 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `?a ~> { a: :a, b: :atom.type }` is assignable to `(?a: :atom.type) ~> { a: a }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType(
-          {
-            a: A,
-            b: atom,
-          },
-          { excess: something },
-        ),
+        return: makeObjectType({
+          a: A,
+          b: atom,
+        }),
       }),
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({ a: extendsAnyAtom }, { excess: something }),
+        return: makeObjectType({ a: extendsAnyAtom }),
       }),
     ],
     true,
@@ -1177,11 +1228,11 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `(?a: :atom.type) ~> { a: :a }` is assignable to `:atom.type ~> { a: :atom.type }`
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType({ a: extendsAnyAtom }, { excess: something }),
+        return: makeObjectType({ a: extendsAnyAtom }),
       }),
       makeFunctionType({
         parameter: atom,
-        return: makeObjectType({ a: atom }, { excess: something }),
+        return: makeObjectType({ a: atom }),
       }),
     ],
     true,
@@ -1190,21 +1241,15 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ a: ?a } ~> :a` is assignable to `{ a: (?a: :atom.type) } ~> :a`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: A,
+        }),
         return: A,
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: extendsAnyAtom,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: extendsAnyAtom,
+        }),
         return: extendsAnyAtom,
       }),
     ],
@@ -1214,32 +1259,20 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ a: a } ~> { b: a }` is assignable to `{ a: (?a: :atom.type) } ~> { b: a }`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: A,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            b: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: A,
+        }),
+        return: makeObjectType({
+          b: A,
+        }),
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: extendsAnyAtom,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            b: extendsAnyAtom,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: extendsAnyAtom,
+        }),
+        return: makeObjectType({
+          b: extendsAnyAtom,
+        }),
       }),
     ],
     true,
@@ -1298,23 +1331,17 @@ typeAssignabilitySuite('generic function types (assignable)', [
       // `?a ~> { 0: :a, 1: :a }` is assignable to `(?a: :atom.type) ~> { 0: :a, 1: :atom.type }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType(
-          {
-            0: A,
-            1: A,
-          },
-          { excess: something },
-        ),
+        return: makeObjectType({
+          0: A,
+          1: A,
+        }),
       }),
       makeFunctionType({
         parameter: extendsAnyAtom,
-        return: makeObjectType(
-          {
-            0: extendsAnyAtom,
-            1: atom,
-          },
-          { excess: something },
-        ),
+        return: makeObjectType({
+          0: extendsAnyAtom,
+          1: atom,
+        }),
       }),
     ],
     true,
@@ -1323,36 +1350,24 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: A,
-            1: B,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: B,
-            1: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: A,
+          1: B,
+        }),
+        return: makeObjectType({
+          0: B,
+          1: A,
+        }),
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: C,
-            1: D,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: D,
-            1: C,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: C,
+          1: D,
+        }),
+        return: makeObjectType({
+          0: D,
+          1: C,
+        }),
       }),
     ],
     true,
@@ -1361,36 +1376,24 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }` is assignable to `{ 0: (?a: :atom.type), 1: (?b: a) } ~> { 0: :b, 1: ?a }`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: A,
-            1: B,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: B,
-            1: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: A,
+          1: B,
+        }),
+        return: makeObjectType({
+          0: B,
+          1: A,
+        }),
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: extendsAnyAtom,
-            1: extendsSpecificAtom,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: extendsSpecificAtom,
-            1: extendsAnyAtom,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: extendsAnyAtom,
+          1: extendsSpecificAtom,
+        }),
+        return: makeObjectType({
+          0: extendsSpecificAtom,
+          1: extendsAnyAtom,
+        }),
       }),
     ],
     true,
@@ -1399,36 +1402,24 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ 0: ?a, 1: ?b } ~> { 0: ?b, 1: ?a }` is assignable to `{ 0: ?a, 1: (?b: :a) } ~> { 0: :b, 1: :a }`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: B,
-            1: C,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: C,
-            1: B,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: B,
+          1: C,
+        }),
+        return: makeObjectType({
+          0: C,
+          1: B,
+        }),
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: A,
-            1: extendsA,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: extendsA,
-            1: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: A,
+          1: extendsA,
+        }),
+        return: makeObjectType({
+          0: extendsA,
+          1: A,
+        }),
       }),
     ],
     true,
@@ -1437,40 +1428,28 @@ typeAssignabilitySuite('generic function types (assignable)', [
     [
       // `{ a: ?a, b: ?b, c: :atom.type | :b } ~> { b: :a, a: :b, c: :a }` is assignable to `{ a: (?a: :atom.type), b: (?b: :a), c: :b } ~> { b: :a, a: :b | :a, c: :atom.type }`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: A,
-            b: B,
-            c: makeUnionType([atom, B]),
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            b: A,
-            a: B,
-            c: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: A,
+          b: B,
+          c: makeUnionType([atom, B]),
+        }),
+        return: makeObjectType({
+          b: A,
+          a: B,
+          c: A,
+        }),
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: extendsAnyAtom,
-            b: extendsExtendsAnyAtom,
-            c: extendsExtendsAnyAtom,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            b: extendsAnyAtom,
-            a: makeUnionType([extendsAnyAtom, extendsExtendsAnyAtom]),
-            c: atom,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: extendsAnyAtom,
+          b: extendsExtendsAnyAtom,
+          c: extendsExtendsAnyAtom,
+        }),
+        return: makeObjectType({
+          b: extendsAnyAtom,
+          a: makeUnionType([extendsAnyAtom, extendsExtendsAnyAtom]),
+          c: atom,
+        }),
       }),
     ],
     true,
@@ -1539,11 +1518,11 @@ typeAssignabilitySuite('generic function types (not assignable)', [
       // `?a ~> { a: :a }` is not assignable to `?a ~> { b: :a }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({ a: A }, { excess: something }),
+        return: makeObjectType({ a: A }),
       }),
       makeFunctionType({
         parameter: A,
-        return: makeObjectType({ b: A }, { excess: something }),
+        return: makeObjectType({ b: A }),
       }),
     ],
     false,
@@ -1566,36 +1545,24 @@ typeAssignabilitySuite('generic function types (not assignable)', [
     [
       // `{ 0: ?a, 1: (?b: :a) } ~> { 0: :b, 1: :a }` is not assignable to `{ 0: ?a, 1: ?b } ~> { 0: :b, 1: :a }`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: A,
-            1: extendsA,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: extendsA,
-            1: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: A,
+          1: extendsA,
+        }),
+        return: makeObjectType({
+          0: extendsA,
+          1: A,
+        }),
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            0: A,
-            1: B,
-          },
-          { excess: something },
-        ),
-        return: makeObjectType(
-          {
-            0: B,
-            1: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          0: A,
+          1: B,
+        }),
+        return: makeObjectType({
+          0: B,
+          1: A,
+        }),
       }),
     ],
     false,
@@ -1635,21 +1602,15 @@ typeAssignabilitySuite('generic function types (not assignable)', [
     [
       // `{ a: ?a } ~> :a` is not assignable to `{ b: ?a } ~> :a`
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            a: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          a: A,
+        }),
         return: A,
       }),
       makeFunctionType({
-        parameter: makeObjectType(
-          {
-            b: A,
-          },
-          { excess: something },
-        ),
+        parameter: makeObjectType({
+          b: A,
+        }),
         return: A,
       }),
     ],
@@ -1660,21 +1621,15 @@ typeAssignabilitySuite('generic function types (not assignable)', [
       // `?a ~> { a: :a }` is not assignable to `?a ~> { b: :a }`
       makeFunctionType({
         parameter: A,
-        return: makeObjectType(
-          {
-            a: A,
-          },
-          { excess: something },
-        ),
+        return: makeObjectType({
+          a: A,
+        }),
       }),
       makeFunctionType({
         parameter: A,
-        return: makeObjectType(
-          {
-            b: A,
-          },
-          { excess: something },
-        ),
+        return: makeObjectType({
+          b: A,
+        }),
       }),
     ],
     false,
@@ -1700,15 +1655,12 @@ typeAssignabilitySuite(
   'union with a broadly-constrained type-parameter member (assignable)',
   [
     [[makeUnionType([A, object]), something], true],
-    [
-      [makeUnionType([A, makeObjectType({}, { excess: nothing })]), something],
-      true,
-    ],
+    [[makeUnionType([A, exactEmptyObject]), something], true],
     [
       [
         makeFunctionType({
           parameter: something,
-          return: makeUnionType([A, makeObjectType({}, { excess: nothing })]),
+          return: makeUnionType([A, exactEmptyObject]),
         }),
         something,
       ],

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -1,10 +1,19 @@
 import type { Option } from '@matt.kantor/option'
 import option from '@matt.kantor/option'
 import type { Atom } from '../../parsing.js'
+import { atom, something } from './prelude-types.js'
 import { matchTypeFormat } from './type-formats/match-type-format.js'
-import { makeObjectType, type ObjectType } from './type-formats/object-type.js'
+import {
+  makeObjectType,
+  type ExcessClause,
+  type ObjectType,
+} from './type-formats/object-type.js'
 import { isTopType, type Type } from './type-formats/type.js'
-import { makeUnionType, type UnionType } from './type-formats/union-type.js'
+import {
+  makeUnionType,
+  unionOfTypes,
+  type UnionType,
+} from './type-formats/union-type.js'
 import { updateTypeAtKeyPathIfValid } from './type-key-path.js'
 import {
   containedTypeParameters,
@@ -95,10 +104,10 @@ export const isAssignable = ({
                 source.signature.parameter.identity ===
                   source.signature.return.identity
               ) {
-                // The source is an identity function (`a => a`), which means this
-                // much simpler check can be performed. This also allows correctly
-                // handling the fact that `a => a` is assignable to a type like
-                // `atom => atom`.
+                // The source is an identity function (`a => a`), which means
+                // this much simpler check can be performed. This also allows
+                // correctly handling the fact that `a => a` is assignable to a
+                // type like `atom => atom`.
                 return (
                   isAssignable({
                     source: target.signature.parameter,
@@ -117,17 +126,17 @@ export const isAssignable = ({
                   target.signature.parameter,
                 )
 
-                // An example showing how this will be used: When checking whether
-                // `{ a: (a <: atom) } => a` is assignable to `{ a: (b <: "a") }
-                // => b`, the parameter types are compatible if `{ a: (b <: "a")
-                // }` is assignable to `{ a: atom }` (it is).
+                // An example showing how this will be used: When checking
+                // whether `{ a: (a <: atom) } => a` is assignable to `{ a: (b
+                // <: "a") } => b`, the parameter types are compatible if `{ a:
+                // (b <: "a") }` is assignable to `{ a: atom }` (it is).
                 let sourceParameterWithTypeParametersReplacedByConstraints =
                   source.signature.parameter
 
-                // An example showing how this will be used: When checking whether
-                // `a => { a: a, b: atom }` is assignable to `(b <: atom) => { a:
-                // b }`, the return types are compatible if `{ a: b, b: atom }` is
-                // assignable to `{ a: b }` (it is).
+                // An example showing how this will be used: When checking
+                // whether `a => { a: a, b: atom }` is assignable to `(b <:
+                // atom) => { a: b }`, the return types are compatible if `{ a:
+                // b, b: atom }` is assignable to `{ a: b }` (it is).
                 let sourceReturnWithTypeParametersReplacedByTargetTypeParameters =
                   source.signature.return
 
@@ -238,25 +247,58 @@ export const isAssignable = ({
                   isAssignable({ source: sourceChild, target: targetChild })
                 )
               })
-              // Source properties beyond the target's children, along with
-              // whatever excess the source itself admits, must fit within the
-              // target's excess bound.
-              const excessPropertiesAreSatisfied =
-                isTopType(target.excess) ||
-                (Object.entries(source.children).every(
-                  ([key, sourceChild]) =>
-                    target.children[key] !== undefined ||
-                    isAssignable({
-                      source: sourceChild,
-                      target: target.excess,
-                    }),
-                ) &&
-                  isAssignable({
-                    source: source.excess,
-                    target: target.excess,
-                  }))
+              // Each source property beyond the target's children must fit
+              // within the target's bound for its specific key.
+              const unlistedSourceChildrenAreSatisfied = Object.entries(
+                source.children,
+              ).every(([key, sourceChild]) => {
+                const targetBound = excessBoundForKey(key, target.excess)
+                return (
+                  target.children[key] !== undefined ||
+                  isTopType(targetBound) ||
+                  isAssignable({ source: sourceChild, target: targetBound })
+                )
+              })
+              // Whatever the source's clauses admit must fit within the
+              // target's clauses wherever they overlap. A pair of clauses
+              // overlaps only if some key can inhabit both domains while
+              // escaping all later domains. Clauses with no overlap are
+              // irrelevant to subtyping.
+              const sourceExcess = effectiveExcessClauses(source.excess)
+              const targetExcess = effectiveExcessClauses(target.excess)
+              const excessClausesAreSatisfied = sourceExcess.every(
+                (sourceClause, sourceIndex) =>
+                  targetExcess.every((targetClause, targetIndex) => {
+                    const laterDomains = unionOfTypes([
+                      ...sourceExcess
+                        .slice(sourceIndex + 1)
+                        .map(clause => clause.keys),
+                      ...targetExcess
+                        .slice(targetIndex + 1)
+                        .map(clause => clause.keys),
+                    ])
+                    const pairIsUnreachable =
+                      isAssignable({
+                        source: sourceClause.keys,
+                        target: laterDomains,
+                      }) ||
+                      isAssignable({
+                        source: targetClause.keys,
+                        target: laterDomains,
+                      })
+                    return (
+                      pairIsUnreachable ||
+                      isAssignable({
+                        source: sourceClause.values,
+                        target: targetClause.values,
+                      })
+                    )
+                  }),
+              )
               return (
-                requiredPropertiesAreSatisfied && excessPropertiesAreSatisfied
+                requiredPropertiesAreSatisfied &&
+                unlistedSourceChildrenAreSatisfied &&
+                excessClausesAreSatisfied
               )
             },
             opaque: target => target.isAssignableFrom(source),
@@ -418,6 +460,41 @@ export const asUnionWithLiteralAtomMembers = (
 }
 
 /**
+ * The bound an object type places on the value of the given property when it
+ * isn't among the type's required children.
+ */
+export const excessBoundForKey = (
+  key: Atom,
+  excess: ObjectType['excess'],
+): Type =>
+  excess.findLast(clause =>
+    isAssignable({ source: makeUnionType([key]), target: clause.keys }),
+  )?.values ?? something
+
+/**
+ * Whether every possible key inhabits some explicit clause's `keys`.
+ */
+export const excessClausesAreTotal = (
+  excess: readonly ExcessClause[],
+): boolean =>
+  excess.some(clause => clause.keys === atom) || // fast path
+  isAssignable({
+    source: atom,
+    target: unionOfTypes(excess.map(clause => clause.keys)),
+  })
+
+/**
+ * Make an excess clause list total by prepending an open base clause when
+ * necessary, which is often more convenient to work with.
+ */
+export const effectiveExcessClauses = (
+  excess: readonly ExcessClause[],
+): readonly ExcessClause[] =>
+  excessClausesAreTotal(excess) ? excess : (
+    [{ keys: atom, values: something }, ...excess]
+  )
+
+/**
  * Removes redundancies and otherwise attempts to reduce the number of members
  * in a union while preserving the semantics of the given `UnionType`.
  *
@@ -439,13 +516,32 @@ export const simplifyUnionType = (typeToSimplify: UnionType): UnionType => {
   const isMergeable = (member: ObjectType) =>
     Object.keys(member.children).length === 1
 
-  const excessBoundsAgree = (first: Type, second: Type): boolean =>
+  const typesAreEquivalent = (first: Type, second: Type): boolean =>
     isAssignable({ source: first, target: second }) &&
     isAssignable({ source: second, target: first })
 
+  const excessBoundsAgree = (
+    first: ObjectType['excess'],
+    second: ObjectType['excess'],
+  ): boolean => {
+    const effectiveFirst = effectiveExcessClauses(first)
+    const effectiveSecond = effectiveExcessClauses(second)
+    return (
+      effectiveFirst.length === effectiveSecond.length &&
+      effectiveFirst.every((firstClause, index) => {
+        const secondClause = effectiveSecond[index]
+        return (
+          secondClause !== undefined &&
+          typesAreEquivalent(firstClause.keys, secondClause.keys) &&
+          typesAreEquivalent(firstClause.values, secondClause.values)
+        )
+      })
+    )
+  }
+
   type MergeGroup = {
     readonly key: string
-    readonly excess: Type
+    readonly excess: ObjectType['excess']
     readonly typesToMerge: readonly ObjectType[]
   }
 
@@ -495,7 +591,7 @@ export const simplifyUnionType = (typeToSimplify: UnionType): UnionType => {
           makeUnionType(typesForTheProperty),
         ),
       },
-      { excess },
+      excess,
     )
   })
 

--- a/src/language/semantics/type-system/type-formats/object-type.ts
+++ b/src/language/semantics/type-system/type-formats/object-type.ts
@@ -1,23 +1,42 @@
 import type { Atom } from '../../../parsing.js'
 import type { Type } from './type.js'
 
+/**
+ * Bounds the values of properties whose keys inhabit `keys`. Excess clauses
+ * never assert that any property must be present; they only constrain the
+ * values of properties that happen to exist.
+ */
+export type ExcessClause = {
+  /**
+   * `Type` indicating the keys of properties constrained by this clause (must
+   * be a subtype of `atom`).
+   */
+  readonly keys: Type
+  /**
+   * Property values matched by this clause are required to be assignable to
+   * this `Type`.
+   */
+  readonly values: Type
+}
+
 export type ObjectType = {
   readonly kind: 'object'
   readonly children: Readonly<Record<Atom, Type>>
   /**
-   * An upper bound on the values of properties *not* explicitly required by
-   * `children`. The bottom type (an empty union) means inhabitants have exactly
-   * the specified keys; the top type admits arbitrary excess properties;
-   * anything in between bounds what excess property values may be.
+   * Clauses bounding the values of properties not explicitly required by
+   * `children`. A bound property's value must inhabit the `values` of the last
+   * clause whose `keys` its key inhabits. A property matching no clauses may
+   * have any type (an empty `excess` array leaves the object fully open). A
+   * clause like `{ keys: atom, values: nothing }` forbids excess properties.
    */
-  readonly excess: Type
+  readonly excess: readonly ExcessClause[]
 }
 
 export const makeObjectType = <Children extends Readonly<Record<Atom, Type>>>(
   children: Children,
-  options: { readonly excess: Type },
+  excess: readonly ExcessClause[] = [],
 ): ObjectType & { readonly children: Children } => ({
   kind: 'object',
   children,
-  excess: options.excess,
+  excess,
 })

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -9,6 +9,7 @@ import {
   isAssignable,
   isExpression,
   isFunctionNode,
+  isObjectNode,
   lookup,
   readApplyExpression,
   readFunctionExpression,
@@ -38,12 +39,16 @@ import {
 import { genericizeFunctionParameterAnnotation } from './genericize-function-parameter.js'
 import { typeFromSemanticGraph } from './literal-type.js'
 import * as types from './prelude-types.js'
+import { effectiveExcessClauses } from './subtyping.js'
 import { makeApplicationType } from './type-formats/application-type.js'
 import { makeFunctionType } from './type-formats/function-type.js'
 import { makeIndexedAccessType } from './type-formats/indexed-access-type.js'
+import { makeIntrinsicApplicationType } from './type-formats/intrinsic-application-type.js'
+import { matchTypeFormat } from './type-formats/match-type-format.js'
 import { makeObjectType } from './type-formats/object-type.js'
 import type { Type } from './type-formats/type.js'
-import { unionOfTypes } from './type-formats/union-type.js'
+import { isBottomType, isTopType } from './type-formats/type.js'
+import { makeUnionType, unionOfTypes } from './type-formats/union-type.js'
 import {
   functionParameterKey,
   stringifyTypeKeyPathForEndUser,
@@ -58,7 +63,6 @@ import {
   applicableFunctionSignatures,
   applyKeyPathToType,
   getTypesForTypeParameters,
-  recursivelyInexact,
   supplyTypeArguments,
 } from './type-substitution.js'
 
@@ -102,6 +106,29 @@ export const inferType = (
   context: ExpressionContext,
 ): Either<ElaborationError, Type> =>
   inferTypeImplementation(
+    node,
+    resolveParameterTypes(context),
+    new Set(),
+    context,
+  )
+
+/**
+ * Like `inferType`, but for a `node` occurring in a type annotation (e.g. a
+ * function parameter type or `@check` type). The denoted type is interpreted as
+ * an open upper bound:
+ * - Each `@union` member is interpreted as if it were written bare in the
+ *   same position (`inferTypeOfTypeAnnotation` distributes over union members).
+ * - A plain object literal is open (allowing arbitrary excess properties), in
+ *   contrast to value positions where inference gives closed object types.
+ * - Anything indirect (lookups, indexed accesses, applications, …) is
+ *   interpreted as its inferred type with every closed object widened to an
+ *   open one.
+ */
+export const inferTypeOfTypeAnnotation = (
+  node: SemanticGraph,
+  context: ExpressionContext,
+): Either<ElaborationError, Type> =>
+  inferTypeOfTypeAnnotationImplementation(
     node,
     resolveParameterTypes(context),
     new Set(),
@@ -477,10 +504,7 @@ const inferTypeImplementation = (
             return either.flatMap(inferThen(), thenType =>
               either.map(inferElse(), elseType =>
                 makeIndexedAccessType(
-                  makeObjectType(
-                    { false: elseType, true: thenType },
-                    { excess: types.something },
-                  ),
+                  makeObjectType({ false: elseType, true: thenType }),
                   conditionType,
                 ),
               ),
@@ -534,7 +558,8 @@ const inferTypeImplementation = (
       case 'expression':
         return cacheOnSuccess(
           either.map(
-            inferTypeImplementation(
+            // Constraints are type annotations (upper bounds).
+            inferTypeOfTypeAnnotationImplementation(
               holeExpression[1].constraint.assignableTo,
               parameterTypes,
               lookingUpKeys,
@@ -570,13 +595,73 @@ const inferTypeImplementation = (
         ),
       ),
       entries =>
-        makeObjectType(Object.fromEntries(entries), {
+        makeObjectType(
+          Object.fromEntries(entries),
           // Expressions will have different keys after elaboration, otherwise
           // this is a literal object where all properties are known.
-          excess: isExpression(node) ? types.something : types.nothing,
-        }),
+          isExpression(node) ?
+            []
+          : [{ keys: types.atom, values: types.nothing }],
+        ),
     ),
   )
+}
+
+/** @see `inferTypeOfTypeAnnotation` for the rules applied here. */
+const inferTypeOfTypeAnnotationImplementation = (
+  node: SemanticGraph,
+  parameterTypes: ReadonlyMap<Atom, Type>,
+  lookingUpKeys: ReadonlySet<Atom>,
+  context: ExpressionContext,
+): Either<ElaborationError, Type> => {
+  const isPlainObjectLiteral = isObjectNode(node) && !isExpression(node)
+  const descendantContext = (subPath: KeyPath): ExpressionContext => ({
+    ...context,
+    location: [...context.location, ...subPath],
+    cacheKeyPrefixOverride:
+      context.cacheKeyPrefixOverride === undefined ?
+        undefined
+      : [...context.cacheKeyPrefixOverride, ...subPath],
+  })
+  const unionExpressionResult = readUnionExpression(node)
+  if (either.isRight(unionExpressionResult)) {
+    // Distribute over union members.
+    return either.map(
+      either.sequence(
+        Object.entries(unionExpressionResult.value[1]).map(([key, member]) =>
+          inferTypeOfTypeAnnotationImplementation(
+            member,
+            parameterTypes,
+            lookingUpKeys,
+            descendantContext(['1', key]),
+          ),
+        ),
+      ),
+      unionOfTypes,
+    )
+  } else if (isPlainObjectLiteral) {
+    return either.map(
+      either.sequence(
+        Object.entries(node).map(([key, propertyValue]) =>
+          either.map(
+            inferTypeOfTypeAnnotationImplementation(
+              propertyValue,
+              parameterTypes,
+              lookingUpKeys,
+              descendantContext([key]),
+            ),
+            propertyType => [key, propertyType],
+          ),
+        ),
+      ),
+      entries => makeObjectType(Object.fromEntries(entries)),
+    )
+  } else {
+    return either.map(
+      inferTypeImplementation(node, parameterTypes, lookingUpKeys, context),
+      recursivelyOpenObjectTypes,
+    )
+  }
 }
 
 /**
@@ -616,7 +701,7 @@ const getFunctionParameterType = (
             // than their own location (a property within the `@function`), so
             // `location` stays anchored at the function while cache keys are
             // rooted at the annotation's true position.
-            inferType(annotation, {
+            inferTypeOfTypeAnnotation(annotation, {
               ...contextOfFunction,
               cacheKeyPrefixOverride: [
                 ...(contextOfFunction.cacheKeyPrefixOverride ??
@@ -634,8 +719,9 @@ const getFunctionParameterType = (
               // to describe concrete function types rather than generic ones.
               if (parameterName === ignoredKey) {
                 return {
-                  // Function parameter types are always inexact.
-                  parameterType: recursivelyInexact(annotationType),
+                  // The annotation was already interpreted as an upper bound by
+                  // `inferTypeOfTypeAnnotation`.
+                  parameterType: annotationType,
                   typeParametersBoundByFunction: new Set<symbol>(),
                 }
               } else {
@@ -728,7 +814,9 @@ const getFunctionParameterType = (
                       .signature.parameter
                   return option.makeSome({
                     // Function parameter types are always inexact.
-                    parameterType: recursivelyInexact(borrowedParameterType),
+                    parameterType: recursivelyOpenObjectTypes(
+                      borrowedParameterType,
+                    ),
                     typeParametersBoundByFunction:
                       typeParameterIdentitiesWithinType(borrowedParameterType),
                   })
@@ -870,3 +958,73 @@ const resolveEnclosingFunctionParameters = (
   }
   return collectFromLocation(context.location)
 }
+
+/**
+ * Recursively widen every closed object type (one whose excess clauses have
+ * bottom-typed `values`) to an open one. Other excess bounds are preserved as
+ * written.
+ *
+ * Type parameters are kept by reference (their identities matter), so their
+ * constraints are not adjusted here; make sure constraints are inexact while
+ * creating type parameters instead.
+ */
+const recursivelyOpenObjectTypes = (type: Type): Type =>
+  // Avoid infinite recursion when we hit the top type.
+  isTopType(type) ? type : (
+    matchTypeFormat<Type>(type, {
+      application: type =>
+        makeApplicationType(
+          recursivelyOpenObjectTypes(type.function),
+          recursivelyOpenObjectTypes(type.argument),
+          type.parametersStuckOn,
+        ),
+      function: type =>
+        makeFunctionType({
+          parameter: recursivelyOpenObjectTypes(type.signature.parameter),
+          return: recursivelyOpenObjectTypes(type.signature.return),
+        }),
+      indexedAccess: type =>
+        makeIndexedAccessType(
+          recursivelyOpenObjectTypes(type.object),
+          recursivelyOpenObjectTypes(type.key),
+        ),
+      intrinsicApplication: type =>
+        makeIntrinsicApplicationType(
+          type.parameterTypes.map(recursivelyOpenObjectTypes),
+          type.reduce,
+          parameterTypes =>
+            recursivelyOpenObjectTypes(type.computeUpperBound(parameterTypes)),
+        ),
+      object: type =>
+        makeObjectType(
+          Object.fromEntries(
+            Object.entries(type.children).map(([key, child]) => [
+              key,
+              recursivelyOpenObjectTypes(child),
+            ]),
+          ),
+          (
+            effectiveExcessClauses(type.excess).every(clause =>
+              isBottomType(clause.values),
+            )
+          ) ?
+            []
+          : type.excess,
+        ),
+      opaque: type => type,
+      parameter: type => type,
+      union: type =>
+        makeUnionType(
+          [...type.members].flatMap(member => {
+            if (typeof member === 'string') {
+              return [member]
+            } else {
+              const strippedMember = recursivelyOpenObjectTypes(member)
+              return strippedMember.kind === 'union' ?
+                  [...strippedMember.members]
+                : [strippedMember]
+            }
+          }),
+        ),
+    })
+  )

--- a/src/language/semantics/type-system/type-key-path.ts
+++ b/src/language/semantics/type-system/type-key-path.ts
@@ -155,7 +155,7 @@ export const updateTypeAtKeyPathIfValid = (
                   operation,
                 ),
               },
-              { excess: type.excess },
+              type.excess,
             )
           }
         } else {

--- a/src/language/semantics/type-system/type-parameter-analysis.ts
+++ b/src/language/semantics/type-system/type-parameter-analysis.ts
@@ -51,13 +51,16 @@ const containedTypeParametersImplementation = (
           ...Object.entries(type.children).map(([key, child]) =>
             containedTypeParametersImplementation(child, [...root, key]),
           ),
-          // Excess bounds may also contain type parameters (which need to be
+          // Excess clauses may also contain type parameters (which need to be
           // visible here for stuckness detection). There's no way to talk about
           // them in `TypeKeyPath`, so they're currently (imprecisely) reported
           // at the object's own key path.
           // TODO: Should there be a `TypeKeyPath` symbol to allow addressing
-          // excess bounds explicitly?
-          containedTypeParametersImplementation(type.excess, root),
+          // excess clauses explicitly?
+          ...type.excess.flatMap(clause => [
+            containedTypeParametersImplementation(clause.keys, root),
+            containedTypeParametersImplementation(clause.values, root),
+          ]),
         ].reduce(mergeTypeParametersByKeyPath, new Map()),
       application: type =>
         mergeTypeParametersByKeyPath(

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -66,8 +66,8 @@ applyKeyPathSuite('applyKeyPathToType with empty key path', [
   [[nothing, []], stringifyTypeForEndUser(nothing)],
   [[something, []], stringifyTypeForEndUser(something)],
   [
-    [makeObjectType({ a: atom }, { excess: something }), []],
-    stringifyTypeForEndUser(makeObjectType({ a: atom }, { excess: something })),
+    [makeObjectType({ a: atom }), []],
+    stringifyTypeForEndUser(makeObjectType({ a: atom })),
   ],
   [
     [makeFunctionType({ parameter: atom, return: something }), []],
@@ -79,30 +79,24 @@ applyKeyPathSuite('applyKeyPathToType with empty key path', [
 
 applyKeyPathSuite('applyKeyPathToType with object types', [
   [
-    [makeObjectType({ a: atom, b: integer }, { excess: something }), ['a']],
+    [makeObjectType({ a: atom, b: integer }), ['a']],
     stringifyTypeForEndUser(atom),
   ],
   [
-    [makeObjectType({ a: atom, b: integer }, { excess: something }), ['b']],
+    [makeObjectType({ a: atom, b: integer }), ['b']],
     stringifyTypeForEndUser(integer),
   ],
-  [[makeObjectType({ a: atom }, { excess: something }), ['z']], '(none)'],
+  [[makeObjectType({ a: atom }), ['z']], '(none)'],
   [
     [
-      makeObjectType(
-        {
-          a: makeObjectType(
-            { b: makeUnionType(['hello']) },
-            { excess: something },
-          ),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeObjectType({ b: makeUnionType(['hello']) }),
+      }),
       ['a', 'b'],
     ],
     stringifyTypeForEndUser(makeUnionType(['hello'])),
   ],
-  [[makeObjectType({ a: atom }, { excess: something }), ['a', 'b']], '(none)'],
+  [[makeObjectType({ a: atom }), ['a', 'b']], '(none)'],
 ])
 
 applyKeyPathSuite('applyKeyPathToType with non-object types', [
@@ -116,8 +110,8 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
   [
     [
       makeUnionType([
-        makeObjectType({ a: makeUnionType(['x']) }, { excess: something }),
-        makeObjectType({ a: makeUnionType(['y']) }, { excess: something }),
+        makeObjectType({ a: makeUnionType(['x']) }),
+        makeObjectType({ a: makeUnionType(['y']) }),
       ]),
       ['a'],
     ],
@@ -125,10 +119,14 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
   ],
   [
     [
-      makeUnionType([
-        makeObjectType({ a: makeUnionType(['x']) }, { excess: something }),
-        'some_atom',
-      ]),
+      makeUnionType([makeObjectType({ a: makeUnionType(['x']) }), 'some_atom']),
+      ['a'],
+    ],
+    '(none)',
+  ],
+  [
+    [
+      makeUnionType([makeObjectType({ b: atom }), makeObjectType({ c: atom })]),
       ['a'],
     ],
     '(none)',
@@ -136,17 +134,7 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
   [
     [
       makeUnionType([
-        makeObjectType({ b: atom }, { excess: something }),
-        makeObjectType({ c: atom }, { excess: something }),
-      ]),
-      ['a'],
-    ],
-    '(none)',
-  ],
-  [
-    [
-      makeUnionType([
-        makeObjectType({ a: integer }, { excess: something }),
+        makeObjectType({ a: integer }),
         makeFunctionType({ parameter: atom, return: atom }),
       ]),
       ['a'],
@@ -156,20 +144,14 @@ applyKeyPathSuite('applyKeyPathToType with union types', [
 ])
 
 applyKeyPathSuite('applyKeyPathToType with bottom types', [
-  [
-    [makeObjectType({ a: nothing }, { excess: something }), ['a']],
-    stringifyTypeForEndUser(nothing),
-  ],
-  [
-    [makeObjectType({ a: nothing }, { excess: something }), ['a', 'b']],
-    '(none)',
-  ],
+  [[makeObjectType({ a: nothing }), ['a']], stringifyTypeForEndUser(nothing)],
+  [[makeObjectType({ a: nothing }), ['a', 'b']], '(none)'],
   [[nothing, ['a']], '(none)'],
   [
     [
       makeUnionType([
-        makeObjectType({ a: nothing }, { excess: something }),
-        makeObjectType({ a: atom }, { excess: something }),
+        makeObjectType({ a: nothing }),
+        makeObjectType({ a: atom }),
       ]),
       ['a'],
     ],
@@ -181,13 +163,10 @@ const keyAssignableToAOrB = makeTypeParameter('key', {
   assignableTo: makeUnionType(['a', 'b']),
 })
 const stuckAccessWithCommonXProperty = makeIndexedAccessType(
-  makeObjectType(
-    {
-      a: makeObjectType({ x: atom }, { excess: something }),
-      b: makeObjectType({ x: integer }, { excess: something }),
-    },
-    { excess: something },
-  ),
+  makeObjectType({
+    a: makeObjectType({ x: atom }),
+    b: makeObjectType({ x: integer }),
+  }),
   keyAssignableToAOrB,
 )
 
@@ -202,13 +181,10 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
   [
     [
       makeIndexedAccessType(
-        makeObjectType(
-          {
-            a: makeObjectType({ x: atom }, { excess: something }),
-            b: makeObjectType({}, { excess: something }),
-          },
-          { excess: something },
-        ),
+        makeObjectType({
+          a: makeObjectType({ x: atom }),
+          b: makeObjectType({}),
+        }),
         keyAssignableToAOrB,
       ),
       ['x'],
@@ -218,7 +194,7 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
   [
     [
       makeIndexedAccessType(
-        makeObjectType({ x: atom, a: atom, b: atom }, { excess: something }),
+        makeObjectType({ x: atom, a: atom, b: atom }),
         keyAssignableToAOrB,
       ),
       ['x'],
@@ -229,16 +205,7 @@ applyKeyPathSuite('applyKeyPathToType with indexed access types', [
 
 applyKeyPathSuite('applyKeyPathToType with degenerate stuck types', [
   [[makeApplicationType(atom, atom, new Set()), ['x']], '(none)'],
-  [
-    [
-      makeIndexedAccessType(
-        makeObjectType({ x: atom }, { excess: something }),
-        atom,
-      ),
-      ['x'],
-    ],
-    '(none)',
-  ],
+  [[makeIndexedAccessType(makeObjectType({ x: atom }), atom), ['x']], '(none)'],
 ])
 
 const getTypesForTypeParametersSuite = testCases(
@@ -266,13 +233,10 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [[something, atom], new Map()],
 
-  [[makeObjectType({ a: A }, { excess: something }), atom], new Map()],
+  [[makeObjectType({ a: A }), atom], new Map()],
 
   [
-    [
-      makeObjectType({ a: A, b: B }, { excess: something }),
-      makeObjectType({ a: atom, b: integer }, { excess: something }),
-    ],
+    [makeObjectType({ a: A, b: B }), makeObjectType({ a: atom, b: integer })],
     new Map([
       [A, atom],
       [B, integer],
@@ -301,10 +265,7 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
   ],
 
   [
-    [
-      makeObjectType({ a: A, b: A }, { excess: something }),
-      makeObjectType({ a: atom, b: integer }, { excess: something }),
-    ],
+    [makeObjectType({ a: A, b: A }), makeObjectType({ a: atom, b: integer })],
     // The first occurrence should be used in situations like this. In real code
     // this will likely result in a type error later.
     new Map([[A, atom]]),
@@ -351,21 +312,27 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
 
   [
     [
-      makeObjectType({}, { excess: A }),
+      makeObjectType({}, [{ keys: atom, values: A }]),
       makeObjectType(
-        { a: makeUnionType(['1']), b: makeUnionType(['2']) },
-        { excess: nothing },
+        {
+          a: makeUnionType(['1']),
+          b: makeUnionType(['2']),
+        },
+        [{ keys: atom, values: nothing }],
       ),
     ],
     new Map([[A, makeUnionType(['1', '2'])]]),
   ],
 
-  [[makeObjectType({}, { excess: A }), object], new Map([[A, something]])],
+  [
+    [makeObjectType({}, [{ keys: atom, values: A }]), object],
+    new Map([[A, something]]),
+  ],
 
   [
     [
-      makeObjectType({}, { excess: A }),
-      makeObjectType({}, { excess: nothing }),
+      makeObjectType({}, [{ keys: atom, values: A }]),
+      makeObjectType({}, [{ keys: atom, values: nothing }]),
     ],
     new Map([[A, nothing]]),
   ],
@@ -373,8 +340,10 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
   [
     // Bindings from required properties take precedence over excess bindings.
     [
-      makeObjectType({ a: A }, { excess: A }),
-      makeObjectType({ a: atom, b: integer }, { excess: nothing }),
+      makeObjectType({ a: A }, [{ keys: atom, values: A }]),
+      makeObjectType({ a: atom, b: integer }, [
+        { keys: atom, values: nothing },
+      ]),
     ],
     new Map([[A, atom]]),
   ],
@@ -406,25 +375,34 @@ enumerateInhabitantsSuite('enumerateInhabitants', [
   [object, optionAdt.none],
 
   [
-    makeObjectType({}, { excess: nothing }),
+    makeObjectType({}, [{ keys: atom, values: nothing }]),
     optionAdt.makeSome([objectNodeFromOrderedEntries([])]),
   ],
 
   [
-    makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
+    makeObjectType({ a: makeUnionType(['1']) }, [
+      { keys: atom, values: nothing },
+    ]),
     optionAdt.makeSome([objectNodeFromOrderedEntries([['a', '1']])]),
   ],
 
   // An open object type admits unlisted properties, so it is not enumerable.
+  [makeObjectType({ a: makeUnionType(['1']) }), optionAdt.none],
+
+  // An all-bottom clause list which doesn't cover every key still leaves the
+  // uncovered keys open.
   [
-    makeObjectType({ a: makeUnionType(['1']) }, { excess: something }),
+    makeObjectType({}, [{ keys: makeUnionType(['a', 'b']), values: nothing }]),
     optionAdt.none,
   ],
 
   [
     makeObjectType(
-      { a: makeUnionType(['1', '2']), b: makeUnionType(['x']) },
-      { excess: nothing },
+      {
+        a: makeUnionType(['1', '2']),
+        b: makeUnionType(['x']),
+      },
+      [{ keys: atom, values: nothing }],
     ),
     optionAdt.makeSome([
       objectNodeFromOrderedEntries([
@@ -438,12 +416,19 @@ enumerateInhabitantsSuite('enumerateInhabitants', [
     ]),
   ],
 
-  [makeObjectType({ a: atom }, { excess: nothing }), optionAdt.none],
+  [
+    makeObjectType({ a: atom }, [{ keys: atom, values: nothing }]),
+    optionAdt.none,
+  ],
 
   [
     makeObjectType(
-      { a: makeObjectType({ b: makeUnionType(['1']) }, { excess: nothing }) },
-      { excess: nothing },
+      {
+        a: makeObjectType({ b: makeUnionType(['1']) }, [
+          { keys: atom, values: nothing },
+        ]),
+      },
+      [{ keys: atom, values: nothing }],
     ),
     optionAdt.makeSome([
       objectNodeFromOrderedEntries([
@@ -454,15 +439,19 @@ enumerateInhabitantsSuite('enumerateInhabitants', [
 
   [
     makeObjectType(
-      { a: makeObjectType({ b: makeUnionType(['1']) }, { excess: something }) },
-      { excess: nothing },
+      {
+        a: makeObjectType({ b: makeUnionType(['1']) }),
+      },
+      [{ keys: atom, values: nothing }],
     ),
     optionAdt.none,
   ],
 
   [
     makeUnionType([
-      makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
+      makeObjectType({ a: makeUnionType(['1']) }, [
+        { keys: atom, values: nothing },
+      ]),
       'z',
     ]),
     optionAdt.makeSome([objectNodeFromOrderedEntries([['a', '1']]), 'z']),
@@ -493,7 +482,12 @@ const intrinsicReductionSuite = testCases(
   (typeArgument: Type) =>
     supplyTypeArgument(
       makeIntrinsicApplicationType(
-        [A, makeObjectType({ b: makeUnionType(['2']) }, { excess: nothing })],
+        [
+          A,
+          makeObjectType({ b: makeUnionType(['2']) }, [
+            { keys: atom, values: nothing },
+          ]),
+        ],
         describeReducedArguments,
         computeUpperBound,
       ),
@@ -506,7 +500,9 @@ const intrinsicReductionSuite = testCases(
 
 intrinsicReductionSuite('intrinsic application reduction over object types', [
   [
-    makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
+    makeObjectType({ a: makeUnionType(['1']) }, [
+      { keys: atom, values: nothing },
+    ]),
     makeUnionType(['{ { a: 1 }, { b: 2 } }']),
   ],
 
@@ -514,19 +510,25 @@ intrinsicReductionSuite('intrinsic application reduction over object types', [
 
   [
     makeUnionType([
-      makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
-      makeObjectType({ a: makeUnionType(['2']) }, { excess: nothing }),
+      makeObjectType({ a: makeUnionType(['1']) }, [
+        { keys: atom, values: nothing },
+      ]),
+      makeObjectType({ a: makeUnionType(['2']) }, [
+        { keys: atom, values: nothing },
+      ]),
     ]),
     makeUnionType(['{ { a: 1 }, { b: 2 } }', '{ { a: 2 }, { b: 2 } }']),
   ],
 
   // An open object type is not enumerable, so the application stays stuck.
   [
-    makeObjectType({ a: makeUnionType(['1']) }, { excess: something }),
+    makeObjectType({ a: makeUnionType(['1']) }),
     makeIntrinsicApplicationType(
       [
-        makeObjectType({ a: makeUnionType(['1']) }, { excess: something }),
-        makeObjectType({ b: makeUnionType(['2']) }, { excess: nothing }),
+        makeObjectType({ a: makeUnionType(['1']) }),
+        makeObjectType({ b: makeUnionType(['2']) }, [
+          { keys: atom, values: nothing },
+        ]),
       ],
       describeReducedArguments,
       computeUpperBound,
@@ -538,29 +540,33 @@ const genericizationConstraintSuite = testCases(
   (annotation: Type) =>
     genericizeFunctionParameterAnnotation('x', annotation).type,
   annotation =>
-    `genericizing \`x: ${stringifyTypeForEndUser(annotation)}\` opens closed objects`,
+    `genericizing \`x: ${stringifyTypeForEndUser(annotation)}\` preserves excess bounds`,
 )
 
-genericizationConstraintSuite(
-  'genericization produces open object constraints',
+genericizationConstraintSuite('genericization preserves excess bounds', [
   [
-    [
-      // The constraint is an upper bound for its instantiations (which should
-      // admit subtypes), so it must not be closed.
-      makeUnionType([
-        makeObjectType({ a: makeUnionType(['1']) }, { excess: nothing }),
+    makeUnionType([
+      makeObjectType({ a: makeUnionType(['1']) }, [
+        { keys: atom, values: nothing },
       ]),
-      parameterType => {
-        assert(parameterType.kind === 'parameter')
-        const constraint = parameterType.constraint.assignableTo
-        assert(constraint.kind === 'union')
-        const [member] = constraint.members
-        assert(typeof member === 'object' && member.kind === 'object')
-        assert.deepEqual(member.excess, something)
-      },
-    ],
+    ]),
+    parameterType => {
+      assert(parameterType.kind === 'parameter')
+      const constraint = parameterType.constraint.assignableTo
+      assert(constraint.kind === 'union')
+      const [member] = constraint.members
+      assert(typeof member === 'object' && member.kind === 'object')
+      assert.deepEqual(member.excess, [{ keys: atom, values: nothing }])
+    },
   ],
-)
+  [
+    makeObjectType({ a: makeUnionType(['1']) }, [{ keys: atom, values: atom }]),
+    parameterType => {
+      assert(parameterType.kind === 'object')
+      assert.deepEqual(parameterType.excess, [{ keys: atom, values: atom }])
+    },
+  ],
+])
 
 const genericizeParameterAnnotationSuite = testCases(
   ([parameterName, annotation]: readonly [
@@ -590,13 +596,10 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType(
-        {
-          a: integer,
-          b: atom,
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: integer,
+        b: atom,
+      }),
     ],
     '{ a: (?"x.a": :integer.type), b: (?"x.b": :atom.type) }',
   ],
@@ -604,12 +607,9 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType(
-        {
-          a: makeObjectType({ b: atom }, { excess: something }),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        a: makeObjectType({ b: atom }),
+      }),
     ],
     '{ a: { b: (?"x.a.b": :atom.type) } }',
   ],
@@ -617,22 +617,19 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   [
     [
       'x',
-      makeObjectType(
-        {
-          callback: makeFunctionType({ parameter: atom, return: integer }),
-        },
-        { excess: something },
-      ),
+      makeObjectType({
+        callback: makeFunctionType({ parameter: atom, return: integer }),
+      }),
     ],
     '{ callback: (?"x.callback.#parameter": :atom.type) ~> (?"x.callback.#return": :integer.type) }',
   ],
 
-  [['empty', makeObjectType({}, { excess: something })], '(?empty: {})'],
+  [['empty', makeObjectType({})], '(?empty: {})'],
 
   [['identity', makeFunctionType({ parameter: A, return: A })], '?a ~> :a'],
 
   [
-    ['wrap', makeObjectType({ value: A }, { excess: something })],
+    ['wrap', makeObjectType({ value: A })],
     `{ value: ${stringifyTypeForEndUser(A)} }`,
   ],
 ])
@@ -698,8 +695,8 @@ const supplyTypeArgumentSuite = testCases(
 
 supplyTypeArgumentSuite('supplying type arguments within excess bounds', [
   [
-    [makeObjectType({}, { excess: A }), A, atom],
-    makeObjectType({}, { excess: atom }),
+    [makeObjectType({}, [{ keys: atom, values: A }]), A, atom],
+    makeObjectType({}, [{ keys: atom, values: atom }]),
   ],
 
   [[object, A, atom], object],
@@ -718,9 +715,9 @@ const containedTypeParametersSuite = testCases(
 )
 
 containedTypeParametersSuite('containedTypeParameters over excess bounds', [
-  [makeObjectType({}, { excess: A }), ['a']],
+  [makeObjectType({}, [{ keys: atom, values: A }]), ['a']],
 
-  [makeObjectType({ x: B }, { excess: A }), ['b', 'a']],
+  [makeObjectType({ x: B }, [{ keys: atom, values: A }]), ['b', 'a']],
 
   [object, []],
   [something, []],

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -4,8 +4,8 @@ import type { Writable } from '../../../utility-types.js'
 import type { FunctionNodeCallError } from '../function-node.js'
 import { objectNodeFromOrderedEntries } from '../object-node.js'
 import type { SemanticGraph } from '../semantic-graph.js'
-import { nothing, something } from './prelude-types.js'
-import { isAssignable } from './subtyping.js'
+import { nothing } from './prelude-types.js'
+import { effectiveExcessClauses, isAssignable } from './subtyping.js'
 import {
   makeApplicationType,
   type ApplicationType,
@@ -14,10 +14,7 @@ import {
   makeFunctionType,
   type FunctionType,
 } from './type-formats/function-type.js'
-import {
-  makeIndexedAccessType,
-  type IndexedAccessType,
-} from './type-formats/indexed-access-type.js'
+import { type IndexedAccessType } from './type-formats/indexed-access-type.js'
 import {
   makeIntrinsicApplicationType,
   type IntrinsicApplicationType,
@@ -282,7 +279,10 @@ export const getTypesForTypeParameters = ({
         } else {
           // Type parameters in excess bounds unify against everything the
           // argument could hold beyond the parameter's required properties.
-          const bindingsFromExcess = (): ReadonlyMap<TypeParameter, Type> => {
+          // Which clause an unlisted key would select isn't computed here, so
+          // every clause unifies against the same union (wide bindings are
+          // acceptable; they're validated downstream).
+          const unmatchedArgumentBound = (): Type => {
             const unmatchedArgumentChildTypes = Object.entries(
               argumentType.children,
             )
@@ -290,15 +290,12 @@ export const getTypesForTypeParameters = ({
                 ([key, _child]) => parameterType.children[key] === undefined,
               )
               .map(([_key, child]) => child)
-            return getTypesForTypeParameters({
-              parameterType: parameterType.excess,
-              argumentType: unionOfTypes([
-                ...unmatchedArgumentChildTypes,
-                ...(isBottomType(argumentType.excess) ?
-                  []
-                : [argumentType.excess]),
-              ]),
-            })
+            return unionOfTypes([
+              ...unmatchedArgumentChildTypes,
+              ...effectiveExcessClauses(argumentType.excess)
+                .map(clause => clause.values)
+                .filter(clauseValues => !isBottomType(clauseValues)),
+            ])
           }
           return [
             ...Object.entries(parameterType.children).map(
@@ -312,12 +309,17 @@ export const getTypesForTypeParameters = ({
                     })
               },
             ),
-            containedTypeParameters(parameterType.excess).size === 0 ?
-              new Map<TypeParameter, Type>()
-              // Excess bindings come last so type parameters prefer binding to
-              // required properties instead of excess (when the same type
-              // parameter appears in both places).
-            : bindingsFromExcess(),
+            ...parameterType.excess.map(clause =>
+              containedTypeParameters(clause.values).size === 0 ?
+                new Map<TypeParameter, Type>()
+                // Excess bindings come last so type parameters prefer binding
+                // to required properties instead (when the same type parameter
+                // appears in both places).
+              : getTypesForTypeParameters({
+                  parameterType: clause.values,
+                  argumentType: unmatchedArgumentBound(),
+                }),
+            ),
           ].reduce(
             (types, typesFromChild) => new Map([...typesFromChild, ...types]),
             new Map<TypeParameter, Type>(),
@@ -526,7 +528,11 @@ export const enumerateInhabitants = (
       opaque: _ => option.none,
       parameter: _ => option.none,
       object: type =>
-        !isBottomType(type.excess) ?
+        (
+          !effectiveExcessClauses(type.excess).every(clause =>
+            isBottomType(clause.values),
+          )
+        ) ?
           option.none
         : option.map(
             option.sequence(
@@ -632,9 +638,17 @@ export const supplyTypeArgument = (
             typeArgument,
           )
         }
-        return makeObjectType(substitutedChildren, {
-          excess: supplyTypeArgument(type.excess, typeParameter, typeArgument),
-        })
+        return makeObjectType(
+          substitutedChildren,
+          type.excess.map(clause => ({
+            keys: supplyTypeArgument(clause.keys, typeParameter, typeArgument),
+            values: supplyTypeArgument(
+              clause.values,
+              typeParameter,
+              typeArgument,
+            ),
+          })),
+        )
       },
       application: type =>
         reduceApplication(
@@ -719,68 +733,3 @@ export const supplyTypeArguments = (
         supplyTypeArgument(partiallyAppliedType, typeParameter, typeArgument),
       type,
     )
-
-/**
- * Recursively widen every closed (`excess: nothing`) object type to an open
- * one; any other excess bound is preserved as written. Used when a type is
- * adopted from a user-written type position (e.g. parameter type annotations),
- * where subtyping means wider values may inhabit it.
- *
- * Type parameters are kept by reference (their identities matter), so their
- * constraints are not adjusted here; make sure constraints are inexact while
- * creating type parameters instead.
- */
-export const recursivelyInexact = (type: Type): Type =>
-  // Avoid infinite recursion when we hit the top type.
-  isTopType(type) ? type : (
-    matchTypeFormat<Type>(type, {
-      application: type =>
-        makeApplicationType(
-          recursivelyInexact(type.function),
-          recursivelyInexact(type.argument),
-          type.parametersStuckOn,
-        ),
-      function: type =>
-        makeFunctionType({
-          parameter: recursivelyInexact(type.signature.parameter),
-          return: recursivelyInexact(type.signature.return),
-        }),
-      indexedAccess: type =>
-        makeIndexedAccessType(
-          recursivelyInexact(type.object),
-          recursivelyInexact(type.key),
-        ),
-      intrinsicApplication: type =>
-        makeIntrinsicApplicationType(
-          type.parameterTypes.map(recursivelyInexact),
-          type.reduce,
-          parameterTypes =>
-            recursivelyInexact(type.computeUpperBound(parameterTypes)),
-        ),
-      object: type =>
-        makeObjectType(
-          Object.fromEntries(
-            Object.entries(type.children).map(([key, child]) => [
-              key,
-              recursivelyInexact(child),
-            ]),
-          ),
-          { excess: isBottomType(type.excess) ? something : type.excess },
-        ),
-      opaque: type => type,
-      parameter: type => type,
-      union: type =>
-        makeUnionType(
-          [...type.members].flatMap(member => {
-            if (typeof member === 'string') {
-              return [member]
-            } else {
-              const strippedMember = recursivelyInexact(member)
-              return strippedMember.kind === 'union' ?
-                  [...strippedMember.members]
-                : [strippedMember]
-            }
-          }),
-        ),
-    })
-  )


### PR DESCRIPTION
This generalizes the work done in #236 even further.

Now it's possible to specify multiple key ranges with differing types. For example, an object type can now describe things like "keys `a`, `b`, and `c` must exist with `boolean` values, natural number keys may exist only if they have `atom` values, and keys `d`, `e`, and `f` may exist only if they have `object` values".

Instead of a single `Type`, `ObjectType['excess']` is now an ordered list of clauses (each specifying a `keys` type and a `values` type) which jointly bound the values of excess properties ("excess" as in those not required by `ObjectType['children']`).

The old `excess: …` is exactly equivalent to a one-clause array like `[{ keys: atom, values: … }]`.

Within `ObjectType['excess']`, later clauses override earlier ones when there are overlapping `keys`, so when checking assignability, a non-required property's value must inhabit the `values` of the last clause whose `keys` its key inhabits.

Object types are open by default: an empty `excess` array means additional arbitrary-valued properties may exist. To forbid excess properties, add a clause like `{ keys: atom, values: nothing }`.

This is still all just internal type system stuff that's not directly expressible in the surface language, but I'm thinking about how to change that.

