### PR TITLE
Capture precise source spans in parser

### DIFF
--- a/src/language/cli/please.test.ts
+++ b/src/language/cli/please.test.ts
@@ -58,7 +58,7 @@ suite('please CLI error reporting', () => {
     assert.match(stderr, /^Error: /)
     assert.ok(stderr.includes('\n<stdin>:1:1\n'))
     assert.ok(stderr.includes('\n1 │ 1 ~ :boolean.type\n'))
-    assert.ok(stderr.includes('\n  │ ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔\n'))
+    assert.ok(stderr.includes('\n  │ ▔\n'))
   })
 
   test('underlines the offending argument of a function call', async () => {
@@ -71,6 +71,18 @@ suite('please CLI error reporting', () => {
     assert.ok(stderr.includes('\n<stdin>:1:14\n'))
     assert.ok(stderr.includes('\n1 │ :boolean.not({})\n'))
     assert.ok(stderr.includes('\n  │              ▔▔\n'))
+  })
+
+  test('underlines the offending atom argument of a function call', async () => {
+    const { stdout, stderr, code } = await runPlease(':boolean.not(5)', [
+      '--no-color',
+    ])
+    assert.equal(code, 1)
+    assert.equal(stdout, '')
+    assert.match(stderr, /^Error: argument with type `5`/)
+    assert.ok(stderr.includes('\n<stdin>:1:14\n'))
+    assert.ok(stderr.includes('\n1 │ :boolean.not(5)\n'))
+    assert.ok(stderr.includes('\n  │              ▔\n'))
   })
 
   test('underlines a sub-expression error on a later line', async () => {

--- a/src/language/compiling/error-spans.test.ts
+++ b/src/language/compiling/error-spans.test.ts
@@ -37,6 +37,12 @@ suite('compile attaches source spans to elaboration errors', () => {
 
     const source2 = '{2: {}}.(1 + 1).(1 + 1).(1 + 1)'
     assert.deepEqual(compileErrorSpan(source2), [16, 23])
+
+    const source3 = '{}.a.b.c'
+    assert.deepEqual(compileErrorSpan(source3), [3, 4])
+
+    const source4 = '{ a: {} }.a.b.c'
+    assert.deepEqual(compileErrorSpan(source4), [12, 13])
   })
 
   test('unknown keyword spans the keyword expression', () => {

--- a/src/language/parsing/expression.ts
+++ b/src/language/parsing/expression.ts
@@ -10,11 +10,10 @@ import {
   type Parser,
 } from '@matt.kantor/parsing'
 import type { OrderedRecord } from '../../ordered-record.js'
-import * as orderedRecord from '../../ordered-record.js'
-import { arrayToMolecule, ignoredKey } from '../semantics.js'
+import { ignoredKey } from '../semantics.js'
 import {
-  atom,
   atomWithAdditionalQuotationRequirements,
+  atom as rawAtom,
   unquotedAtomParser,
   type Atom,
 } from './atom.js'
@@ -36,15 +35,22 @@ import {
   optionallySurroundedByParentheses,
   surroundedByParentheses,
 } from './parentheses.js'
-import { recordExpressionSpan } from './spans.js'
+import {
+  recordSpan,
+  spannedAtom,
+  syntheticAtom,
+  syntheticMolecule,
+  type SpannedAtom,
+  type SpannedMolecule,
+  type SpannedTree,
+} from './spans.js'
 import { optionalTrivia, trivia, triviaExceptNewlines } from './trivia.js'
 
 // `interface` (not `type`) is used to avoid a circular reference error.
 export interface Molecule extends OrderedRecord<Atom | Molecule> {}
 
-const molecule = (
-  entries: Iterable<readonly [string, Atom | Molecule]>,
-): Molecule => orderedRecord.make(entries)
+// Leaf atoms carry their own source spans.
+const atom: Parser<SpannedAtom> = spannedAtom(rawAtom)
 
 // Keyless properties are automatically assigned numeric indexes, which uses
 // some mutable state.
@@ -63,40 +69,48 @@ const optional = <Output>(
   parser: Parser<NonNullable<Output>>,
 ): Parser<Output | undefined> => oneOf([parser, nothing])
 
+const spannedArrayToMolecule = (
+  elements: readonly SpannedTree[],
+): SpannedMolecule =>
+  syntheticMolecule(elements.map((element, index) => [String(index), element]))
+
 const trailingIndexesAndArgumentsToExpression = (
-  root: Atom | Molecule,
+  root: SpannedTree,
   trailingIndexesAndArguments: readonly TrailingIndexOrArgument[],
-): Atom | Molecule =>
-  trailingIndexesAndArguments.reduce((expression, indexOrArgument) => {
-    switch (indexOrArgument.kind) {
-      case 'argument':
-        return molecule([
-          ['0', '@apply'],
-          [
-            '1',
-            molecule([
-              ['function', expression],
-              ['argument', indexOrArgument.argument],
-            ]),
-          ],
-        ])
-      case 'index':
-        return molecule([
-          ['0', '@index'],
-          [
-            '1',
-            molecule([
-              ['object', expression],
-              ['query', arrayToMolecule(indexOrArgument.query)],
-            ]),
-          ],
-        ])
-    }
-  }, root)
+): SpannedTree =>
+  trailingIndexesAndArguments.reduce<SpannedTree>(
+    (expression, indexOrArgument) => {
+      switch (indexOrArgument.kind) {
+        case 'argument':
+          return syntheticMolecule([
+            ['0', syntheticAtom('@apply')],
+            [
+              '1',
+              syntheticMolecule([
+                ['function', expression],
+                ['argument', indexOrArgument.argument],
+              ]),
+            ],
+          ])
+        case 'index':
+          return syntheticMolecule([
+            ['0', syntheticAtom('@index')],
+            [
+              '1',
+              syntheticMolecule([
+                ['object', expression],
+                ['query', spannedArrayToMolecule(indexOrArgument.query)],
+              ]),
+            ],
+          ])
+      }
+    },
+    root,
+  )
 
 const signatureTokensToExpression = (
-  tokens: readonly [Atom | Molecule, ...(Atom | Molecule)[], Atom | Molecule],
-): Molecule | Atom => {
+  tokens: readonly [SpannedTree, ...SpannedTree[], SpannedTree],
+): SpannedTree => {
   const [lastReturnType, lastParameterType, ...additionalParameterTypes] =
     tokens.toReversed()
 
@@ -107,24 +121,27 @@ const signatureTokensToExpression = (
     throw new Error('Signature parameter type did not exist. This is a bug!')
   }
 
-  const initialSignature = molecule([
-    ['0', '@function'],
+  const initialSignature = syntheticMolecule([
+    ['0', syntheticAtom('@function')],
     [
       '1',
-      molecule([
-        ['parameter', molecule([[ignoredKey, lastParameterType]])],
+      syntheticMolecule([
+        ['parameter', syntheticMolecule([[ignoredKey, lastParameterType]])],
         ['body', lastReturnType],
       ]),
     ],
   ])
-  return additionalParameterTypes.reduce(
+  return additionalParameterTypes.reduce<SpannedTree>(
     (expression, additionalParameter) =>
-      molecule([
-        ['0', '@function'],
+      syntheticMolecule([
+        ['0', syntheticAtom('@function')],
         [
           '1',
-          molecule([
-            ['parameter', molecule([[ignoredKey, additionalParameter]])],
+          syntheticMolecule([
+            [
+              'parameter',
+              syntheticMolecule([[ignoredKey, additionalParameter]]),
+            ],
             ['body', expression],
           ]),
         ],
@@ -134,17 +151,19 @@ const signatureTokensToExpression = (
 }
 
 const unionTokensToExpression = (
-  tokens: readonly [Atom | Molecule, ...(Atom | Molecule)[], Atom | Molecule],
-): Molecule | Atom => {
-  const members = molecule(tokens.map((token, index) => [String(index), token]))
-  return molecule([
-    ['0', '@union'],
+  tokens: readonly [SpannedTree, ...SpannedTree[], SpannedTree],
+): SpannedTree => {
+  const members = syntheticMolecule(
+    tokens.map((token, index) => [String(index), token]),
+  )
+  return syntheticMolecule([
+    ['0', syntheticAtom('@union')],
     ['1', members],
   ])
 }
 
-type InfixOperator = readonly [Atom, readonly TrailingIndexOrArgument[]]
-type InfixOperand = Atom | Molecule
+type InfixOperator = readonly [SpannedAtom, readonly TrailingIndexOrArgument[]]
+type InfixOperand = SpannedTree
 type InfixToken = InfixOperator | InfixOperand
 
 /**
@@ -161,9 +180,7 @@ const isOperand = (value: InfixToken | undefined): value is InfixOperand =>
 const isOperator = (value: InfixToken | undefined): value is InfixOperator =>
   Array.isArray(value)
 
-const infixTokensToExpression = (
-  operation: InfixOperation,
-): Molecule | Atom => {
+const infixTokensToExpression = (operation: InfixOperation): SpannedTree => {
   const firstToken = operation[0]
   if (operation.length === 1 && isOperand(firstToken)) {
     return firstToken
@@ -190,25 +207,25 @@ const infixTokensToExpression = (
     }
 
     const leftmostFunction = trailingIndexesAndArgumentsToExpression(
-      molecule([
-        ['0', '@lookup'],
-        ['1', molecule([['key', leftmostOperator[0]]])],
+      syntheticMolecule([
+        ['0', syntheticAtom('@lookup')],
+        ['1', syntheticMolecule([['key', leftmostOperator[0]]])],
       ]),
       leftmostOperator[1],
     )
 
-    const reducedLeftmostOperation = molecule([
-      ['0', '@apply'],
+    const reducedLeftmostOperation = syntheticMolecule([
+      ['0', syntheticAtom('@apply')],
       [
         '1',
-        molecule([
+        syntheticMolecule([
           [
             'function',
-            molecule([
-              ['0', '@apply'],
+            syntheticMolecule([
+              ['0', syntheticAtom('@apply')],
               [
                 '1',
-                molecule([
+                syntheticMolecule([
                   ['function', leftmostFunction],
                   ['argument', leftmostOperationRHS],
                 ]),
@@ -227,11 +244,13 @@ const infixTokensToExpression = (
   }
 }
 
-const atomRequiringDotQuotation = atomWithAdditionalQuotationRequirements(dot)
+const atomRequiringDotQuotation: Parser<SpannedAtom> = spannedAtom(
+  atomWithAdditionalQuotationRequirements(dot),
+)
 
 const namedProperty = map(
   sequence([atom, colon, optionalTrivia, lazy(() => expression)]),
-  ([key, _colon, _trivia, value]) => [key, value] as const,
+  ([key, _colon, _trivia, value]) => [key.value, value] as const,
 )
 
 const propertyWithOptionalKey = optionallySurroundedByParentheses(
@@ -251,7 +270,7 @@ const propertyDelimiter = oneOf([
 
 const argument = surroundedByParentheses(lazy(() => expression))
 
-const dottedKeyPathKey = recordExpressionSpan(
+const dottedKeyPathKey = recordSpan(
   oneOf([
     // (a)
     // (1 + 1)
@@ -261,9 +280,9 @@ const dottedKeyPathKey = recordExpressionSpan(
 
     // :a
     map(sequence([colon, atomRequiringDotQuotation]), ([_colon, key]) =>
-      molecule([
-        ['0', '@lookup'],
-        ['1', molecule([['key', key]])],
+      syntheticMolecule([
+        ['0', syntheticAtom('@lookup')],
+        ['1', syntheticMolecule([['key', key]])],
       ]),
     ),
 
@@ -283,7 +302,7 @@ const dottedKeyPathComponent = map(
   ([_trivia1, _dot, _trivia2, key]) => key,
 )
 
-const sugarFreeMolecule: Parser<Molecule> = map(
+const sugarFreeMolecule: Parser<SpannedMolecule> = map(
   sequence([
     openingBrace,
     optionalTrivia,
@@ -314,7 +333,7 @@ const sugarFreeMolecule: Parser<Molecule> = map(
         [optionalInitialProperty, ...remainingProperties]
       )
     const enumerate = makeIncrementingIndexer()
-    return molecule(
+    return syntheticMolecule(
       properties.map(([key, value]) =>
         // Note that `enumerate()` increments its internal counter as a side
         // effect.
@@ -327,11 +346,11 @@ const sugarFreeMolecule: Parser<Molecule> = map(
 type TrailingIndexOrArgument =
   | {
       readonly kind: 'argument'
-      readonly argument: Molecule | Atom
+      readonly argument: SpannedTree
     }
   | {
       readonly kind: 'index'
-      readonly query: readonly (Molecule | Atom)[]
+      readonly query: readonly SpannedTree[]
     }
 
 const dottedKeyPath = oneOrMore(dottedKeyPathComponent)
@@ -362,7 +381,7 @@ const infixOperator = sequence([
   compactTrailingIndexesAndArguments,
 ])
 
-const compactExpression: Parser<Molecule | Atom> = recordExpressionSpan(
+const compactExpression: Parser<SpannedTree> = recordSpan(
   oneOf([
     // (a)
     // (1 + 1)
@@ -464,14 +483,14 @@ const trailingCheckToken = map(
 )
 
 const checkTokenToExpression = (
-  value: Atom | Molecule,
-  type: Atom | Molecule,
-): Molecule =>
-  molecule([
-    ['0', '@check'],
+  value: SpannedTree,
+  type: SpannedTree,
+): SpannedMolecule =>
+  syntheticMolecule([
+    ['0', syntheticAtom('@check')],
     [
       '1',
-      molecule([
+      syntheticMolecule([
         ['value', value],
         ['type', type],
       ]),
@@ -512,7 +531,7 @@ const trailingInfixTokens = oneOrMore(
 )
 
 // (a: :integer.type) => :a + 1
-const typedFunctionParameter: Parser<Molecule> = surroundedByParentheses(
+const typedFunctionParameter: Parser<SpannedMolecule> = surroundedByParentheses(
   map(
     sequence([
       atom,
@@ -521,11 +540,12 @@ const typedFunctionParameter: Parser<Molecule> = surroundedByParentheses(
       optionalTrivia,
       lazy(() => expression),
     ]),
-    ([name, _trivia1, _colon, _trivia2, type]) => molecule([[name, type]]),
+    ([name, _trivia1, _colon, _trivia2, type]) =>
+      syntheticMolecule([[name.value, type]]),
   ),
 )
 
-const functionParameter: Parser<Atom | Molecule> = oneOf([
+const functionParameter: Parser<SpannedTree> = oneOf([
   typedFunctionParameter,
   atom,
 ])
@@ -563,23 +583,23 @@ const precededByAtomThenFunctionArrow = map(
       ...trailingParameters.toReversed(),
       initialParameter,
     ]
-    const initialFunction = molecule([
-      ['0', '@function'],
+    const initialFunction = syntheticMolecule([
+      ['0', syntheticAtom('@function')],
       [
         '1',
-        molecule([
+        syntheticMolecule([
           ['parameter', lastParameter],
           ['body', body],
         ]),
       ],
     ])
-    return additionalParameters.reduce(
+    return additionalParameters.reduce<SpannedTree>(
       (expression, additionalParameter) =>
-        molecule([
-          ['0', '@function'],
+        syntheticMolecule([
+          ['0', syntheticAtom('@function')],
           [
             '1',
-            molecule([
+            syntheticMolecule([
               ['parameter', additionalParameter],
               ['body', expression],
             ]),
@@ -601,9 +621,9 @@ const precededByAtSign = map(
     optional(lazy(() => compactExpression)),
   ]),
   ([_atSign, keyword, _trivia, argument]) =>
-    molecule([
-      ['0', `@${keyword}`],
-      ['1', argument ?? orderedRecord.empty],
+    syntheticMolecule([
+      ['0', syntheticAtom(`@${keyword}`)],
+      ['1', argument ?? syntheticMolecule([])],
     ]),
 )
 
@@ -616,9 +636,9 @@ const precededByColonThenAtom = map(
   sequence([colon, atomRequiringDotQuotation, trailingIndexesAndArguments]),
   ([_colon, key, trailingIndexesAndArguments]) =>
     trailingIndexesAndArgumentsToExpression(
-      molecule([
-        ['0', '@lookup'],
-        ['1', molecule([['key', key]])],
+      syntheticMolecule([
+        ['0', syntheticAtom('@lookup')],
+        ['1', syntheticMolecule([['key', key]])],
       ]),
       trailingIndexesAndArguments,
     ),
@@ -656,29 +676,32 @@ const precededByOpeningBrace = map(
 )
 
 /** `:something.type` in desugared form. */
-const topTypeAsMolecule = molecule([
-  ['0', '@index'],
+const topTypeAsMolecule = syntheticMolecule([
+  ['0', syntheticAtom('@index')],
   [
     '1',
-    molecule([
+    syntheticMolecule([
       [
         'object',
-        molecule([
-          ['0', '@lookup'],
-          ['1', molecule([['key', 'something']])],
+        syntheticMolecule([
+          ['0', syntheticAtom('@lookup')],
+          ['1', syntheticMolecule([['key', syntheticAtom('something')]])],
         ]),
       ],
-      ['query', molecule([['0', 'type']])],
+      ['query', syntheticMolecule([['0', syntheticAtom('type')]])],
     ]),
   ],
 ])
 
-const makeHoleMolecule = (name: Atom, constraint: Molecule): Molecule =>
-  molecule([
-    ['0', '@hole'],
+const makeHoleMolecule = (
+  name: SpannedTree,
+  constraint: SpannedMolecule,
+): SpannedMolecule =>
+  syntheticMolecule([
+    ['0', syntheticAtom('@hole')],
     [
       '1',
-      molecule([
+      syntheticMolecule([
         ['name', name],
         ['constraint', constraint],
       ]),
@@ -691,8 +714,8 @@ const hole = map(
   sequence([questionMark, optional(atomRequiringDotQuotation)]),
   ([_questionMark, name]) =>
     makeHoleMolecule(
-      name ?? ignoredKey,
-      molecule([['assignableTo', topTypeAsMolecule]]),
+      name ?? syntheticAtom(ignoredKey),
+      syntheticMolecule([['assignableTo', topTypeAsMolecule]]),
     ),
 )
 
@@ -710,13 +733,13 @@ const parenthesizedHole = surroundedByParentheses(
     ]),
     ([_questionMark, name, _trivia1, _colon, _trivia2, constraint]) =>
       makeHoleMolecule(
-        name ?? ignoredKey,
-        molecule([['assignableTo', constraint]]),
+        name ?? syntheticAtom(ignoredKey),
+        syntheticMolecule([['assignableTo', constraint]]),
       ),
   ),
 )
 
-const expressionWhichMayHaveTrailingExpressions = recordExpressionSpan(
+const expressionWhichMayHaveTrailingExpressions = recordSpan(
   oneOf([
     parenthesizedHole,
     precededByOpeningParenthesis,
@@ -729,12 +752,12 @@ const expressionWhichMayHaveTrailingExpressions = recordExpressionSpan(
   ]),
 )
 
-const trailingInfixExpression = (initialExpression: string | Molecule) =>
+const trailingInfixExpression = (initialExpression: SpannedTree) =>
   map(trailingInfixTokens, trailingInfixTokens =>
     infixTokensToExpression([initialExpression, ...trailingInfixTokens.flat()]),
   )
 
-const trailingSignatureExpression = (initialExpression: string | Molecule) =>
+const trailingSignatureExpression = (initialExpression: SpannedTree) =>
   map(trailingSignatureTokens, trailingSignatureTokens =>
     signatureTokensToExpression([
       initialExpression,
@@ -742,24 +765,24 @@ const trailingSignatureExpression = (initialExpression: string | Molecule) =>
     ]),
   )
 
-const trailingCheckExpression = (initialExpression: string | Molecule) =>
+const trailingCheckExpression = (initialExpression: SpannedTree) =>
   map(trailingCheckToken, trailingCheckType =>
     checkTokenToExpression(initialExpression, trailingCheckType),
   )
 
-const trailingUnionExpression = (initialExpression: string | Molecule) =>
+const trailingUnionExpression = (initialExpression: SpannedTree) =>
   map(trailingUnionTokens, trailingUnionTokens =>
     unionTokensToExpression([initialExpression, ...trailingUnionTokens]),
   )
 
-const trailingExpressionsExceptUnion = (initialExpression: string | Molecule) =>
+const trailingExpressionsExceptUnion = (initialExpression: SpannedTree) =>
   [
     trailingInfixExpression(initialExpression),
     trailingSignatureExpression(initialExpression),
     trailingCheckExpression(initialExpression),
   ] as const
 
-export const expression: Parser<Atom | Molecule> = recordExpressionSpan(
+export const expression: Parser<SpannedTree> = recordSpan(
   flatMap(expressionWhichMayHaveTrailingExpressions, initialExpression =>
     oneOf([
       ...trailingExpressionsExceptUnion(initialExpression),

--- a/src/language/parsing/parser.ts
+++ b/src/language/parsing/parser.ts
@@ -1,10 +1,15 @@
 import either, { type Either } from '@matt.kantor/either'
 import parsing from '@matt.kantor/parsing'
 import type { ParseError } from '../errors.js'
-import { spansFromSyntaxTree, type ExpressionSpansByLocation } from './spans.js'
+import {
+  spansFromSpannedTree,
+  toSyntaxTree,
+  type ExpressionSpansByLocation,
+  type SpannedTree,
+} from './spans.js'
 import { syntaxTreeParser, type SyntaxTree } from './syntax-tree.js'
 
-export const parse = (input: string): Either<ParseError, SyntaxTree> =>
+const parseSpanned = (input: string): Either<ParseError, SpannedTree> =>
   either.mapLeft(
     parsing.parse(syntaxTreeParser, input),
     (error): ParseError => {
@@ -20,6 +25,9 @@ export const parse = (input: string): Either<ParseError, SyntaxTree> =>
     },
   )
 
+export const parse = (input: string): Either<ParseError, SyntaxTree> =>
+  either.map(parseSpanned(input), toSyntaxTree)
+
 export type SyntaxTreeWithSpans = {
   readonly tree: SyntaxTree
   readonly spans: ExpressionSpansByLocation
@@ -28,7 +36,7 @@ export type SyntaxTreeWithSpans = {
 export const parseWithSpans = (
   input: string,
 ): Either<ParseError, SyntaxTreeWithSpans> =>
-  either.map(parse(input), tree => ({
-    tree,
-    spans: spansFromSyntaxTree(tree),
+  either.map(parseSpanned(input), spanned => ({
+    tree: toSyntaxTree(spanned),
+    spans: spansFromSpannedTree(spanned),
   }))

--- a/src/language/parsing/spans.test.ts
+++ b/src/language/parsing/spans.test.ts
@@ -42,7 +42,37 @@ suite('parseWithSpans', () => {
     assert.equal(source.slice(5), '{ a: 1 }')
   })
 
-  test('does not record spans for atoms', () => {
-    assert.equal(spansOf('42').size, 0)
+  test('records an atom span', () => {
+    const source = '{ a: 5 }'
+    assert.deepEqual(
+      spansOf(source).get(stringifyKeyPathForInternalUse(['a'])),
+      [5, 6],
+    )
+    assert.equal(source.slice(5, 6), '5')
+  })
+
+  test('records distinct spans for repeated atoms', () => {
+    const source = '{ a: 1, b: 1 }'
+    const spans = spansOf(source)
+    assert.deepEqual(spans.get(stringifyKeyPathForInternalUse(['a'])), [5, 6])
+    assert.deepEqual(spans.get(stringifyKeyPathForInternalUse(['b'])), [11, 12])
+    assert.equal(source.slice(5, 6), '1')
+    assert.equal(source.slice(11, 12), '1')
+  })
+
+  test('records a quoted atom span covering its source form', () => {
+    const source = '{ a: "x y" }'
+    assert.deepEqual(
+      spansOf(source).get(stringifyKeyPathForInternalUse(['a'])),
+      [5, 10],
+    )
+    assert.equal(source.slice(5, 10), '"x y"')
+  })
+
+  test('records the whole-program span for a bare top-level atom', () => {
+    assert.deepEqual(
+      spansOf('42').get(stringifyKeyPathForInternalUse([])),
+      [0, 2],
+    )
   })
 })

--- a/src/language/parsing/spans.ts
+++ b/src/language/parsing/spans.ts
@@ -1,12 +1,15 @@
 import either from '@matt.kantor/either'
 import type { Parser } from '@matt.kantor/parsing'
+import type { OrderedRecord } from '../../ordered-record.js'
+import * as orderedRecord from '../../ordered-record.js'
 import {
   stringifyKeyPathForInternalUse,
+  type KeyPath,
   type KeyPathStringifiedForInternalUse,
 } from '../semantics.js'
 import type { Span } from '../source-location.js'
 import type { Atom } from './atom.js'
-import type { Molecule } from './expression.js'
+import type { SyntaxTree } from './syntax-tree.js'
 
 /**
  * Maps parsed expressions' key paths to their source spans.
@@ -16,55 +19,98 @@ export type ExpressionSpansByLocation = ReadonlyMap<
   Span
 >
 
-// Each parsed molecule's source span is stashed in here (by identity) while
-// parsing. The `WeakMap` allows entries to be garbage-collected once their
-// syntax tree is no longer needed.
-const spanByMolecule = new WeakMap<Molecule, Span>()
+/**
+ * A parse tree in which every node carries its source span. `span` is the
+ * region a node covers, or `undefined` for synthetic nodes introduced by
+ * desugaring.
+ */
+export type SpannedAtom = {
+  readonly span: Span | undefined
+  readonly value: Atom
+}
+export type SpannedMolecule = {
+  readonly span: Span | undefined
+  readonly value: OrderedRecord<SpannedTree>
+}
+export type SpannedTree = SpannedAtom | SpannedMolecule
 
 /**
- * Wrap the given parser so every nesting level records the spans of produced
- * molecules as a side effect.
+ * Wrap a leaf atom parser so each parsed atom records its exact source span.
  */
-export const recordExpressionSpan =
-  (parser: Parser<Atom | Molecule>): Parser<Atom | Molecule> =>
+export const spannedAtom =
+  (parser: Parser<Atom>): Parser<SpannedAtom> =>
   (input, offset = 0n) =>
-    either.map(parser(input, offset), success => {
-      // Atoms are strings and can't key a `WeakMap`; only molecules get spans.
-      if (typeof success.output !== 'string') {
-        // Side effect: keep track of the span.
-        spanByMolecule.set(success.output, [
-          Number(offset),
-          Number(success.offset),
-        ])
-      }
-      return success
-    })
+    either.map(parser(input, offset), success => ({
+      offset: success.offset,
+      output: {
+        span: spanFromOffsets(offset, success.offset),
+        value: success.output,
+      },
+    }))
 
-export const spansFromSyntaxTree = (
-  tree: Atom | Molecule,
-): ExpressionSpansByLocation => new Map(spanEntriesWithinSubtree(tree, []))
+/**
+ * Override the produced node's span with the source region it consumed. Used at
+ * the expression-nesting sites to capture leading sigils (`:`, `@`) and
+ * delimiters (`{}`, `()`) that a node's children don't cover.
+ */
+export const recordSpan =
+  (parser: Parser<SpannedTree>): Parser<SpannedTree> =>
+  (input, offset = 0n) =>
+    either.map(parser(input, offset), success => ({
+      offset: success.offset,
+      output: {
+        ...success.output,
+        span: spanFromOffsets(offset, success.offset),
+      },
+    }))
 
-const spanEntriesWithinSubtree = (
-  node: Atom | Molecule,
-  keyPath: readonly Atom[],
+/**
+ * Build a synthetic atom node (no source span of its own).
+ */
+export const syntheticAtom = (value: Atom): SpannedAtom => ({
+  span: undefined,
+  value,
+})
+
+/**
+ * Build a synthetic molecule node (no source span of its own).
+ */
+export const syntheticMolecule = (
+  entries: Iterable<readonly [string, SpannedTree]>,
+): SpannedMolecule => ({ span: undefined, value: orderedRecord.make(entries) })
+
+/**
+ * Drop spans from the syntax tree.
+ */
+export const toSyntaxTree = (node: SpannedTree): SyntaxTree =>
+  typeof node.value === 'string' ?
+    node.value
+  : orderedRecord.mapValues(node.value, toSyntaxTree)
+
+export const spansFromSpannedTree = (
+  tree: SpannedTree,
+): ExpressionSpansByLocation => new Map(spanEntries(tree, []))
+
+const spanFromOffsets = (start: bigint, end: bigint): Span => [
+  Number(start),
+  Number(end),
+]
+
+// Recursively find all spans within the given `node`.
+const spanEntries = (
+  node: SpannedTree,
+  keyPath: KeyPath,
 ): readonly (readonly [KeyPathStringifiedForInternalUse, Span])[] => {
-  if (typeof node === 'string') {
-    return []
-  } else {
-    const spanForThisMolecule = spanByMolecule.get(node)
-    const entryForThisMolecule =
-      spanForThisMolecule === undefined ? undefined : (
-        ([
-          stringifyKeyPathForInternalUse(keyPath),
-          spanForThisMolecule,
-        ] as const)
+  const descendantSpanEntries =
+    typeof node.value === 'string' ?
+      []
+    : node.value.entries.flatMap(([key, value]) =>
+        spanEntries(value, [...keyPath, key]),
       )
-    const entriesForChildren = node.entries.flatMap(([key, value]) =>
-      spanEntriesWithinSubtree(value, [...keyPath, key]),
-    )
-
-    return entryForThisMolecule === undefined ? entriesForChildren : (
-        [entryForThisMolecule, ...entriesForChildren]
-      )
-  }
+  return node.span === undefined ?
+      descendantSpanEntries
+    : [
+        [stringifyKeyPathForInternalUse(keyPath), node.span],
+        ...descendantSpanEntries,
+      ]
 }

--- a/src/language/parsing/syntax-tree.ts
+++ b/src/language/parsing/syntax-tree.ts
@@ -1,11 +1,12 @@
 import { map, sequence, type Parser } from '@matt.kantor/parsing'
 import type { Atom } from './atom.js'
 import { expression, type Molecule } from './expression.js'
+import type { SpannedTree } from './spans.js'
 import { optionalTrivia } from './trivia.js'
 
 export type SyntaxTree = Atom | Molecule
 
-export const syntaxTreeParser: Parser<SyntaxTree> = map(
+export const syntaxTreeParser: Parser<SpannedTree> = map(
   sequence([optionalTrivia, expression, optionalTrivia]),
   ([_leadingTrivia, syntaxTree, _trailingTrivia]) => syntaxTree,
 )


### PR DESCRIPTION
This improves the locality of underlines in error messages.

Rather than having the parsers hackily record spans in a `WeakMap` as a side effect, the expression parser now returns a `SpannedTree` which directly includes source spans for all non-synthetic (desugared) expressions.

#### Before:
<img width="670" height="115" alt="Screenshot 2026-07-16 at 3 52 39 PM" src="https://github.com/user-attachments/assets/bdf7b9ca-476b-4e1f-af70-d0b3b1a1e268" />

#### After:
<img width="673" height="113" alt="Screenshot 2026-07-16 at 3 52 48 PM" src="https://github.com/user-attachments/assets/eae36dbe-a031-4b55-9f6a-4657ec409243" />
