### PR TITLE
Unparser improvements

### DIFF
--- a/examples/.snapshot
+++ b/examples/.snapshot
@@ -151,7 +151,9 @@ exports[`examples > fizzbuzz.plz > roundtripped syntax tree 1`] = `
   fizzbuzz: (limit: :natural_number.type) => {
     fizzbuzz_internal: (state: {
       current: :natural_number.type
-      output: { [:atom.type]: :natural_number.type | Fizz | Buzz | FizzBuzz }
+      output: {
+        [:atom.type]: :natural_number.type | Fizz | Buzz | FizzBuzz
+      }
     }) => @if {
       (:state.current > :limit)
       then: :state.output

--- a/src/language/compiling/unparsing.test.ts
+++ b/src/language/compiling/unparsing.test.ts
@@ -760,7 +760,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
         inlinePlz: '{ [:atom.type]: d, a, b, name: c }',
         sugarFreeInlinePlz:
           '{ 0: "@object", 1: { properties: { 0: a, 1: b, name: c }, excess: { 0: { 0: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: atom } }, query: { 0: type } } }, 1: d } } } }',
-        prettyPlz: '{ [:atom.type]: d, a, b, name: c }\n',
+        prettyPlz: '{\n  [:atom.type]: d\n  a\n  b\n  name: c\n}\n',
         sugarFreePrettyPlz:
           '{\n  0: "@object"\n  1: {\n    properties: {\n      0: a\n      1: b\n      name: c\n    }\n    excess: {\n      0: {\n        0: {\n          0: "@index"\n          1: {\n            object: {\n              0: "@lookup"\n              1: {\n                key: atom\n              }\n            }\n            query: {\n              0: type\n            }\n          }\n        }\n        1: d\n      }\n    }\n  }\n}\n',
         prettyJson:
@@ -792,7 +792,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
         inlinePlz: '{ [:atom.type]: d, [k]: v }',
         sugarFreeInlinePlz:
           '{ 0: "@object", 1: { properties: {}, excess: { 0: { 0: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: atom } }, query: { 0: type } } }, 1: d }, 1: { 0: k, 1: v } } } }',
-        prettyPlz: '{ [:atom.type]: d, [k]: v }\n',
+        prettyPlz: '{\n  [:atom.type]: d\n  [k]: v\n}\n',
         sugarFreePrettyPlz:
           '{\n  0: "@object"\n  1: {\n    properties: {}\n    excess: {\n      0: {\n        0: {\n          0: "@index"\n          1: {\n            object: {\n              0: "@lookup"\n              1: {\n                key: atom\n              }\n            }\n            query: {\n              0: type\n            }\n          }\n        }\n        1: d\n      }\n      1: {\n        0: k\n        1: v\n      }\n    }\n  }\n}\n',
         prettyJson:
@@ -824,7 +824,7 @@ testCases(unparsers, input => `unparsing \`${JSON.stringify(input)}\``)(
         inlinePlz: '{ [k]: v, [:atom.type]: d }',
         sugarFreeInlinePlz:
           '{ 0: "@object", 1: { properties: {}, excess: { 0: { 0: k, 1: v }, 1: { 0: { 0: "@index", 1: { object: { 0: "@lookup", 1: { key: atom } }, query: { 0: type } } }, 1: d } } } }',
-        prettyPlz: '{ [k]: v, [:atom.type]: d }\n',
+        prettyPlz: '{\n  [k]: v\n  [:atom.type]: d\n}\n',
         sugarFreePrettyPlz:
           '{\n  0: "@object"\n  1: {\n    properties: {}\n    excess: {\n      0: {\n        0: k\n        1: v\n      }\n      1: {\n        0: {\n          0: "@index"\n          1: {\n            object: {\n              0: "@lookup"\n              1: {\n                key: atom\n              }\n            }\n            query: {\n              0: type\n            }\n          }\n        }\n        1: d\n      }\n    }\n  }\n}\n',
         prettyJson:

--- a/src/language/unparsing/inline-plz.ts
+++ b/src/language/unparsing/inline-plz.ts
@@ -1,54 +1,11 @@
-import either, { type Either } from '@matt.kantor/either'
-import { styleText } from 'node:util'
-import type { UnserializableValueError } from '../errors.js'
-import type { Atom, Molecule } from '../parsing.js'
-import {
-  moleculeAsKeyValuePairStrings,
-  moleculeUnparser,
-  unparseAtom,
-  type SemanticContext,
-} from './plz-utilities.js'
-import { punctuation, type Notation } from './unparsing-utilities.js'
-
-const unparseSugarFreeMolecule = (value: Molecule) => {
-  const { comma, closeBrace, openBrace } = punctuation(styleText)
-  if (value.entries.length === 0) {
-    return either.makeRight(openBrace + closeBrace)
-  } else {
-    return either.map(
-      moleculeAsKeyValuePairStrings(
-        value,
-        { unparseAtomOrMolecule, semanticContext: 'default' },
-        {
-          ordinalKeys: 'omit',
-        },
-      ),
-      keyValuePairsAsStrings =>
-        openBrace.concat(
-          ' ',
-          keyValuePairsAsStrings.join(comma.concat(' ')),
-          ' ',
-          closeBrace,
-        ),
-    )
-  }
-}
-
-const unparseAtomOrMolecule =
-  (semanticContext: SemanticContext) =>
-  (value: Atom | Molecule): Either<UnserializableValueError, string> =>
-    typeof value === 'string' ?
-      unparseAtom(value)
-    : unparseMolecule(semanticContext)(value)
-
-const unparseMolecule = (semanticContext: SemanticContext) =>
-  moleculeUnparser('inline', semanticContext)(
-    unparseAtomOrMolecule,
-    unparseSugarFreeMolecule,
-  )
+import { moleculeUnparser, unparseAtom } from './plz-utilities.js'
+import { type Notation } from './unparsing-utilities.js'
 
 export const inlinePlz: Notation = {
   atom: unparseAtom,
-  molecule: unparseMolecule('default'),
+  molecule: moleculeUnparser({
+    flow: 'inline',
+    ordinalKeys: 'omit',
+  })('default'),
   suffix: '',
 }

--- a/src/language/unparsing/inline-plz.ts
+++ b/src/language/unparsing/inline-plz.ts
@@ -42,7 +42,7 @@ const unparseAtomOrMolecule =
     : unparseMolecule(semanticContext)(value)
 
 const unparseMolecule = (semanticContext: SemanticContext) =>
-  moleculeUnparser(semanticContext)(
+  moleculeUnparser('inline', semanticContext)(
     unparseAtomOrMolecule,
     unparseSugarFreeMolecule,
   )

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -470,16 +470,16 @@ const unparseSugaredFunctionParameter =
               unparseAtomOrMolecule('default')(serializedTypeAnnotation),
               typeAnnotationAsString => {
                 const {
-                  openGroupingParenthesis,
-                  closeGroupingParenthesis,
+                  openApplyParenthesis,
+                  closeApplyParenthesis,
                   typeAnnotationColon,
                 } = punctuation(styleText)
-                return openGroupingParenthesis.concat(
+                return openApplyParenthesis.concat(
                   parameterName,
                   typeAnnotationColon,
                   ' ',
                   typeAnnotationAsString,
-                  closeGroupingParenthesis,
+                  closeApplyParenthesis,
                 )
               },
             ),

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -53,6 +53,11 @@ import {
 
 export type SemanticContext = 'apply' | 'default'
 
+type Options = {
+  readonly flow: 'inline' | 'multiline'
+  readonly ordinalKeys: 'omit' | 'preserve'
+}
+
 type Context = {
   readonly unparseAtomOrMolecule: UnparseAtomOrMolecule
   readonly semanticContext: SemanticContext
@@ -62,17 +67,24 @@ export type UnparseAtomOrMolecule = (
   semanticContext: SemanticContext,
 ) => (value: Atom | Molecule) => Either<UnserializableValueError, string>
 
+export const atomOrMoleculeUnparser = (options: Options) => {
+  const unparseMolecule = moleculeUnparser(options)
+  return (semanticContext: SemanticContext) => (value: Atom | Molecule) =>
+    typeof value === 'string' ?
+      unparseAtom(value)
+    : unparseMolecule(semanticContext)(value)
+}
+
 export const moleculeUnparser =
-  (formatting: 'inline' | 'multiline', semanticContext: SemanticContext) =>
-  (
-    unparseAtomOrMolecule: UnparseAtomOrMolecule,
-    unparseSugarFreeMolecule: (
-      expression: Molecule,
-      context: Context,
-    ) => Either<UnserializableValueError, string>,
-  ) => {
+  (options: Options) => (semanticContext: SemanticContext) => {
+    const unparseSugarFreeMolecule = sugarFreeMoleculeUnparser(options)
+    const unparseAtomOrMolecule = atomOrMoleculeUnparser(options)
+
     const context: Context = { unparseAtomOrMolecule, semanticContext }
-    const sugar = unparseSugaredExpression(context, unparseSugarFreeMolecule)
+    const sugar = unparseSugaredExpression(
+      context,
+      unparseSugarFreeMolecule(context),
+    )
     return (value: Molecule): Either<UnserializableValueError, string> => {
       const keyword = option.match(orderedRecord.get(value, '0'), {
         none: () => undefined,
@@ -95,74 +107,72 @@ export const moleculeUnparser =
           return sugar(
             value,
             readObjectTypeExpression,
-            unparseSugaredObjectType(formatting),
+            unparseSugaredObjectType(options),
           )
         case '@union':
           return sugar(value, readUnionExpression, unparseSugaredUnion)
         default: {
           const potentialKeywordExpression = asSemanticGraph(value)
           if (isExpression(potentialKeywordExpression)) {
-            const result = unparseSugaredGeneralizedKeywordExpression(
+            const result = unparseSugaredGeneralizedKeywordExpression(context)(
               potentialKeywordExpression,
-              context,
             )
             return either.flatMapLeft(result, _ =>
-              unparseSugarFreeMolecule(value, context),
+              unparseSugarFreeMolecule(context)(value),
             )
           } else {
-            return unparseSugarFreeMolecule(value, context)
+            return unparseSugarFreeMolecule(context)(value)
           }
         }
       }
     }
   }
 
-export const moleculeAsKeyValuePairStrings = (
-  value: Molecule,
-  { unparseAtomOrMolecule, semanticContext }: Context,
-  options: { readonly ordinalKeys: 'omit' | 'preserve' },
-): Either<UnserializableValueError, readonly string[]> => {
-  const { colon, openGroupingParenthesis, closeGroupingParenthesis } =
-    punctuation(styleText)
-  const entries = value.entries
+export const moleculeAsKeyValuePairStrings =
+  (options: Options) =>
+  ({ unparseAtomOrMolecule, semanticContext }: Context) =>
+  (value: Molecule): Either<UnserializableValueError, readonly string[]> => {
+    const { colon, openGroupingParenthesis, closeGroupingParenthesis } =
+      punctuation(styleText)
+    const entries = value.entries
 
-  const keyValuePairsAsStrings: string[] = []
-  let ordinalPropertyKeyCounter = 0n
-  for (const [propertyKey, propertyValue] of entries) {
-    const valueAsStringResult =
-      unparseAtomOrMolecule(semanticContext)(propertyValue)
-    if (either.isLeft(valueAsStringResult)) {
-      return valueAsStringResult
-    }
+    const keyValuePairsAsStrings: string[] = []
+    let ordinalPropertyKeyCounter = 0n
+    for (const [propertyKey, propertyValue] of entries) {
+      const valueAsStringResult =
+        unparseAtomOrMolecule(semanticContext)(propertyValue)
+      if (either.isLeft(valueAsStringResult)) {
+        return valueAsStringResult
+      }
 
-    // Omit ordinal property keys:
-    if (
-      propertyKey === String(ordinalPropertyKeyCounter) &&
-      options.ordinalKeys === 'omit'
-    ) {
-      keyValuePairsAsStrings.push(
-        // If the property value is something like an anonymous function or an
-        // infix operation then it needs parentheses when the key is omitted. We
-        // can skip the parentheses when this is the only property.
-        isNonCompactExpression(propertyValue) && entries.length !== 1 ?
-          openGroupingParenthesis.concat(
-            valueAsStringResult.value,
-            closeGroupingParenthesis,
-          )
-        : valueAsStringResult.value,
-      )
-      ordinalPropertyKeyCounter += 1n
-    } else {
-      keyValuePairsAsStrings.push(
-        styleText(
-          keyColor,
-          quoteAtomIfNecessary(propertyKey).concat(colon),
-        ).concat(' ', valueAsStringResult.value),
-      )
+      // Omit ordinal property keys:
+      if (
+        propertyKey === String(ordinalPropertyKeyCounter) &&
+        options.ordinalKeys === 'omit'
+      ) {
+        keyValuePairsAsStrings.push(
+          // If the property value is something like an anonymous function or an
+          // infix operation then it needs parentheses when the key is omitted. We
+          // can skip the parentheses when this is the only property.
+          isNonCompactExpression(propertyValue) && entries.length !== 1 ?
+            openGroupingParenthesis.concat(
+              valueAsStringResult.value,
+              closeGroupingParenthesis,
+            )
+          : valueAsStringResult.value,
+        )
+        ordinalPropertyKeyCounter += 1n
+      } else {
+        keyValuePairsAsStrings.push(
+          styleText(
+            keyColor,
+            quoteAtomIfNecessary(propertyKey).concat(colon),
+          ).concat(' ', valueAsStringResult.value),
+        )
+      }
     }
+    return either.makeRight(keyValuePairsAsStrings)
   }
-  return either.makeRight(keyValuePairsAsStrings)
-}
 
 export const unparseAtom = (atom: string): Right<string> =>
   either.makeRight(
@@ -177,6 +187,43 @@ export const quoteAtomIfNecessary = (value: string): string => {
     return quote.concat(escapeStringContents(value), quote)
   } else {
     return value
+  }
+}
+
+const sugarFreeMoleculeUnparser = (options: Options) => {
+  const moleculeAsKeyValuePairStringsWithOptions =
+    moleculeAsKeyValuePairStrings(options)
+  return (context: Context) => {
+    const moleculeAsKeyValuePairStringsWithContext =
+      moleculeAsKeyValuePairStringsWithOptions(context)
+    return (value: Molecule) => {
+      const { closeBrace, comma, openBrace } = punctuation(styleText)
+      if (value.entries.length === 0) {
+        return either.makeRight(openBrace + closeBrace)
+      } else {
+        return either.map(
+          moleculeAsKeyValuePairStringsWithContext(value),
+          keyValuePairsAsStrings => {
+            switch (options.flow) {
+              case 'inline':
+                return openBrace.concat(
+                  ' ',
+                  keyValuePairsAsStrings.join(comma.concat(' ')),
+                  ' ',
+                  closeBrace,
+                )
+              case 'multiline':
+                return openBrace.concat(
+                  '\n',
+                  indent(2, keyValuePairsAsStrings.join('\n')),
+                  '\n',
+                  closeBrace,
+                )
+            }
+          },
+        )
+      }
+    }
   }
 }
 
@@ -208,7 +255,6 @@ const unparseSugaredExpression =
     context: Context,
     unparseSugarFreeMolecule: (
       expression: Molecule,
-      context: Context,
     ) => Either<UnserializableValueError, string>,
   ) =>
   <
@@ -222,112 +268,120 @@ const unparseSugaredExpression =
       node: SemanticGraph,
     ) => Either<ElaborationError, SpecificExpression>,
     unparseSpecificExpression: (
-      expression: SpecificExpression,
       context: Context,
+    ) => (
+      expression: SpecificExpression,
     ) => Either<UnserializableValueError, string>,
   ) =>
     either.match(readSpecificExpression(asSemanticGraph(value)), {
-      left: _ => unparseSugarFreeMolecule(value, context),
-      right: expression => unparseSpecificExpression(expression, context),
+      left: _ => unparseSugarFreeMolecule(value),
+      right: unparseSpecificExpression(context),
     })
 
-const unparseSugaredApply = (
-  expression: ApplyExpression,
-  { unparseAtomOrMolecule, semanticContext }: Context,
-) => {
-  const {
-    openGroupingParenthesis,
-    closeGroupingParenthesis,
-    openApplyParenthesis,
-    closeApplyParenthesis,
-  } = punctuation(styleText)
+const unparseSugaredApply =
+  ({ unparseAtomOrMolecule, semanticContext }: Context) =>
+  (expression: ApplyExpression) => {
+    const {
+      openGroupingParenthesis,
+      closeGroupingParenthesis,
+      openApplyParenthesis,
+      closeApplyParenthesis,
+    } = punctuation(styleText)
 
-  const infixSugaredApply = either.flatMap(
-    readInfixOperation(expression),
-    ({ operand1, operatorLookupKey, operatorIndexExpression, operand2 }) => {
-      // Infix syntax is probably appropriate.
-      const unparsedOperand1 = either.map(
-        either.flatMap(
-          serializeIfNeeded(operand1),
-          unparseAtomOrMolecule(semanticContext),
-        ),
-        unparsedOperand1 =>
-          isTightlyBoundNonCompactExpression(operand1) ?
-            openGroupingParenthesis.concat(
-              unparsedOperand1,
-              closeGroupingParenthesis,
-            )
-          : unparsedOperand1,
-      )
-      const unparsedOperand2 = either.map(
-        either.flatMap(
-          serializeIfNeeded(operand2),
-          unparseAtomOrMolecule(semanticContext),
-        ),
-        unparsedOperand2 =>
-          isNonCompactExpression(operand2) ?
-            openGroupingParenthesis.concat(
+    const infixSugaredApply = either.flatMap(
+      readInfixOperation(expression),
+      ({ operand1, operatorLookupKey, operatorIndexExpression, operand2 }) => {
+        // Infix syntax is probably appropriate.
+        const unparsedOperand1 = either.map(
+          either.flatMap(
+            serializeIfNeeded(operand1),
+            unparseAtomOrMolecule(semanticContext),
+          ),
+          unparsedOperand1 =>
+            isTightlyBoundNonCompactExpression(operand1) ?
+              openGroupingParenthesis.concat(
+                unparsedOperand1,
+                closeGroupingParenthesis,
+              )
+            : unparsedOperand1,
+        )
+        const unparsedOperand2 = either.map(
+          either.flatMap(
+            serializeIfNeeded(operand2),
+            unparseAtomOrMolecule(semanticContext),
+          ),
+          unparsedOperand2 =>
+            isNonCompactExpression(operand2) ?
+              openGroupingParenthesis.concat(
+                unparsedOperand2,
+                closeGroupingParenthesis,
+              )
+            : unparsedOperand2,
+        )
+
+        // Operators omit the leading `:`, but otherwise look like lookups
+        // (possibly followed by indexes).
+        const unparsedOperator = styleText(
+          applyColor,
+          operatorLookupKey,
+        ).concat(
+          option.match(operatorIndexExpression, {
+            some: operatorIndexExpression =>
+              either.unwrapOrElse(
+                unparseKeyPathOfSugaredIndex({
+                  unparseAtomOrMolecule,
+                  semanticContext: 'apply',
+                })(operatorIndexExpression[1].query),
+                _ => '',
+              ),
+            none: _ => '',
+          }),
+        )
+
+        return either.flatMap(unparsedOperand1, unparsedOperand1 =>
+          either.map(unparsedOperand2, unparsedOperand2 =>
+            unparsedOperand1.concat(
+              ' ',
+              unparsedOperator,
+              ' ',
               unparsedOperand2,
+            ),
+          ),
+        )
+      },
+    )
+
+    return either.flatMapLeft(infixSugaredApply, _ => {
+      // Fall back to non-infix syntax.
+      const unparsedFunction = either.map(
+        either.flatMap(
+          serializeIfNeeded(expression[1].function),
+          unparseAtomOrMolecule('apply'),
+        ),
+        unparsedFunction =>
+          isNonCompactExpression(expression[1].function) ?
+            // It's an immediately-applied anonymous function.
+            openGroupingParenthesis.concat(
+              unparsedFunction,
               closeGroupingParenthesis,
             )
-          : unparsedOperand2,
+          : unparsedFunction,
       )
-
-      // Operators omit the leading `:`, but otherwise look like lookups
-      // (possibly followed by indexes).
-      const unparsedOperator = styleText(applyColor, operatorLookupKey).concat(
-        option.match(operatorIndexExpression, {
-          some: operatorIndexExpression =>
-            either.unwrapOrElse(
-              unparseKeyPathOfSugaredIndex(operatorIndexExpression[1].query, {
-                unparseAtomOrMolecule,
-                semanticContext: 'apply',
-              }),
-              _ => '',
-            ),
-          none: _ => '',
-        }),
+      const unparsedArgument = either.flatMap(
+        serializeIfNeeded(expression[1].argument),
+        unparseAtomOrMolecule(semanticContext),
       )
-
-      return either.flatMap(unparsedOperand1, unparsedOperand1 =>
-        either.map(unparsedOperand2, unparsedOperand2 =>
-          unparsedOperand1.concat(' ', unparsedOperator, ' ', unparsedOperand2),
+      return either.flatMap(unparsedFunction, unparsedFunction =>
+        either.map(unparsedArgument, unparsedArgument =>
+          unparsedFunction.concat(
+            openApplyParenthesis,
+            unparsedArgument,
+            closeApplyParenthesis,
+          ),
         ),
       )
-    },
-  )
-
-  return either.flatMapLeft(infixSugaredApply, _ => {
-    // Fall back to non-infix syntax.
-    const unparsedFunction = either.map(
-      either.flatMap(
-        serializeIfNeeded(expression[1].function),
-        unparseAtomOrMolecule('apply'),
-      ),
-      unparsedFunction =>
-        isNonCompactExpression(expression[1].function) ?
-          // It's an immediately-applied anonymous function.
-          openGroupingParenthesis.concat(
-            unparsedFunction,
-            closeGroupingParenthesis,
-          )
-        : unparsedFunction,
-    )
-    const unparsedArgument = either.flatMap(
-      serializeIfNeeded(expression[1].argument),
-      unparseAtomOrMolecule(semanticContext),
-    )
-    return either.flatMap(unparsedFunction, unparsedFunction =>
-      either.map(unparsedArgument, unparsedArgument =>
-        unparsedFunction.concat(
-          openApplyParenthesis,
-          unparsedArgument,
-          closeApplyParenthesis,
-        ),
-      ),
-    )
-  })
-}
+    })
+  }
 
 // `type ~> body` is sugar for `(_: type) => body`, so it applies when the
 // parameter is the ignored name `_` and it has an explicit type annotation
@@ -341,174 +395,173 @@ const signatureSugarTypeAnnotation = (
       isTopType(typeAnnotation) ? option.none : option.makeSome(typeAnnotation),
     )
 
-const unparseSugaredFunction = (
-  expression: FunctionExpression,
-  context: Context,
-): Either<UnserializableValueError, string> => {
-  const {
-    openGroupingParenthesis,
-    closeGroupingParenthesis,
-    functionArrow,
-    signatureArrow,
-  } = punctuation(styleText)
-  return option.match(signatureSugarTypeAnnotation(expression), {
-    some: typeAnnotation =>
-      // Unparse using `~>` notation.
-      either.flatMap(
+const unparseSugaredFunction =
+  (context: Context) =>
+  (
+    expression: FunctionExpression,
+  ): Either<UnserializableValueError, string> => {
+    const {
+      openGroupingParenthesis,
+      closeGroupingParenthesis,
+      functionArrow,
+      signatureArrow,
+    } = punctuation(styleText)
+    return option.match(signatureSugarTypeAnnotation(expression), {
+      some: typeAnnotation =>
+        // Unparse using `~>` notation.
         either.flatMap(
-          serializeIfNeeded(typeAnnotation),
-          context.unparseAtomOrMolecule('default'),
+          either.flatMap(
+            serializeIfNeeded(typeAnnotation),
+            context.unparseAtomOrMolecule('default'),
+          ),
+          typeAnnotationAsString => {
+            const possiblyParenthesizedTypeAnnotation =
+              isNonCompactExpression(typeAnnotation) ?
+                openGroupingParenthesis.concat(
+                  typeAnnotationAsString,
+                  closeGroupingParenthesis,
+                )
+              : typeAnnotationAsString
+            return either.map(
+              either.flatMap(
+                serializeIfNeeded(expression[1].body),
+                context.unparseAtomOrMolecule('default'),
+              ),
+              bodyAsString =>
+                [
+                  possiblyParenthesizedTypeAnnotation,
+                  signatureArrow,
+                  bodyAsString,
+                ].join(' '),
+            )
+          },
         ),
-        typeAnnotationAsString => {
-          const possiblyParenthesizedTypeAnnotation =
-            isNonCompactExpression(typeAnnotation) ?
-              openGroupingParenthesis.concat(
-                typeAnnotationAsString,
-                closeGroupingParenthesis,
-              )
-            : typeAnnotationAsString
-          return either.map(
+      none: _ =>
+        // Unparse using `=>` notation.
+        either.flatMap(
+          unparseSugaredFunctionParameter(context)(expression),
+          parameterAsString =>
             either.flatMap(
               serializeIfNeeded(expression[1].body),
-              context.unparseAtomOrMolecule('default'),
-            ),
-            bodyAsString =>
-              [
-                possiblyParenthesizedTypeAnnotation,
-                signatureArrow,
-                bodyAsString,
-              ].join(' '),
-          )
-        },
-      ),
-    none: _ =>
-      // Unparse using `=>` notation.
-      either.flatMap(
-        unparseSugaredFunctionParameter(expression, context),
-        parameterAsString =>
-          either.flatMap(
-            serializeIfNeeded(expression[1].body),
-            serializedBody =>
-              either.map(
-                context.unparseAtomOrMolecule('default')(serializedBody),
-                bodyAsString =>
-                  [parameterAsString, functionArrow, bodyAsString].join(' '),
-              ),
-          ),
-      ),
-  })
-}
-
-const unparseSugaredFunctionParameter = (
-  expression: FunctionExpression,
-  { unparseAtomOrMolecule }: Context,
-): Either<UnserializableValueError, string> => {
-  const parameterName = styleText(keyColor, getParameterName(expression))
-  return option.match(getParameterTypeAnnotation(expression), {
-    none: () => either.makeRight(parameterName),
-    some: typeAnnotation =>
-      either.flatMap(
-        serializeIfNeeded(typeAnnotation),
-        serializedTypeAnnotation =>
-          either.map(
-            unparseAtomOrMolecule('default')(serializedTypeAnnotation),
-            typeAnnotationAsString => {
-              const {
-                openGroupingParenthesis,
-                closeGroupingParenthesis,
-                typeAnnotationColon,
-              } = punctuation(styleText)
-              return openGroupingParenthesis.concat(
-                parameterName,
-                typeAnnotationColon,
-                ' ',
-                typeAnnotationAsString,
-                closeGroupingParenthesis,
-              )
-            },
-          ),
-      ),
-  })
-}
-
-const unparseSugaredIndex = (
-  expression: IndexExpression,
-  { unparseAtomOrMolecule, semanticContext }: Context,
-) => {
-  const objectUnparseResult = either.flatMap(
-    serializeIfNeeded(expression[1].object),
-    unparseAtomOrMolecule(semanticContext),
-  )
-  return either.flatMap(objectUnparseResult, unparsedObject =>
-    either.map(
-      unparseKeyPathOfSugaredIndex(expression[1].query, {
-        unparseAtomOrMolecule,
-        semanticContext,
-      }),
-      unparsedKeyPath => unparsedObject.concat(unparsedKeyPath),
-    ),
-  )
-}
-
-const unparseKeyPathOfSugaredIndex = (
-  query: ObjectNode,
-  { unparseAtomOrMolecule, semanticContext }: Context,
-): Either<UnserializableValueError, string> => {
-  const { dot, colon, openGroupingParenthesis, closeGroupingParenthesis } =
-    punctuation(styleText)
-  const componentResults = Object.entries(query).map(
-    ([key, value], index): Either<UnserializableValueError, string> =>
-      // Keys must be sequential ("0", "1", …) to use the dotted sugar.
-      key !== String(index) ?
-        either.makeLeft({
-          kind: 'unserializableValue',
-          message: 'invalid key path',
-        })
-        // A literal atom uses `.a`.
-      : typeof value === 'string' ?
-        either.makeRight(quoteKeyPathComponentIfNecessary(value))
-      : either.match(readLookupExpression(value), {
-          // A `@lookup` uses `.:key`.
-          right: lookup =>
-            either.makeRight(
-              colon.concat(quoteKeyPathComponentIfNecessary(lookup[1].key)),
-            ),
-          // Any other expression uses `.(…)`.
-          left: _ =>
-            either.map(
-              either.flatMap(
-                serializeIfNeeded(value),
-                unparseAtomOrMolecule('default'),
-              ),
-              unparsedExpression =>
-                openGroupingParenthesis.concat(
-                  unparsedExpression,
-                  closeGroupingParenthesis,
+              serializedBody =>
+                either.map(
+                  context.unparseAtomOrMolecule('default')(serializedBody),
+                  bodyAsString =>
+                    [parameterAsString, functionArrow, bodyAsString].join(' '),
                 ),
             ),
-        }),
-  )
+        ),
+    })
+  }
 
-  return either.map(either.sequence(componentResults), components =>
-    styleText(
-      semanticContext === 'apply' ? applyColor : keyColor,
-      dot.concat(components.join(dot)),
-    ),
-  )
-}
+const unparseSugaredFunctionParameter =
+  ({ unparseAtomOrMolecule }: Context) =>
+  (
+    expression: FunctionExpression,
+  ): Either<UnserializableValueError, string> => {
+    const parameterName = styleText(keyColor, getParameterName(expression))
+    return option.match(getParameterTypeAnnotation(expression), {
+      none: () => either.makeRight(parameterName),
+      some: typeAnnotation =>
+        either.flatMap(
+          serializeIfNeeded(typeAnnotation),
+          serializedTypeAnnotation =>
+            either.map(
+              unparseAtomOrMolecule('default')(serializedTypeAnnotation),
+              typeAnnotationAsString => {
+                const {
+                  openGroupingParenthesis,
+                  closeGroupingParenthesis,
+                  typeAnnotationColon,
+                } = punctuation(styleText)
+                return openGroupingParenthesis.concat(
+                  parameterName,
+                  typeAnnotationColon,
+                  ' ',
+                  typeAnnotationAsString,
+                  closeGroupingParenthesis,
+                )
+              },
+            ),
+        ),
+    })
+  }
 
-const unparseSugaredLookup = (
-  expression: LookupExpression,
-  { semanticContext }: Context,
-) =>
-  either.makeRight(
-    styleText(
-      semanticContext === 'apply' ? applyColor : keyColor,
-      punctuation(styleText).colon.concat(
-        quoteKeyPathComponentIfNecessary(expression[1].key),
+const unparseSugaredIndex =
+  ({ unparseAtomOrMolecule, semanticContext }: Context) =>
+  (expression: IndexExpression) => {
+    const objectUnparseResult = either.flatMap(
+      serializeIfNeeded(expression[1].object),
+      unparseAtomOrMolecule(semanticContext),
+    )
+    return either.flatMap(objectUnparseResult, unparsedObject =>
+      either.map(
+        unparseKeyPathOfSugaredIndex({
+          unparseAtomOrMolecule,
+          semanticContext,
+        })(expression[1].query),
+        unparsedKeyPath => unparsedObject.concat(unparsedKeyPath),
       ),
-    ),
-  )
+    )
+  }
+
+const unparseKeyPathOfSugaredIndex =
+  ({ unparseAtomOrMolecule, semanticContext }: Context) =>
+  (query: ObjectNode): Either<UnserializableValueError, string> => {
+    const { dot, colon, openGroupingParenthesis, closeGroupingParenthesis } =
+      punctuation(styleText)
+    const componentResults = Object.entries(query).map(
+      ([key, value], index): Either<UnserializableValueError, string> =>
+        // Keys must be sequential ("0", "1", …) to use the dotted sugar.
+        key !== String(index) ?
+          either.makeLeft({
+            kind: 'unserializableValue',
+            message: 'invalid key path',
+          })
+          // A literal atom uses `.a`.
+        : typeof value === 'string' ?
+          either.makeRight(quoteKeyPathComponentIfNecessary(value))
+        : either.match(readLookupExpression(value), {
+            // A `@lookup` uses `.:key`.
+            right: lookup =>
+              either.makeRight(
+                colon.concat(quoteKeyPathComponentIfNecessary(lookup[1].key)),
+              ),
+            // Any other expression uses `.(…)`.
+            left: _ =>
+              either.map(
+                either.flatMap(
+                  serializeIfNeeded(value),
+                  unparseAtomOrMolecule('default'),
+                ),
+                unparsedExpression =>
+                  openGroupingParenthesis.concat(
+                    unparsedExpression,
+                    closeGroupingParenthesis,
+                  ),
+              ),
+          }),
+    )
+
+    return either.map(either.sequence(componentResults), components =>
+      styleText(
+        semanticContext === 'apply' ? applyColor : keyColor,
+        dot.concat(components.join(dot)),
+      ),
+    )
+  }
+
+const unparseSugaredLookup =
+  ({ semanticContext }: Context) =>
+  (expression: LookupExpression) =>
+    either.makeRight(
+      styleText(
+        semanticContext === 'apply' ? applyColor : keyColor,
+        punctuation(styleText).colon.concat(
+          quoteKeyPathComponentIfNecessary(expression[1].key),
+        ),
+      ),
+    )
 
 const isTopType = (value: SemanticGraph): boolean =>
   value === types.somethingTypeSymbol ||
@@ -524,82 +577,80 @@ const isTopType = (value: SemanticGraph): boolean =>
     },
   )
 
-const unparseSugaredHole = (
-  expression: HoleExpression,
-  { unparseAtomOrMolecule }: Context,
-) => {
-  const {
-    openGroupingParenthesis,
-    closeGroupingParenthesis,
-    typeAnnotationColon,
-  } = punctuation(styleText)
-  const { name, constraint } = expression[1]
-  const holeNameWithSigil = styleText(
-    keyColor,
-    name === ignoredKey ? '?' : (
-      '?'.concat(quoteKeyPathComponentIfNecessary(name))
-    ),
-  )
-  if (isTopType(constraint.assignableTo)) {
-    // Omit the constraint if it's the top type.
-    return either.makeRight(holeNameWithSigil)
-  } else {
-    return either.map(
-      either.flatMap(
-        serializeIfNeeded(constraint.assignableTo),
-        unparseAtomOrMolecule('default'),
+const unparseSugaredHole =
+  ({ unparseAtomOrMolecule }: Context) =>
+  (expression: HoleExpression) => {
+    const {
+      openGroupingParenthesis,
+      closeGroupingParenthesis,
+      typeAnnotationColon,
+    } = punctuation(styleText)
+    const { name, constraint } = expression[1]
+    const holeNameWithSigil = styleText(
+      keyColor,
+      name === ignoredKey ? '?' : (
+        '?'.concat(quoteKeyPathComponentIfNecessary(name))
       ),
-      constraintAsString =>
-        openGroupingParenthesis.concat(
-          holeNameWithSigil,
-          typeAnnotationColon,
-          ' ',
-          constraintAsString,
-          closeGroupingParenthesis,
+    )
+    if (isTopType(constraint.assignableTo)) {
+      // Omit the constraint if it's the top type.
+      return either.makeRight(holeNameWithSigil)
+    } else {
+      return either.map(
+        either.flatMap(
+          serializeIfNeeded(constraint.assignableTo),
+          unparseAtomOrMolecule('default'),
+        ),
+        constraintAsString =>
+          openGroupingParenthesis.concat(
+            holeNameWithSigil,
+            typeAnnotationColon,
+            ' ',
+            constraintAsString,
+            closeGroupingParenthesis,
+          ),
+      )
+    }
+  }
+
+const unparseSugaredCheck =
+  ({ unparseAtomOrMolecule }: Context) =>
+  (expression: CheckExpression) => {
+    const { openGroupingParenthesis, closeGroupingParenthesis, tilde } =
+      punctuation(styleText)
+    return either.flatMap(
+      either.map(
+        either.flatMap(
+          serializeIfNeeded(expression[1].value),
+          unparseAtomOrMolecule('default'),
+        ),
+        valueAsString =>
+          isNonCompactExpression(expression[1].value) ?
+            openGroupingParenthesis.concat(
+              valueAsString,
+              closeGroupingParenthesis,
+            )
+          : valueAsString,
+      ),
+      valueAsString =>
+        either.map(
+          either.flatMap(
+            serializeIfNeeded(expression[1].type),
+            unparseAtomOrMolecule('default'),
+          ),
+          typeAsString => {
+            const possiblyParenthesizedType =
+              isNonCompactExpression(expression[1].type) ?
+                openGroupingParenthesis.concat(
+                  typeAsString,
+                  closeGroupingParenthesis,
+                )
+              : typeAsString
+            return [valueAsString, tilde, possiblyParenthesizedType].join(' ')
+          },
         ),
     )
   }
-}
-
-const unparseSugaredCheck = (
-  expression: CheckExpression,
-  { unparseAtomOrMolecule }: Context,
-) => {
-  const { openGroupingParenthesis, closeGroupingParenthesis, tilde } =
-    punctuation(styleText)
-  return either.flatMap(
-    either.map(
-      either.flatMap(
-        serializeIfNeeded(expression[1].value),
-        unparseAtomOrMolecule('default'),
-      ),
-      valueAsString =>
-        isNonCompactExpression(expression[1].value) ?
-          openGroupingParenthesis.concat(
-            valueAsString,
-            closeGroupingParenthesis,
-          )
-        : valueAsString,
-    ),
-    valueAsString =>
-      either.map(
-        either.flatMap(
-          serializeIfNeeded(expression[1].type),
-          unparseAtomOrMolecule('default'),
-        ),
-        typeAsString => {
-          const possiblyParenthesizedType =
-            isNonCompactExpression(expression[1].type) ?
-              openGroupingParenthesis.concat(
-                typeAsString,
-                closeGroupingParenthesis,
-              )
-            : typeAsString
-          return [valueAsString, tilde, possiblyParenthesizedType].join(' ')
-        },
-      ),
-  )
-}
 
 const unparseExcessPropertyClause =
   (context: Context) => (clause: ExcessClause) => {
@@ -624,8 +675,9 @@ const unparseExcessPropertyClause =
   }
 
 const unparseSugaredObjectType =
-  (formatting: 'inline' | 'multiline') =>
-  (expression: ObjectTypeExpression, context: Context) => {
+  (options: Options) =>
+  (context: Context) =>
+  (expression: ObjectTypeExpression) => {
     const { openBrace, closeBrace, comma } = punctuation(styleText)
     return either.flatMap(
       either.flatMapLeft(
@@ -646,16 +698,16 @@ const unparseSugaredObjectType =
                 message: '`@object` properties were unexpectedly an atom',
               })
             : either.flatMap(
-                moleculeAsKeyValuePairStrings(serializedProperties, context, {
-                  ordinalKeys: 'omit',
-                }),
+                moleculeAsKeyValuePairStrings(options)(context)(
+                  serializedProperties,
+                ),
                 propertyPairsAsStrings =>
                   either.map(
                     either.sequence(
                       clauses.map(unparseExcessPropertyClause(context)),
                     ),
                     refinementClausesAsStrings => {
-                      switch (formatting) {
+                      switch (options.flow) {
                         case 'inline':
                           return openBrace.concat(
                             ' ',
@@ -687,97 +739,93 @@ const unparseSugaredObjectType =
     )
   }
 
-const unparseSugaredUnion = (
-  expression: UnionExpression,
-  { unparseAtomOrMolecule, semanticContext }: Context,
-) => {
-  const { openGroupingParenthesis, closeGroupingParenthesis, unionBar } =
-    punctuation(styleText)
+const unparseSugaredUnion =
+  (context: Context) => (expression: UnionExpression) => {
+    const { openGroupingParenthesis, closeGroupingParenthesis, unionBar } =
+      punctuation(styleText)
 
-  const members = Object.values(expression[1])
+    const members = Object.values(expression[1])
 
-  if (members.length === 0) {
-    return unparseSugaredIndex(getBottomTypeAsSemanticGraph(), {
-      unparseAtomOrMolecule,
-      semanticContext,
-    })
-  } else {
-    // Unparse each member, adding parentheses when needed.
-    return members.reduce(
-      (unparsedUnion: Either<UnserializableValueError, string>, member) =>
-        either.flatMap(unparsedUnion, unionAsString =>
-          either.map(
-            either.flatMap(
-              serializeIfNeeded(member),
-              unparseAtomOrMolecule(semanticContext),
-            ),
-            memberAsString => {
-              const possiblyParenthesizedMember =
-                isNonCompactExpression(member) ?
-                  openGroupingParenthesis.concat(
-                    memberAsString,
-                    closeGroupingParenthesis,
-                  )
-                : memberAsString
-
-              return unionAsString === '' ?
-                  possiblyParenthesizedMember
-                : unionAsString.concat(
-                    ' ',
-                    unionBar,
-                    ' ',
-                    possiblyParenthesizedMember,
-                  )
-            },
-          ),
-        ),
-      either.makeRight(''),
-    )
-  }
-}
-
-const unparseSugaredGeneralizedKeywordExpression = (
-  expression: Expression,
-  { unparseAtomOrMolecule, semanticContext }: Context,
-) => {
-  if (
-    // Not every valid keyword expression can be expressed with the generalized
-    // sugar, e.g. if there are any additional properties besides the keyword
-    // and its argument, or if the keyword requires quotation (which won't be
-    // the case for any built-in keywords, but maybe eventually users will be
-    // able to create custom keywords).
-    requiresQuotation(expression['0'].substring(1)) ||
-    Object.keys(expression).some(key => key !== '0' && key !== '1')
-  ) {
-    return either.makeLeft({
-      kind: 'unserializableValue',
-      message:
-        'expression cannot be faithfully represented using generalized keyword expression sugar',
-    })
-  } else {
-    const unparsedKeyword = styleText(['bold', 'underline'], expression['0'])
-    if ('1' in expression) {
-      return either.map(
-        either.flatMap(serializeIfNeeded(expression['1']), expressionArgument =>
-          unparseAtomOrMolecule(semanticContext)(
-            // If there's only a single property in the argument, unparse it
-            // with an implicit key (e.g. `@runtime { a => b }` rather than
-            // `@runtime { function: a => b }`).
-            (
-              typeof expressionArgument !== 'string' &&
-                orderedRecord.size(expressionArgument) === 1
-            ) ?
-              orderedRecord.mapKeys(expressionArgument, _ => '0')
-            : expressionArgument,
-          ),
-        ),
-        unparsedArgument => unparsedKeyword.concat(' ', unparsedArgument),
-      )
+    if (members.length === 0) {
+      return unparseSugaredIndex(context)(getBottomTypeAsSemanticGraph())
     } else {
-      return either.makeRight(unparsedKeyword)
+      // Unparse each member, adding parentheses when needed.
+      return members.reduce(
+        (unparsedUnion: Either<UnserializableValueError, string>, member) =>
+          either.flatMap(unparsedUnion, unionAsString =>
+            either.map(
+              either.flatMap(
+                serializeIfNeeded(member),
+                context.unparseAtomOrMolecule(context.semanticContext),
+              ),
+              memberAsString => {
+                const possiblyParenthesizedMember =
+                  isNonCompactExpression(member) ?
+                    openGroupingParenthesis.concat(
+                      memberAsString,
+                      closeGroupingParenthesis,
+                    )
+                  : memberAsString
+
+                return unionAsString === '' ?
+                    possiblyParenthesizedMember
+                  : unionAsString.concat(
+                      ' ',
+                      unionBar,
+                      ' ',
+                      possiblyParenthesizedMember,
+                    )
+              },
+            ),
+          ),
+        either.makeRight(''),
+      )
     }
   }
-}
+
+const unparseSugaredGeneralizedKeywordExpression =
+  ({ unparseAtomOrMolecule, semanticContext }: Context) =>
+  (expression: Expression) => {
+    if (
+      // Not every valid keyword expression can be expressed with the generalized
+      // sugar, e.g. if there are any additional properties besides the keyword
+      // and its argument, or if the keyword requires quotation (which won't be
+      // the case for any built-in keywords, but maybe eventually users will be
+      // able to create custom keywords).
+      requiresQuotation(expression['0'].substring(1)) ||
+      Object.keys(expression).some(key => key !== '0' && key !== '1')
+    ) {
+      return either.makeLeft({
+        kind: 'unserializableValue',
+        message:
+          'expression cannot be faithfully represented using generalized keyword expression sugar',
+      })
+    } else {
+      const unparsedKeyword = styleText(['bold', 'underline'], expression['0'])
+      if ('1' in expression) {
+        return either.map(
+          either.flatMap(
+            serializeIfNeeded(expression['1']),
+            expressionArgument =>
+              unparseAtomOrMolecule(semanticContext)(
+                // If there's only a single property in the argument, unparse it
+                // with an implicit key (e.g. `@runtime { a => b }` rather than
+                // `@runtime { function: a => b }`).
+                (
+                  typeof expressionArgument !== 'string' &&
+                    orderedRecord.size(expressionArgument) === 1
+                ) ?
+                  orderedRecord.mapKeys(expressionArgument, _ => '0')
+                : expressionArgument,
+              ),
+          ),
+          unparsedArgument => unparsedKeyword.concat(' ', unparsedArgument),
+        )
+      } else {
+        return either.makeRight(unparsedKeyword)
+      }
+    }
+  }
 
 /**
  * An apply should be written in infix notation if it is immediately applied

--- a/src/language/unparsing/plz-utilities.ts
+++ b/src/language/unparsing/plz-utilities.ts
@@ -44,7 +44,12 @@ import {
   type ExcessClause,
   type ObjectTypeExpression,
 } from '../semantics/expressions/object-type-expression.js'
-import { applyColor, keyColor, punctuation } from './unparsing-utilities.js'
+import {
+  applyColor,
+  indent,
+  keyColor,
+  punctuation,
+} from './unparsing-utilities.js'
 
 export type SemanticContext = 'apply' | 'default'
 
@@ -58,7 +63,7 @@ export type UnparseAtomOrMolecule = (
 ) => (value: Atom | Molecule) => Either<UnserializableValueError, string>
 
 export const moleculeUnparser =
-  (semanticContext: SemanticContext) =>
+  (formatting: 'inline' | 'multiline', semanticContext: SemanticContext) =>
   (
     unparseAtomOrMolecule: UnparseAtomOrMolecule,
     unparseSugarFreeMolecule: (
@@ -90,7 +95,7 @@ export const moleculeUnparser =
           return sugar(
             value,
             readObjectTypeExpression,
-            unparseSugaredObjectType,
+            unparseSugaredObjectType(formatting),
           )
         case '@union':
           return sugar(value, readUnionExpression, unparseSugaredUnion)
@@ -618,53 +623,69 @@ const unparseExcessPropertyClause =
     )
   }
 
-const unparseSugaredObjectType = (
-  expression: ObjectTypeExpression,
-  context: Context,
-) => {
-  const { openBrace, closeBrace, comma } = punctuation(styleText)
-  return either.flatMap(
-    either.flatMapLeft(
-      readExcessClauses(expression),
-      (error): Either<UnserializableValueError, never> =>
-        either.makeLeft({
-          kind: 'unserializableValue',
-          message: error.message,
-        }),
-    ),
-    clauses =>
-      either.flatMap(
-        serializeIfNeeded(expression[1].properties),
-        serializedProperties =>
-          typeof serializedProperties === 'string' ?
-            either.makeLeft({
-              kind: 'unserializableValue',
-              message: '`@object` properties were unexpectedly an atom',
-            })
-          : either.flatMap(
-              moleculeAsKeyValuePairStrings(serializedProperties, context, {
-                ordinalKeys: 'omit',
-              }),
-              propertyPairsAsStrings =>
-                either.map(
-                  either.sequence(
-                    clauses.map(unparseExcessPropertyClause(context)),
-                  ),
-                  refinementClausesAsStrings =>
-                    openBrace.concat(
-                      ' ',
-                      [
-                        ...refinementClausesAsStrings,
-                        ...propertyPairsAsStrings,
-                      ].join(comma.concat(' ')),
-                      ' ',
-                      closeBrace,
-                    ),
-                ),
-            ),
+const unparseSugaredObjectType =
+  (formatting: 'inline' | 'multiline') =>
+  (expression: ObjectTypeExpression, context: Context) => {
+    const { openBrace, closeBrace, comma } = punctuation(styleText)
+    return either.flatMap(
+      either.flatMapLeft(
+        readExcessClauses(expression),
+        (error): Either<UnserializableValueError, never> =>
+          either.makeLeft({
+            kind: 'unserializableValue',
+            message: error.message,
+          }),
       ),
-  )
-}
+      clauses =>
+        either.flatMap(
+          serializeIfNeeded(expression[1].properties),
+          serializedProperties =>
+            typeof serializedProperties === 'string' ?
+              either.makeLeft({
+                kind: 'unserializableValue',
+                message: '`@object` properties were unexpectedly an atom',
+              })
+            : either.flatMap(
+                moleculeAsKeyValuePairStrings(serializedProperties, context, {
+                  ordinalKeys: 'omit',
+                }),
+                propertyPairsAsStrings =>
+                  either.map(
+                    either.sequence(
+                      clauses.map(unparseExcessPropertyClause(context)),
+                    ),
+                    refinementClausesAsStrings => {
+                      switch (formatting) {
+                        case 'inline':
+                          return openBrace.concat(
+                            ' ',
+                            [
+                              ...refinementClausesAsStrings,
+                              ...propertyPairsAsStrings,
+                            ].join(comma.concat(' ')),
+                            ' ',
+                            closeBrace,
+                          )
+                        case 'multiline':
+                          return openBrace.concat(
+                            '\n',
+                            indent(
+                              2,
+                              [
+                                ...refinementClausesAsStrings,
+                                ...propertyPairsAsStrings,
+                              ].join('\n'),
+                            ),
+                            '\n',
+                            closeBrace,
+                          )
+                      }
+                    },
+                  ),
+              ),
+        ),
+    )
+  }
 
 const unparseSugaredUnion = (
   expression: UnionExpression,

--- a/src/language/unparsing/pretty-plz.ts
+++ b/src/language/unparsing/pretty-plz.ts
@@ -1,53 +1,11 @@
-import either from '@matt.kantor/either'
-import { styleText } from 'node:util'
-import type { Molecule } from '../parsing.js'
-import {
-  moleculeAsKeyValuePairStrings,
-  moleculeUnparser,
-  unparseAtom,
-  type SemanticContext,
-  type UnparseAtomOrMolecule,
-} from './plz-utilities.js'
-import { indent, punctuation, type Notation } from './unparsing-utilities.js'
-
-const unparseSugarFreeMolecule = (value: Molecule) => {
-  const { closeBrace, openBrace } = punctuation(styleText)
-  if (value.entries.length === 0) {
-    return either.makeRight(openBrace + closeBrace)
-  } else {
-    return either.map(
-      moleculeAsKeyValuePairStrings(
-        value,
-        { unparseAtomOrMolecule, semanticContext: 'default' },
-        {
-          ordinalKeys: 'omit',
-        },
-      ),
-      keyValuePairsAsStrings =>
-        openBrace.concat(
-          '\n',
-          indent(2, keyValuePairsAsStrings.join('\n')),
-          '\n',
-          closeBrace,
-        ),
-    )
-  }
-}
-
-const unparseAtomOrMolecule: UnparseAtomOrMolecule =
-  semanticContext => value =>
-    typeof value === 'string' ?
-      unparseAtom(value)
-    : unparseMolecule(semanticContext)(value)
-
-const unparseMolecule = (semanticContext: SemanticContext) =>
-  moleculeUnparser('multiline', semanticContext)(
-    unparseAtomOrMolecule,
-    unparseSugarFreeMolecule,
-  )
+import { moleculeUnparser, unparseAtom } from './plz-utilities.js'
+import { type Notation } from './unparsing-utilities.js'
 
 export const prettyPlz: Notation = {
   atom: unparseAtom,
-  molecule: unparseMolecule('default'),
+  molecule: moleculeUnparser({
+    flow: 'multiline',
+    ordinalKeys: 'omit',
+  })('default'),
   suffix: '\n',
 }

--- a/src/language/unparsing/pretty-plz.ts
+++ b/src/language/unparsing/pretty-plz.ts
@@ -41,7 +41,7 @@ const unparseAtomOrMolecule: UnparseAtomOrMolecule =
     : unparseMolecule(semanticContext)(value)
 
 const unparseMolecule = (semanticContext: SemanticContext) =>
-  moleculeUnparser(semanticContext)(
+  moleculeUnparser('multiline', semanticContext)(
     unparseAtomOrMolecule,
     unparseSugarFreeMolecule,
   )

--- a/src/language/unparsing/sugar-free-inline-plz.ts
+++ b/src/language/unparsing/sugar-free-inline-plz.ts
@@ -9,30 +9,28 @@ import {
 } from './plz-utilities.js'
 import { punctuation, type Notation } from './unparsing-utilities.js'
 
-const unparseMolecule =
-  (semanticContext: SemanticContext) => (value: Molecule) => {
+const unparseMolecule = (semanticContext: SemanticContext) => {
+  const keyValuePairStrings = moleculeAsKeyValuePairStrings({
+    flow: 'inline',
+    ordinalKeys: 'preserve',
+  })({ unparseAtomOrMolecule, semanticContext })
+
+  return (value: Molecule) => {
     const { closeBrace, openBrace, comma } = punctuation(styleText)
     if (value.entries.length === 0) {
       return either.makeRight(openBrace + closeBrace)
     } else {
-      return either.map(
-        moleculeAsKeyValuePairStrings(
-          value,
-          { unparseAtomOrMolecule, semanticContext },
-          {
-            ordinalKeys: 'preserve',
-          },
+      return either.map(keyValuePairStrings(value), keyValuePairsAsStrings =>
+        openBrace.concat(
+          ' ',
+          keyValuePairsAsStrings.join(comma.concat(' ')),
+          ' ',
+          closeBrace,
         ),
-        keyValuePairsAsStrings =>
-          openBrace.concat(
-            ' ',
-            keyValuePairsAsStrings.join(comma.concat(' ')),
-            ' ',
-            closeBrace,
-          ),
       )
     }
   }
+}
 
 const unparseAtomOrMolecule: UnparseAtomOrMolecule =
   semanticContext => value =>

--- a/src/language/unparsing/sugar-free-pretty-plz.ts
+++ b/src/language/unparsing/sugar-free-pretty-plz.ts
@@ -9,30 +9,28 @@ import {
 } from './plz-utilities.js'
 import { indent, punctuation, type Notation } from './unparsing-utilities.js'
 
-const unparseMolecule =
-  (semanticContext: SemanticContext) => (value: Molecule) => {
+const unparseMolecule = (semanticContext: SemanticContext) => {
+  const keyValuePairStrings = moleculeAsKeyValuePairStrings({
+    flow: 'multiline',
+    ordinalKeys: 'preserve',
+  })({ unparseAtomOrMolecule, semanticContext })
+
+  return (value: Molecule) => {
     const { closeBrace, openBrace } = punctuation(styleText)
     if (value.entries.length === 0) {
       return either.makeRight(openBrace + closeBrace)
     } else {
-      return either.map(
-        moleculeAsKeyValuePairStrings(
-          value,
-          { unparseAtomOrMolecule, semanticContext },
-          {
-            ordinalKeys: 'preserve',
-          },
+      return either.map(keyValuePairStrings(value), keyValuePairsAsStrings =>
+        openBrace.concat(
+          '\n',
+          indent(2, keyValuePairsAsStrings.join('\n')),
+          '\n',
+          closeBrace,
         ),
-        keyValuePairsAsStrings =>
-          openBrace.concat(
-            '\n',
-            indent(2, keyValuePairsAsStrings.join('\n')),
-            '\n',
-            closeBrace,
-          ),
       )
     }
   }
+}
 
 const unparseAtomOrMolecule: UnparseAtomOrMolecule =
   semanticContext => value =>


### PR DESCRIPTION
Revamp the plumbing for plz unparsers. Changes include:
- Establish first-class options for single-line vs multi-line and whether to omit ordinal keys.
- Standardizing signatures so it's easier to partially apply `SemanticContext`.

The only user-visible changes should be that line breaks are now used to delimit excess property clauses in "pretty" notations and function parameter list parentheses are now colored red.

Most of the action is in src/language/unparsing/plz-utilities.ts; if you're looking at the diff read that module first.

The changeset will be much easier to review if you ignore whitespace diffs.