### PR TITLE
Reason about stuck types via their upper bounds in more places

### DIFF
--- a/src/end-to-end.test.ts
+++ b/src/end-to-end.test.ts
@@ -950,6 +950,34 @@ testCases(endToEnd, code => code)('end-to-end tests', [
     assertSuccess,
   ],
   [
+    `(o: :object.type) => {
+      first: :o object.lookup 0
+      return: :identity(:first.value)
+    }.return`,
+    assertSuccess,
+  ],
+  [
+    `{
+      deferred: @runtime { _context => { value: 1 } }
+      out: :deferred.value
+    }`,
+    success({ deferred: { value: '1' }, out: '1' }),
+  ],
+  [
+    `(o: :object.type) => {
+      first: :o object.lookup 0
+      return: :first.value + 1
+    }.return`,
+    typeMismatch,
+  ],
+  [
+    `(o: :object.type) => {
+      first: :o object.lookup 0
+      return: :first.value(1)
+    }.return`,
+    invalidExpression,
+  ],
+  [
     `(x: { a: :atom.type }) => (y: { b: :atom.type }) =>
       (:object.overlay(:x)(:y) ~ @object {
         properties: { a: :atom.type, b: :something.type }

--- a/src/language/semantics/type-system/prelude-types/opaque-types.ts
+++ b/src/language/semantics/type-system/prelude-types/opaque-types.ts
@@ -1,6 +1,6 @@
 import optionAdt from '@matt.kantor/option'
 import { makeOpaqueType } from '../type-formats/opaque-type.js'
-import { replaceAllTypeParametersWithTheirConstraints } from '../type-substitution.js'
+import { upperBoundOfStuckType } from '../type-substitution.js'
 import {
   atomTypeSymbol,
   integerTypeSymbol,
@@ -14,7 +14,7 @@ import {
 
 export const atom = makeOpaqueType(atomTypeSymbol, {
   isAssignableFromLiteralType: (_literalType: string) => true,
-  upperBoundOfStuckType: replaceAllTypeParametersWithTheirConstraints,
+  upperBoundOfStuckType,
   nearestOpaqueAssignableFrom: () => optionAdt.makeSome(integer),
   nearestOpaqueAssignableTo: () => optionAdt.none,
 })
@@ -22,7 +22,7 @@ export const atom = makeOpaqueType(atomTypeSymbol, {
 export const integer = makeOpaqueType(integerTypeSymbol, {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|-?[1-9][0-9]*)$/.test(literalType),
-  upperBoundOfStuckType: replaceAllTypeParametersWithTheirConstraints,
+  upperBoundOfStuckType,
   nearestOpaqueAssignableFrom: () => optionAdt.makeSome(naturalNumber),
   nearestOpaqueAssignableTo: () => optionAdt.makeSome(atom),
 })
@@ -30,7 +30,7 @@ export const integer = makeOpaqueType(integerTypeSymbol, {
 export const naturalNumber = makeOpaqueType(naturalNumberTypeSymbol, {
   isAssignableFromLiteralType: literalType =>
     /^(?:0|[1-9][0-9]*)$/.test(literalType),
-  upperBoundOfStuckType: replaceAllTypeParametersWithTheirConstraints,
+  upperBoundOfStuckType,
   nearestOpaqueAssignableFrom: () => optionAdt.none,
   nearestOpaqueAssignableTo: () => optionAdt.makeSome(integer),
 })

--- a/src/language/semantics/type-system/subtyping.test.ts
+++ b/src/language/semantics/type-system/subtyping.test.ts
@@ -1,9 +1,11 @@
+import either from '@matt.kantor/either'
 import { testCases } from '../../../test-utilities.test.js'
 import { stringifyTypeForEndUser } from '../semantic-graph.js'
 import {
   makeApplicationType,
   makeFunctionType,
   makeIndexedAccessType,
+  makeIntrinsicApplicationType,
   makeObjectType,
   makeTypeParameter,
   makeUnionType,
@@ -86,7 +88,6 @@ const applicationBoolean = makeApplicationType(
     applicationReturnParameter.identity,
   ]),
 )
-// Same as above:
 const applicationBoolean2 = makeApplicationType(
   makeFunctionType({
     parameter: applicationFunctionParameter,
@@ -97,6 +98,41 @@ const applicationBoolean2 = makeApplicationType(
     applicationFunctionParameter.identity,
     applicationReturnParameter.identity,
   ]),
+)
+
+const parameterFreeStuckApplication = makeApplicationType(
+  something,
+  something,
+  new Set(),
+)
+const parameterFreeStuckIntrinsicApplication = makeIntrinsicApplicationType(
+  [makeUnionType(['0']), object],
+  _argumentValues => either.makeRight(something),
+  _parameterTypes =>
+    makeUnionType([
+      makeObjectType({ value: integer }),
+      makeObjectType({ value: exactEmptyObject }),
+    ]),
+)
+const parameterFreeStuckIndexedAccess = makeIndexedAccessType(
+  parameterFreeStuckIntrinsicApplication,
+  makeUnionType(['value']),
+)
+const integerBoundStuckIndexedAccess = makeIndexedAccessType(
+  makeIntrinsicApplicationType(
+    [makeUnionType(['0']), object],
+    _argumentValues => either.makeRight(something),
+    _parameterTypes => makeObjectType({ value: integer }),
+  ),
+  makeUnionType(['value']),
+)
+const parameterFreeStuckApplicationOfFunctionUnion = makeApplicationType(
+  makeUnionType([
+    makeFunctionType({ parameter: something, return: makeUnionType(['a']) }),
+    makeFunctionType({ parameter: something, return: makeUnionType(['b']) }),
+  ]),
+  something,
+  new Set(),
 )
 
 testCases(
@@ -204,6 +240,35 @@ typeAssignabilitySuite('application types (not assignable)', [
   // As with stuck indexed accesses, `boolean` can't be assigned to a stuck
   // application even though the application's upper bound is `boolean`.
   [[boolean, applicationBoolean], false],
+])
+
+typeAssignabilitySuite('parameter-free stuck types', [
+  [[parameterFreeStuckIndexedAccess, parameterFreeStuckIndexedAccess], true],
+  [[parameterFreeStuckIndexedAccess, something], true],
+  [
+    [
+      parameterFreeStuckIndexedAccess,
+      makeUnionType([integer, exactEmptyObject]),
+    ],
+    true,
+  ],
+  [
+    [
+      parameterFreeStuckIntrinsicApplication,
+      makeUnionType([
+        makeObjectType({ value: integer }),
+        makeObjectType({ value: exactEmptyObject }),
+      ]),
+    ],
+    true,
+  ],
+  [[makeUnionType([integerBoundStuckIndexedAccess]), integer], true],
+  [[parameterFreeStuckApplicationOfFunctionUnion, atom], true],
+  [[makeUnionType([parameterFreeStuckApplicationOfFunctionUnion]), atom], true],
+  [[parameterFreeStuckIndexedAccess, integer], false],
+  [[makeUnionType([parameterFreeStuckIndexedAccess]), integer], false],
+  [[makeUnionType([parameterFreeStuckApplication]), atom], false],
+  [[parameterFreeStuckApplicationOfFunctionUnion, makeUnionType(['a'])], false],
 ])
 
 typeAssignabilitySuite('stuck application in a contravariant position', [

--- a/src/language/semantics/type-system/subtyping.ts
+++ b/src/language/semantics/type-system/subtyping.ts
@@ -24,6 +24,7 @@ import {
   replaceAllTypeParametersWithTheirConstraints,
   supplyTypeArgument,
   supplyTypeArguments,
+  upperBoundOfStuckType,
 } from './type-substitution.js'
 
 export const isAssignable = ({
@@ -89,9 +90,9 @@ export const isAssignable = ({
             })
           ) ?
             true
-          : isAssignable({
-              source: replaceAllTypeParametersWithTheirConstraints(source),
-              target,
+          : option.match(upperBoundOfStuckType(source), {
+              none: _ => false,
+              some: upperBound => isAssignable({ source: upperBound, target }),
             }),
         function: source =>
           matchTypeFormat(target, {
@@ -215,14 +216,14 @@ export const isAssignable = ({
             union: target => isNonUnionAssignableToUnion({ source, target }),
           }),
         indexedAccess: source =>
-          isAssignable({
-            source: replaceAllTypeParametersWithTheirConstraints(source),
-            target,
+          option.match(upperBoundOfStuckType(source), {
+            none: _ => false,
+            some: upperBound => isAssignable({ source: upperBound, target }),
           }),
         intrinsicApplication: source =>
-          isAssignable({
-            source: replaceAllTypeParametersWithTheirConstraints(source),
-            target,
+          option.match(upperBoundOfStuckType(source), {
+            none: _ => false,
+            some: upperBound => isAssignable({ source: upperBound, target }),
           }),
         object: source =>
           matchTypeFormat(target, {

--- a/src/language/semantics/type-system/type-formats/opaque-type.ts
+++ b/src/language/semantics/type-system/type-formats/opaque-type.ts
@@ -1,4 +1,4 @@
-import option, { type None, type Some } from '@matt.kantor/option'
+import option, { type None, type Option, type Some } from '@matt.kantor/option'
 import type { TypeSymbol } from '../../semantic-graph.js'
 import type { ApplicationType } from './application-type.js'
 import type { IndexedAccessType } from './indexed-access-type.js'
@@ -21,7 +21,7 @@ export const makeOpaqueType = (
     // types.
     readonly upperBoundOfStuckType: (
       type: ApplicationType | IndexedAccessType | IntrinsicApplicationType,
-    ) => Type
+    ) => Option<Type>
   } & (
     | {
         readonly nearestOpaqueAssignableFrom: () => None
@@ -43,11 +43,12 @@ export const makeOpaqueType = (
     isAssignableFrom: source => {
       switch (source.kind) {
         case 'application':
-          return self.isAssignableFrom(subtyping.upperBoundOfStuckType(source))
         case 'indexedAccess':
-          return self.isAssignableFrom(subtyping.upperBoundOfStuckType(source))
         case 'intrinsicApplication':
-          return self.isAssignableFrom(subtyping.upperBoundOfStuckType(source))
+          return option.match(subtyping.upperBoundOfStuckType(source), {
+            none: _ => false,
+            some: upperBound => self.isAssignableFrom(upperBound),
+          })
         case 'function':
           return false
         case 'object':
@@ -56,7 +57,7 @@ export const makeOpaqueType = (
           return (
             source === self ||
             option.match(subtyping.nearestOpaqueAssignableFrom(), {
-              none: () => false,
+              none: _ => false,
               some: nearestOpaqueAssignableFrom =>
                 nearestOpaqueAssignableFrom.isAssignableFrom(source),
             })
@@ -92,7 +93,7 @@ export const makeOpaqueType = (
           return (
             target === self ||
             option.match(subtyping.nearestOpaqueAssignableTo(), {
-              none: () => false,
+              none: _ => false,
               some: nearestOpaqueAssignableTo =>
                 nearestOpaqueAssignableTo.isAssignableTo(target),
             })

--- a/src/language/semantics/type-system/type-substitution.test.ts
+++ b/src/language/semantics/type-system/type-substitution.test.ts
@@ -34,6 +34,7 @@ import {
 import { nestedIndexedAccess } from './type-key-path.js'
 import { containedTypeParameters } from './type-parameter-analysis.js'
 import {
+  applicableFunctionSignatures,
   applyKeyPathToType,
   applyTypeToArgumentType,
   enumerateInhabitants,
@@ -347,6 +348,8 @@ getTypesForTypeParametersSuite('getTypesForTypeParameters', [
     ],
     new Map([[A, atom]]),
   ],
+
+  [[A, makeApplicationType(atom, atom, new Set())], new Map()],
 ])
 
 const enumerateInhabitantsSuite = testCases(
@@ -634,6 +637,50 @@ genericizeParameterAnnotationSuite('genericizeParameterAnnotation', [
   ],
 ])
 
+const atomToAtom = makeFunctionType({ parameter: atom, return: atom })
+const keyAssignableToF = makeTypeParameter('key', {
+  assignableTo: makeUnionType(['f']),
+})
+
+const applicableFunctionSignaturesSuite = testCases(
+  applicableFunctionSignatures,
+  type =>
+    `finding applicable function signatures of \`${stringifyTypeForEndUser(type)}\``,
+)
+
+applicableFunctionSignaturesSuite('applicableFunctionSignatures', [
+  [atomToAtom, optionAdt.makeSome([atomToAtom.signature])],
+  [
+    makeIndexedAccessType(makeObjectType({ f: atomToAtom }), keyAssignableToF),
+    optionAdt.makeSome([atomToAtom.signature]),
+  ],
+  [
+    makeIndexedAccessType(
+      makeObjectType({ f: atomToAtom }),
+      makeUnionType(['f']),
+    ),
+    optionAdt.makeSome([atomToAtom.signature]),
+  ],
+  [
+    makeApplicationType(
+      makeFunctionType({ parameter: something, return: atomToAtom }),
+      something,
+      new Set(),
+    ),
+    optionAdt.makeSome([atomToAtom.signature]),
+  ],
+  [
+    makeIntrinsicApplicationType(
+      [atom],
+      _ => either.makeLeft({ kind: 'panic', message: 'unexpected error' }),
+      _ => atomToAtom,
+    ),
+    optionAdt.makeSome([atomToAtom.signature]),
+  ],
+  [makeIndexedAccessType(makeObjectType({ x: atom }), atom), optionAdt.none],
+  [makeApplicationType(atom, atom, new Set()), optionAdt.none],
+])
+
 const applyTypeToArgumentTypeSuite = testCases(
   ([functionLikeType, argumentType]: readonly [
     functionLikeType: Type,
@@ -679,8 +726,21 @@ applyTypeToArgumentTypeSuite('applyTypeToArgumentType', [
     stringifyTypeForEndUser(makeUnionType([integer, atom])),
   ],
 
+  [
+    [
+      makeApplicationType(
+        makeFunctionType({ parameter: something, return: atomToAtom }),
+        something,
+        new Set(),
+      ),
+      atom,
+    ],
+    stringifyTypeForEndUser(atom),
+  ],
+
   [[object, integer], 'none'],
   [[integer, atom], 'none'],
+  [[makeApplicationType(atom, atom, new Set()), atom], 'none'],
 ])
 
 const supplyTypeArgumentSuite = testCases(

--- a/src/language/semantics/type-system/type-substitution.ts
+++ b/src/language/semantics/type-system/type-substitution.ts
@@ -218,16 +218,42 @@ export const replaceAllTypeParametersWithTheirConstraints = (
         type,
       )
 
-const upperBoundOfStuckApplication = (application: ApplicationType): Type =>
-  application.function.kind === 'function' ?
-    supplyTypeArguments(
-      application.function.signature.return,
-      getTypesForTypeParameters({
-        parameterType: application.function.signature.parameter,
-        argumentType: application.argument,
-      }),
-    )
-  : replaceAllTypeParametersWithTheirConstraints(application)
+/**
+ * The most specific resolvable upper bound of a stuck type, or `none` when
+ * nothing further can be resolved.
+ */
+export const upperBoundOfStuckType = (
+  stuckType: ApplicationType | IndexedAccessType | IntrinsicApplicationType,
+): Option<Type> => {
+  const substituted = replaceAllTypeParametersWithTheirConstraints(stuckType)
+  if (substituted !== stuckType) {
+    return option.makeSome(substituted)
+  } else {
+    switch (stuckType.kind) {
+      case 'application':
+        return applyTypeToArgumentType(stuckType.function, stuckType.argument)
+      case 'indexedAccess':
+        return option.flatMap(
+          either.match(atomKeyPathComponentFromType(stuckType.key), {
+            left: _ => option.none,
+            right: option.makeSome,
+          }),
+          key =>
+            applyKeyPathToType(
+              replaceAllTypeParametersWithTheirConstraints(stuckType.object),
+              [key],
+            ),
+        )
+      case 'intrinsicApplication':
+        // TODO: Feels like this case should look like the following, but `none`
+        // seems to work (I'm not sure execution can ever make it here):
+        // return option.makeSome(
+        //   stuckType.computeUpperBound(stuckType.parameterTypes),
+        // )
+        return option.none
+    }
+  }
+}
 
 /**
  * Finds concrete types for the `TypeParameter`s in `parameter` by locating the
@@ -253,10 +279,25 @@ export const getTypesForTypeParameters = ({
       argumentType: replaceAllTypeParametersWithTheirConstraints(argumentType),
     })
   } else if (argumentType.kind === 'application') {
-    return getTypesForTypeParameters({
-      parameterType,
-      argumentType: upperBoundOfStuckApplication(argumentType),
-    })
+    const argumentUpperBound =
+      argumentType.function.kind === 'function' ?
+        supplyTypeArguments(
+          argumentType.function.signature.return,
+          getTypesForTypeParameters({
+            parameterType: argumentType.function.signature.parameter,
+            argumentType: argumentType.argument,
+          }),
+        )
+      : replaceAllTypeParametersWithTheirConstraints(argumentType)
+
+    // When the stuck application's bound can't be resolved any further, no
+    // type arguments are derivable from it (and recursing would loop forever).
+    return argumentUpperBound === argumentType ?
+        new Map()
+      : getTypesForTypeParameters({
+          parameterType,
+          argumentType: argumentUpperBound,
+        })
   } else {
     return matchTypeFormat(parameterType, {
       function: parameterType =>
@@ -411,8 +452,10 @@ export const applicableFunctionSignatures = (
 ): Option<readonly FunctionType['signature'][]> =>
   matchTypeFormat(type, {
     function: type => option.makeSome([type.signature]),
+
     parameter: type =>
       applicableFunctionSignatures(type.constraint.assignableTo),
+
     union: type =>
       type.members.size === 0 ?
         option.none
@@ -434,19 +477,15 @@ export const applicableFunctionSignatures = (
             ),
           option.makeSome([]),
         ),
+
     // A stuck application/indexed access is applicable when its upper bound is.
     application: type =>
-      applicableFunctionSignatures(
-        replaceAllTypeParametersWithTheirConstraints(type),
-      ),
+      option.flatMap(upperBoundOfStuckType(type), applicableFunctionSignatures),
     indexedAccess: type =>
-      applicableFunctionSignatures(
-        replaceAllTypeParametersWithTheirConstraints(type),
-      ),
+      option.flatMap(upperBoundOfStuckType(type), applicableFunctionSignatures),
     intrinsicApplication: type =>
-      applicableFunctionSignatures(
-        replaceAllTypeParametersWithTheirConstraints(type),
-      ),
+      option.flatMap(upperBoundOfStuckType(type), applicableFunctionSignatures),
+
     object: _ => option.none,
     opaque: _ => option.none,
   })


### PR DESCRIPTION
The immediate motivation for this was to avoid infinite recursion when traversing stuck[^1] types containing no type parameters (previously we'd often recurse on `replaceAllTypeParametersWithTheirConstraints(…)` and make no progress).

But this changeset also improves completeness, making it possible to reason about the assignability of stuck types to other types in more situations and otherwise enhancing static analysis.

[^1]: "Stuck" types are things like indexed access types that can't necessarily immediately be reduced because they may depend on not-yet-provided context (like type parameters from an enclosing function). For example, the return type of `(key: a | b) => { a: true, b: false }.:key` is stuck on `:key`.