### PR TITLE
Add the `@object` keyword for expressing excess property bounds

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -646,6 +646,8 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     )(es)`,
     success('Hola'),
   ],
+  [`((x: { a: :integer.type }) => :x.a)({ a: 42, b: extra })`, success('42')],
+  [`((x: :object.type) => :x)({ a: 1, b: {} })`, success({ a: '1', b: {} })],
   [
     // Lookups should never target keyword expression properties.
     `{
@@ -902,6 +904,63 @@ testCases(endToEnd, code => code)('end-to-end tests', [
       {a:{b:{1:{2:{true:{false:{🎉:"it works"}}}}}}}.a.:key1.(1).(1 + 1).(:boolean.not(false)).(:get_key2(_)).(@runtime { _ => 🎉 })
     }.0`,
     success('it works'),
+  ],
+  [
+    `(x: @object {
+      properties: {}
+      excess: {
+        { :atom.type, :nothing.type }
+        { :natural_number.type, :atom.type }
+      }
+    }) =>
+      (:x ~ @object {
+        properties: {}
+        excess: {
+          { :atom.type, :atom.type }
+        }
+      })`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+  [
+    `(x: @object {
+      properties: {}
+      excess: {
+        { :atom.type, :atom.type }
+      }
+    }) =>
+      (:x ~ @object {
+        properties: {}
+        excess: {
+          { :atom.type, :atom.type }
+          { :natural_number.type, :integer.type }
+        }
+      })`,
+    typeMismatch,
+  ],
+  [
+    `(x: @object {
+      properties: { a: :integer.type }
+      excess: {
+        { :atom.type, :atom.type }
+        { :natural_number.type, :integer.type }
+      }
+    }) =>
+      (:object.lookup(5)(:x) ~ :option.type(:integer.type))`,
+    result => {
+      assert(either.isRight(result))
+    },
+  ],
+  [
+    `(x: { a: :atom.type }) => (y: { b: :atom.type }) =>
+      (:object.overlay(:x)(:y) ~ @object {
+        properties: { a: :atom.type, b: :something.type }
+        excess: {
+          { :atom.type, :nothing.type }
+        }
+      })`,
+    typeMismatch,
   ],
   [
     `:match({ a: (v: :integer.type) => :v })({ tag: a, value: hello })`,

--- a/src/language/cli/please.test.ts
+++ b/src/language/cli/please.test.ts
@@ -67,7 +67,11 @@ suite('please CLI error reporting', () => {
     ])
     assert.equal(code, 1)
     assert.equal(stdout, '')
-    assert.match(stderr, /^Error: argument with type `{}`/)
+    assert.ok(
+      stderr.startsWith(
+        'Error: argument with type `@object { properties: {}, excess: { { :atom.type, :nothing.type } } }`',
+      ),
+    )
     assert.ok(stderr.includes('\n<stdin>:1:14\n'))
     assert.ok(stderr.includes('\n1 │ :boolean.not({})\n'))
     assert.ok(stderr.includes('\n  │              ▔▔\n'))

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -101,6 +101,7 @@ export const ifKeywordHandler: KeywordHandler = (
                     '@function': doNotElaborate,
                     '@hole': doNotElaborate,
                     '@if': doNotElaborate,
+                    '@object': doNotElaborate,
                     '@panic': doNotElaborate,
                     '@runtime': doNotElaborate,
                     '@todo': doNotElaborate,

--- a/src/language/compiling/semantics/keyword-handlers/object-type-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/object-type-handler.test.ts
@@ -1,0 +1,811 @@
+import either from '@matt.kantor/either'
+import assert from 'node:assert'
+import type { JsonValue } from '../../../../utility-types.js'
+import {
+  arrayToMolecule,
+  makeIndexExpression,
+  makeLookupExpression,
+  objectNodeFromMolecule,
+  serialize,
+} from '../../../semantics.js'
+import { prettyJson, unparse } from '../../../unparsing.js'
+import { elaborationSuite, success } from '../test-utilities.test.js'
+
+const resolve = (
+  lookupKey: string,
+  ...indexQuery: readonly string[]
+): JsonValue =>
+  either.unwrapOrElse(
+    either.map(
+      either.flatMap(
+        serialize(
+          indexQuery.length === 0 ?
+            makeLookupExpression(lookupKey)
+          : makeIndexExpression({
+              object: makeLookupExpression(lookupKey),
+              query: objectNodeFromMolecule(arrayToMolecule(indexQuery)),
+            }),
+        ),
+        molecule => unparse(molecule, prettyJson),
+      ),
+      json =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        JSON.parse(json) as JsonValue,
+    ),
+    error => {
+      throw new Error(error.message, { cause: error })
+    },
+  )
+
+elaborationSuite('@object', [
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: { a: resolve('integer', 'type') },
+                  excess: {
+                    0: {
+                      0: resolve('atom', 'type'),
+                      1: resolve('something', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x', 'a'),
+          },
+        },
+        argument: { a: 42, b: 'extra' },
+      },
+    },
+    success('42'),
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: {},
+                  excess: {
+                    0: {
+                      0: resolve('atom', 'type'),
+                      1: resolve('integer', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { a: 1, b: 2 },
+      },
+    },
+    success({ a: 1, b: 2 }),
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: {},
+                  excess: {
+                    0: {
+                      0: resolve('atom', 'type'),
+                      1: resolve('integer', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { a: 'hello' },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: { a: resolve('integer', 'type') },
+                  excess: {
+                    0: {
+                      0: resolve('atom', 'type'),
+                      1: resolve('nothing', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { a: 1, b: 2 },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: { a: resolve('integer', 'type') },
+                  excess: {
+                    0: {
+                      0: resolve('atom', 'type'),
+                      1: resolve('nothing', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { a: 1 },
+      },
+    },
+    success({ a: '1' }),
+  ],
+  [
+    {
+      closed: {
+        0: '@object',
+        1: {
+          properties: {},
+          excess: {
+            0: {
+              0: resolve('atom', 'type'),
+              1: resolve('nothing', 'type'),
+            },
+          },
+        },
+      },
+      result: {
+        0: '@apply',
+        1: {
+          function: {
+            0: '@function',
+            1: {
+              parameter: { x: resolve('closed') },
+              body: resolve('x'),
+            },
+          },
+          argument: { a: 1 },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: {},
+                  excess: {
+                    0: {
+                      0: resolve('natural_number', 'type'),
+                      1: resolve('integer', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { 0: -5, foo: {} },
+      },
+    },
+    success({ 0: -5, foo: {} }),
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@object',
+                1: {
+                  properties: {},
+                  excess: {
+                    0: {
+                      0: resolve('natural_number', 'type'),
+                      1: resolve('integer', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { 0: 'hello' },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@hole',
+                1: {
+                  name: '_',
+                  constraint: {
+                    assignableTo: {
+                      0: '@object',
+                      1: {
+                        properties: {},
+                        excess: {
+                          0: {
+                            0: resolve('atom', 'type'),
+                            1: resolve('atom', 'type'),
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { hello: 'world' },
+      },
+    },
+    success({ hello: 'world' }),
+  ],
+  [
+    {
+      0: '@apply',
+      1: {
+        function: {
+          0: '@function',
+          1: {
+            parameter: {
+              x: {
+                0: '@hole',
+                1: {
+                  name: '_',
+                  constraint: {
+                    assignableTo: {
+                      0: '@object',
+                      1: {
+                        properties: {},
+                        excess: {
+                          0: {
+                            0: resolve('atom', 'type'),
+                            1: resolve('atom', 'type'),
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            body: resolve('x'),
+          },
+        },
+        argument: { not_an_atom: {} },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: 1 },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('atom', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    success({ a: '1' }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: {} },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('atom', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: 1 },
+        type: {
+          0: '@object',
+          1: {
+            properties: { a: resolve('integer', 'type') },
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('nothing', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    success({ a: '1' }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: 1, b: 2 },
+        type: {
+          0: '@object',
+          1: {
+            properties: { a: resolve('integer', 'type') },
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('nothing', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: { b: 1, c: 2 } },
+        type: {
+          0: '@object',
+          1: {
+            properties: { a: { b: resolve('integer', 'type') } },
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('nothing', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    success({ a: { b: '1', c: '2' } }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: { b: 1, c: 2 } },
+        type: {
+          0: '@object',
+          1: {
+            properties: {
+              a: {
+                0: '@object',
+                1: {
+                  properties: { b: resolve('integer', 'type') },
+                  excess: {
+                    0: {
+                      0: resolve('atom', 'type'),
+                      1: resolve('nothing', 'type'),
+                    },
+                  },
+                },
+              },
+            },
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('nothing', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: 1, b: 2 },
+        type: {
+          0: '@union',
+          1: {
+            0: {
+              0: '@object',
+              1: {
+                properties: { b: resolve('integer', 'type') },
+                excess: {
+                  0: {
+                    0: resolve('atom', 'type'),
+                    1: resolve('nothing', 'type'),
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { 1: 'hello', name: {} },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('natural_number', 'type'),
+                1: resolve('atom', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    success({ 1: 'hello', name: {} }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { 1: {} },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('natural_number', 'type'),
+                1: resolve('atom', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  // A key inhabiting several clauses' domains is bounded by the last matching
+  // clause.
+  [
+    {
+      0: '@check',
+      1: {
+        value: { 1: 'hello' },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('nothing', 'type'),
+              },
+              1: {
+                0: resolve('natural_number', 'type'),
+                1: resolve('atom', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    success({ 1: 'hello' }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { 1: 'hello' },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('atom', 'type'),
+              },
+              1: {
+                0: resolve('natural_number', 'type'),
+                1: resolve('integer', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { name: 'x' },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('nothing', 'type'),
+              },
+              1: {
+                0: resolve('natural_number', 'type'),
+                1: resolve('atom', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { x: 'hello' },
+        type: {
+          0: '@object',
+          1: {
+            properties: {},
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('atom', 'type'),
+              },
+              1: {
+                0: resolve('natural_number', 'type'),
+                1: resolve('integer', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    success({ x: 'hello' }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: 'hello' },
+        type: {
+          0: '@object',
+          1: {
+            properties: { a: resolve('atom', 'type') },
+            excess: {
+              0: { 0: 'a', 1: resolve('nothing', 'type') },
+            },
+          },
+        },
+      },
+    },
+    success({ a: 'hello' }),
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: { a: 'hello', b: 'x' },
+        type: {
+          0: '@object',
+          1: {
+            properties: { a: resolve('atom', 'type') },
+            excess: {
+              0: {
+                0: { 0: '@union', 1: { 0: 'a', 1: 'b' } },
+                1: resolve('nothing', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'typeMismatch')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: {},
+        type: {
+          0: '@object',
+          1: { properties: {} },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'invalidExpression')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: {},
+        type: {
+          0: '@object',
+          1: {
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('something', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'invalidExpression')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: {},
+        type: { 0: '@object', 1: {} },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'invalidExpression')
+    },
+  ],
+  [
+    {
+      0: '@check',
+      1: {
+        value: {},
+        type: {
+          0: '@object',
+          1: {
+            properties: 'not an object',
+            excess: {
+              0: {
+                0: resolve('atom', 'type'),
+                1: resolve('something', 'type'),
+              },
+            },
+          },
+        },
+      },
+    },
+    output => {
+      assert(either.isLeft(output))
+      assert.deepEqual(output.value.kind, 'invalidExpression')
+    },
+  ],
+])

--- a/src/language/compiling/semantics/keyword-handlers/object-type-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/object-type-handler.ts
@@ -1,0 +1,24 @@
+import either, { type Either } from '@matt.kantor/either'
+import type { ElaborationError } from '../../../errors.js'
+import type {
+  Expression,
+  ExpressionContext,
+  KeywordHandler,
+  SemanticGraph,
+} from '../../../semantics.js'
+import {
+  readExcessClauses,
+  readObjectTypeExpression,
+} from '../../../semantics/expressions/object-type-expression.js'
+
+export const objectTypeKeywordHandler: KeywordHandler = (
+  expression: Expression,
+  _context: ExpressionContext,
+): Either<ElaborationError, SemanticGraph> =>
+  // This is only used in types and doesn't need transformation here, but it's
+  // validated so that malformed `@object`s fail during elaboration rather than
+  // surfacing later as surprising types.
+  either.map(
+    either.flatMap(readObjectTypeExpression(expression), readExcessClauses),
+    _ => expression,
+  )

--- a/src/language/compiling/semantics/keywords.ts
+++ b/src/language/compiling/semantics/keywords.ts
@@ -6,6 +6,7 @@ import { holeKeywordHandler } from './keyword-handlers/hole-handler.js'
 import { ifKeywordHandler } from './keyword-handlers/if-handler.js'
 import { indexKeywordHandler } from './keyword-handlers/index-handler.js'
 import { lookupKeywordHandler } from './keyword-handlers/lookup-handler.js'
+import { objectTypeKeywordHandler } from './keyword-handlers/object-type-handler.js'
 import { panicKeywordHandler } from './keyword-handlers/panic-handler.js'
 import { runtimeKeywordHandler } from './keyword-handlers/runtime-handler.js'
 import { todoKeywordHandler } from './keyword-handlers/todo-handler.js'
@@ -46,6 +47,11 @@ export const keywordHandlers: KeywordHandlers = {
    * Gets the value of a property with the given key (using lexical scoping).
    */
   '@lookup': lookupKeywordHandler,
+
+  /**
+   * Creates an object type with excess property bounds.
+   */
+  '@object': objectTypeKeywordHandler,
 
   /**
    * Immediately terminates the process when evaluated.

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -54,6 +54,11 @@ export {
   type LookupExpression,
 } from './semantics/expressions/lookup-expression.js'
 export {
+  makeObjectTypeExpression,
+  readObjectTypeExpression,
+  type ObjectTypeExpression,
+} from './semantics/expressions/object-type-expression.js'
+export {
   readPanicExpression,
   type PanicExpression,
 } from './semantics/expressions/panic-expression.js'

--- a/src/language/semantics/expressions/object-type-expression.ts
+++ b/src/language/semantics/expressions/object-type-expression.ts
@@ -1,0 +1,153 @@
+import either, { type Either } from '@matt.kantor/either'
+import type { ElaborationError } from '../../errors.js'
+import { isExpression, isKeywordExpressionWithArgument } from '../expression.js'
+import {
+  isObjectNode,
+  makeObjectNode,
+  type ObjectNode,
+} from '../object-node.js'
+import type { SemanticGraph } from '../semantic-graph.js'
+import { readArgumentsFromExpression } from './expression-utilities.js'
+
+export type ObjectTypeExpression = ObjectNode & {
+  readonly 0: '@object'
+  readonly 1: ObjectNode & {
+    readonly properties: ObjectNode
+    /**
+     * Clauses bounding the values of properties not listed in `properties`, as
+     * an enumerated object containing key/value pairs. For example:
+     * ```plz
+     * @object {
+     *   properties: …
+     *   excess: {
+     *     { :atom.type, :integer.type }
+     *     { :natural_number.type, :boolean.type }
+     *   }
+     * }
+     * ```
+     * When multiple clauses have overlapping keys, the last clause targeting
+     * the given key takes effect. The example above means "natural-number-keyed
+     * excess properties must have boolean values, while every other excess
+     * property must have an integer value".
+     */
+    readonly excess: ObjectNode
+  }
+}
+
+type ExcessClause = readonly [keys: SemanticGraph, values: SemanticGraph]
+
+export const readObjectTypeExpression = (
+  node: SemanticGraph,
+): Either<ElaborationError, ObjectTypeExpression> =>
+  isKeywordExpressionWithArgument('@object', node) ?
+    either.flatMap(
+      readArgumentsFromExpression(node, ['properties', 'excess']),
+      ([properties, excess]): Either<ElaborationError, ObjectTypeExpression> =>
+        either.flatMap(
+          readPlainObjectOperand(properties, 'properties'),
+          validProperties =>
+            either.map(readPlainObjectOperand(excess, 'excess'), validExcess =>
+              makeObjectTypeExpression(validProperties, validExcess),
+            ),
+        ),
+    )
+  : either.makeLeft({
+      kind: 'invalidExpression',
+      message: 'not an `@object` expression',
+    })
+
+const readPlainObjectOperand = (
+  operand: SemanticGraph,
+  operandName: string,
+): Either<ElaborationError, ObjectNode> =>
+  !isObjectNode(operand) ?
+    either.makeLeft({
+      kind: 'invalidExpression',
+      message: `\`@object\` ${operandName} must be an object`,
+    })
+    // A keyword expression is itself an `ObjectNode`, so without this check
+    // its `0`/`1` properties would silently be read as ordinary entries.
+  : isExpression(operand) ?
+    either.makeLeft({
+      kind: 'invalidExpression',
+      message: `\`@object\` ${operandName} must be an object, not a keyword expression`,
+    })
+  : either.makeRight(operand)
+
+/**
+ * Interpret an `@object` expression's `excess` operand as an ordered list of
+ * clauses, validating its structure.
+ */
+export const readExcessClauses = (
+  expression: ObjectTypeExpression,
+): Either<ElaborationError, readonly ExcessClause[]> => {
+  // Ordinal keys enumerate in ascending numeric order, giving clause order.
+  const clauseEntries = Object.entries(expression[1].excess)
+  if (clauseEntries.length === 0) {
+    // A plain object should be used when there are no excess clauses.
+    return either.makeLeft({
+      kind: 'invalidExpression',
+      message: '`@object` must have at least one excess clause',
+    })
+  } else {
+    return either.sequence(
+      clauseEntries.map(([key, clause], index) =>
+        readExcessClause(key, clause, index),
+      ),
+    )
+  }
+}
+
+const readExcessClause = (
+  key: string,
+  clause: SemanticGraph,
+  index: number,
+): Either<ElaborationError, ExcessClause> => {
+  if (key !== String(index)) {
+    return either.makeLeft({
+      kind: 'invalidExpression',
+      message:
+        '`@object` excess clauses must be listed with ordinal keys (`0`, `1`, …)',
+    })
+  } else if (!isObjectNode(clause) || isExpression(clause)) {
+    return either.makeLeft({
+      kind: 'invalidExpression',
+      message: '`@object` excess clauses must be pairs of key & value types',
+    })
+  } else if (
+    Object.keys(clause).some(property => property !== '0' && property !== '1')
+  ) {
+    return either.makeLeft({
+      kind: 'invalidExpression',
+      message:
+        '`@object` excess clauses may only have property keys `0` and `1`',
+    })
+  } else {
+    const keys = clause['0']
+    const values = clause['1']
+    return (
+      values === undefined ?
+        either.makeLeft({
+          kind: 'invalidExpression',
+          message:
+            '`@object` excess clauses must have a `1` property (the values type)',
+        })
+      : keys === undefined ?
+        either.makeLeft({
+          kind: 'invalidExpression',
+          message:
+            '`@object` excess clauses must have a `0` property (the keys type)',
+        })
+      : either.makeRight([keys, values])
+    )
+  }
+}
+
+export const makeObjectTypeExpression = (
+  properties: ObjectNode,
+  excess: ObjectNode,
+): ObjectTypeExpression =>
+  makeObjectNode({
+    0: '@object',
+    1: makeObjectNode({ properties, excess }),
+  })

--- a/src/language/semantics/keyword.ts
+++ b/src/language/semantics/keyword.ts
@@ -1,5 +1,5 @@
 export const isExemptFromElaboration = (input: Keyword) =>
-  input === '@hole' || input === '@union'
+  input === '@hole' || input === '@object' || input === '@union'
 
 export const isKeyword = (input: string) =>
   input === '@apply' ||
@@ -9,6 +9,7 @@ export const isKeyword = (input: string) =>
   input === '@if' ||
   input === '@index' ||
   input === '@lookup' ||
+  input === '@object' ||
   input === '@panic' ||
   input === '@runtime' ||
   input === '@todo' ||

--- a/src/language/semantics/semantic-graph.ts
+++ b/src/language/semantics/semantic-graph.ts
@@ -19,6 +19,7 @@ import {
 import { inlinePlz, unparse, type Notation } from '../unparsing.js'
 import { isExpression } from './expression.js'
 import { makeHoleExpressionWithExtantTypeParameter } from './expressions/hole-expression.js'
+import { makeObjectTypeExpression } from './expressions/object-type-expression.js'
 import { serializeFunctionNode, type FunctionNode } from './function-node.js'
 import { isSemanticGraph } from './is-semantic-graph.js'
 import { stringifyKeyPathForEndUser, type KeyPath } from './key-path.js'
@@ -38,6 +39,7 @@ import {
   isTopType,
   matchTypeFormat,
   typeParameterAssignableToConstraintKey,
+  types,
   type TypeKeyPath,
 } from './type-system.js'
 import {
@@ -337,13 +339,36 @@ export const typeToSemanticGraph = (
           ['0', recurseWithSameTypeParameters(type.key)],
         ]),
       }),
-    object: type =>
-      objectNodeFromOrderedEntries(
+    object: type => {
+      const properties = objectNodeFromOrderedEntries(
         Object.entries(type.children).map(([key, value]) => [
           key,
           recurseWithSameTypeParameters(value),
         ]),
-      ),
+      )
+      // An open object becomes a plain literal; any other excess bounds are
+      // spelled out with the explicit `@object` form.
+      const [firstClause, ...remainingClauses] = type.excess
+      const isOpen =
+        firstClause === undefined ||
+        (remainingClauses.length === 0 &&
+          firstClause.keys === types.atom &&
+          isTopType(firstClause.values))
+      return isOpen ? properties : (
+          makeObjectTypeExpression(
+            properties,
+            objectNodeFromOrderedEntries(
+              type.excess.map((clause, index) => [
+                String(index),
+                objectNodeFromOrderedEntries([
+                  ['0', recurseWithSameTypeParameters(clause.keys)],
+                  ['1', recurseWithSameTypeParameters(clause.values)],
+                ]),
+              ]),
+            ),
+          )
+        )
+    },
     // A stuck intrinsic application is displayed as its (concrete) upper bound,
     // which is also how it behaves for assignability.
     intrinsicApplication: type =>

--- a/src/language/semantics/stdlib/stdlib-utilities.ts
+++ b/src/language/semantics/stdlib/stdlib-utilities.ts
@@ -98,6 +98,7 @@ export const emptyContextForStdlibApplications: ExpressionContext = {
     '@if': either.makeRight,
     '@index': either.makeRight,
     '@lookup': either.makeRight,
+    '@object': either.makeRight,
     '@panic': either.makeRight,
     '@runtime': either.makeRight,
     '@todo': either.makeRight,

--- a/src/language/semantics/type-system/literal-type.ts
+++ b/src/language/semantics/type-system/literal-type.ts
@@ -4,6 +4,10 @@ import {
   getHoleTypeParameter,
   readHoleExpression,
 } from '../expressions/hole-expression.js'
+import {
+  readExcessClauses,
+  readObjectTypeExpression,
+} from '../expressions/object-type-expression.js'
 import { readUnionExpression } from '../expressions/union-expression.js'
 import type { SemanticGraph } from '../semantic-graph.js'
 import { atom, nothing, typesBySymbol } from './prelude-types.js'
@@ -17,11 +21,14 @@ import { unionOfTypes } from './type-formats/union-type.js'
  * - `TypeSymbol`s are translated back to their corresponding `Type`s.
  * - `FunctionNode`s become `FunctionType`s with a corresponding signature.
  * - `@union`-shaped `ObjectNode`s become `UnionType`s.
+ * - `@object`-shaped `ObjectNode`s become `ObjectType`s with their written
+ *   excess clauses (in both modes; `objectsAreExact` only applies to plain
+ *   object literals).
  * - `@hole`-shaped `ObjectNode`s become `TypeParameter`s.
  * - Everything else becomes an `ObjectType`.
  *
- * Warning: other than `@union` and `@hole`, there is no specific expression
- * handling here (e.g. `@function`-shaped `ObjectNode`s don't become
+ * Warning: other than `@union`, `@object`, and `@hole`, there is no specific
+ * expression handling here (e.g. `@function`-shaped `ObjectNode`s don't become
  * `FunctionType`s, `@index`-shaped `ObjectNode`s don't `IndexedAccessType`s,
  * etc). Use `inferType` instead when more sophisticated translation is desired.
  */
@@ -61,28 +68,71 @@ export const typeFromSemanticGraph = (
           unionOfTypes,
         ),
       left: _ =>
-        // Is it a `@hole`?
-        either.flatMapLeft(
-          either.map(readHoleExpression(node), getHoleTypeParameter),
-          _ =>
-            // Interpret `node` as an object type.
-            either.map(
-              either.sequence(
-                Object.entries(node).map(([key, value]) =>
-                  either.map(
-                    typeFromSemanticGraph(value, options),
-                    childType => [key, childType],
+        // Is it an `@object`?
+        either.match(
+          either.flatMap(readObjectTypeExpression(node), objectTypeExpression =>
+            either.map(readExcessClauses(objectTypeExpression), clauses => ({
+              objectTypeExpression,
+              clauses,
+            })),
+          ),
+          {
+            right: ({ objectTypeExpression, clauses }) =>
+              either.flatMap(
+                either.sequence(
+                  Object.entries(objectTypeExpression[1].properties).map(
+                    ([key, propertyValue]) =>
+                      either.map(
+                        typeFromSemanticGraph(propertyValue, options),
+                        childType => [key, childType],
+                      ),
                   ),
                 ),
+                children =>
+                  either.map(
+                    either.sequence(
+                      clauses.map(clause =>
+                        either.map(
+                          either.sequence([
+                            typeFromSemanticGraph(clause[0], options),
+                            typeFromSemanticGraph(clause[1], options),
+                          ]),
+                          ([keys, values]) => ({ keys, values }),
+                        ),
+                      ),
+                    ),
+                    refinementClauses =>
+                      makeObjectType(
+                        Object.fromEntries(children),
+                        refinementClauses,
+                      ),
+                  ),
               ),
-              entries =>
-                makeObjectType(
-                  Object.fromEntries(entries),
-                  options.objectsAreExact ?
-                    [{ keys: atom, values: nothing }]
-                  : [],
-                ),
-            ),
+            left: _ =>
+              // Is it a `@hole`?
+              either.flatMapLeft(
+                either.map(readHoleExpression(node), getHoleTypeParameter),
+                _ =>
+                  // Interpret `node` as an object type.
+                  either.map(
+                    either.sequence(
+                      Object.entries(node).map(([key, value]) =>
+                        either.map(
+                          typeFromSemanticGraph(value, options),
+                          childType => [key, childType],
+                        ),
+                      ),
+                    ),
+                    entries =>
+                      makeObjectType(
+                        Object.fromEntries(entries),
+                        options.objectsAreExact ?
+                          [{ keys: atom, values: nothing }]
+                        : [],
+                      ),
+                  ),
+              ),
+          },
         ),
     })
   }

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -130,7 +130,7 @@ testCases(
       ]),
       makeObjectType({ a: makeUnionType(['c']) }),
     ]),
-    '{ a: a | b } | { a: c }',
+    '@object { properties: { a: a | b }, excess: { { :atom.type, :nothing.type } } } | { a: c }',
   ],
 ])
 typeAssignabilitySuite('prelude types (assignable)', [

--- a/src/language/semantics/type-system/type-inference.ts
+++ b/src/language/semantics/type-system/type-inference.ts
@@ -9,7 +9,6 @@ import {
   isAssignable,
   isExpression,
   isFunctionNode,
-  isObjectNode,
   lookup,
   readApplyExpression,
   readFunctionExpression,
@@ -36,6 +35,11 @@ import {
   getHoleTypeParameter,
   readHoleExpression,
 } from '../expressions/hole-expression.js'
+import {
+  readExcessClauses,
+  readObjectTypeExpression,
+} from '../expressions/object-type-expression.js'
+import { isObjectNode } from '../object-node.js'
 import { genericizeFunctionParameterAnnotation } from './genericize-function-parameter.js'
 import { typeFromSemanticGraph } from './literal-type.js'
 import * as types from './prelude-types.js'
@@ -116,13 +120,15 @@ export const inferType = (
  * Like `inferType`, but for a `node` occurring in a type annotation (e.g. a
  * function parameter type or `@check` type). The denoted type is interpreted as
  * an open upper bound:
+ * - An explicit `@object` expression is interpreted exactly as written.
  * - Each `@union` member is interpreted as if it were written bare in the
  *   same position (`inferTypeOfTypeAnnotation` distributes over union members).
  * - A plain object literal is open (allowing arbitrary excess properties), in
  *   contrast to value positions where inference gives closed object types.
  * - Anything indirect (lookups, indexed accesses, applications, …) is
  *   interpreted as its inferred type with every closed object widened to an
- *   open one.
+ *   open one; in particular an alias to an explicitly-closed `@object` is
+ *   interpreted as open.
  */
 export const inferTypeOfTypeAnnotation = (
   node: SemanticGraph,
@@ -547,6 +553,80 @@ const inferTypeImplementation = (
     )
   }
 
+  // @object: an explicit object type.
+  const objectTypeExpressionResult = readObjectTypeExpression(node)
+  if (either.isRight(objectTypeExpressionResult)) {
+    const objectTypeExpression = objectTypeExpressionResult.value
+    const { properties } = objectTypeExpression[1]
+    const inferExcessClauseKeys = (keys: SemanticGraph, index: number) =>
+      either.flatMap(
+        inferTypeOfTypeAnnotationImplementation(
+          keys,
+          parameterTypes,
+          lookingUpKeys,
+          descendantContext(['1', 'excess', String(index), '0']),
+        ),
+        (keysType): Either<ElaborationError, Type> =>
+          // Keys must be concrete atom subtypes.
+          containedTypeParameters(keysType).size > 0 ?
+            either.makeLeft({
+              kind: 'invalidExpression',
+              message:
+                '`@object` excess clause keys must not reference type parameters',
+            })
+          : !isAssignable({ source: keysType, target: types.atom }) ?
+            either.makeLeft({
+              kind: 'typeMismatch',
+              message: `\`@object\` excess clause keys must be an atom subtype, but \`${stringifyTypeForEndUser(
+                keysType,
+              )}\` is not assignable to \`${stringifyTypeForEndUser(
+                types.atom,
+              )}\``,
+            })
+          : either.makeRight(keysType),
+      )
+    return cacheOnSuccess(
+      either.flatMap(readExcessClauses(objectTypeExpression), clauses =>
+        either.flatMap(
+          either.sequence(
+            Object.entries(properties).map(([key, propertyValue]) =>
+              either.map(
+                inferTypeOfTypeAnnotationImplementation(
+                  propertyValue,
+                  parameterTypes,
+                  lookingUpKeys,
+                  descendantContext(['1', 'properties', key]),
+                ),
+                propertyType => [key, propertyType],
+              ),
+            ),
+          ),
+          children =>
+            either.map(
+              either.sequence(
+                clauses.map((clause, index) =>
+                  either.map(
+                    either.sequence([
+                      inferExcessClauseKeys(clause[0], index),
+                      inferTypeOfTypeAnnotationImplementation(
+                        clause[1],
+                        parameterTypes,
+                        lookingUpKeys,
+                        descendantContext(['1', 'excess', String(index), '1']),
+                      ),
+                    ]),
+                    ([keys, values]) => ({ keys, values }),
+                  ),
+                ),
+              ),
+              refinementClauses =>
+                makeObjectType(Object.fromEntries(children), refinementClauses),
+            ),
+        ),
+      ),
+    )
+  }
+
   // @hole: a hole denotes its type parameter. Unless its constraint is already
   // sourced from the carried type parameter, resolve it here.
   const holeExpressionResult = readHoleExpression(node)
@@ -624,7 +704,11 @@ const inferTypeOfTypeAnnotationImplementation = (
       : [...context.cacheKeyPrefixOverride, ...subPath],
   })
   const unionExpressionResult = readUnionExpression(node)
-  if (either.isRight(unionExpressionResult)) {
+  if (either.isRight(readObjectTypeExpression(node))) {
+    // `@object` operands are type positions; `inferTypeImplementation`
+    // interprets the whole subtree as written.
+    return inferTypeImplementation(node, parameterTypes, lookingUpKeys, context)
+  } else if (either.isRight(unionExpressionResult)) {
     // Distribute over union members.
     return either.map(
       either.sequence(

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -716,7 +716,11 @@ const isTightlyBoundNonCompactExpression = (
 
 const isNonCompactExpression = (expression: SemanticGraph | Molecule) =>
   isTightlyBoundNonCompactExpression(expression) ||
-  either.isRight(readUnionExpression(asSemanticGraph(expression))) ||
+  either.match(readUnionExpression(asSemanticGraph(expression)), {
+    // Empty unions render as `:nothing.type`.
+    right: unionExpression => Object.values(unionExpression[1]).length !== 0,
+    left: _ => false,
+  }) ||
   either.isRight(
     either.flatMap(
       readApplyExpression(asSemanticGraph(expression)),


### PR DESCRIPTION
`@object { properties: { … }, excess: { … } }` denotes an `ObjectType` with the written excess property bounds. This makes the new type system concepts from #239 and prior expressible in the surface language.

Syntax sugar will arrive in a future changeset.