### PR TITLE
Make keyword expression elaboration uniform

### DIFF
--- a/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/apply-handler.ts
@@ -6,6 +6,7 @@ import {
   attachSpanIfAbsent,
   containedTypeParameters,
   containsAnyUnelaboratedNodes,
+  elaborateOperands,
   getTypesForTypeParameters,
   inferType,
   isAssignable,
@@ -17,9 +18,9 @@ import {
   supplyTypeArguments,
   typeParameterAssignableToConstraintKey,
   typeParameterIdentitiesWithinType,
+  type ApplyExpression,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
   type Type,
   type TypeParameter,
@@ -179,82 +180,91 @@ const checkApplication = (
     },
   })
 
-export const applyKeywordHandler: KeywordHandler = (
+export const applyKeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   either.flatMap(
-    readApplyExpression(expression),
+    readAndAnalyzeApplyExpression(expression, context),
     (applyExpression): Either<ElaborationError, SemanticGraph> => {
       const functionToApply = applyExpression[1].function
       const argument = applyExpression[1].argument
 
-      const subContextForFunction = {
-        ...context,
-        location: [...context.location, '1', 'function'],
+      if (containsAnyUnelaboratedNodes(argument)) {
+        // The argument isn't ready, so keep the @apply unelaborated.
+        return either.makeRight(applyExpression)
+      } else if (isFunctionNode(functionToApply)) {
+        const result = functionToApply(argument, context)
+        if (either.isLeft(result)) {
+          if (result.value.kind === 'dependencyUnavailable') {
+            // Keep the @apply unelaborated.
+            return either.makeRight(applyExpression)
+          } else {
+            return either.makeLeft(result.value)
+          }
+        } else {
+          return result
+        }
+      } else if (containsAnyUnelaboratedNodes(functionToApply)) {
+        // The function isn't ready, so keep the @apply unelaborated.
+        return either.makeRight(applyExpression)
+      } else {
+        return either.makeLeft({
+          kind: 'invalidExpression',
+          message: 'only functions can be applied',
+        })
       }
-      const subContextForArgument = {
-        ...context,
-        location: [...context.location, '1', 'argument'],
-      }
+    },
+  )
 
-      const argumentTypeCheck = either.flatMap(
-        either.mapLeft(
-          inferType(functionToApply, subContextForFunction),
-          attachSpanIfAbsent(subContextForFunction),
-        ),
-        functionType =>
-          either.flatMap(
+export const readAndAnalyzeApplyExpression = (
+  expression: Expression,
+  context: ExpressionContext,
+): Either<ElaborationError, ApplyExpression> =>
+  either.flatMap(
+    elaborateOperands(expression, context),
+    ({ expression, context }) =>
+      either.flatMap(readApplyExpression(expression), applyExpression => {
+        const functionToApply = applyExpression[1].function
+        const argument = applyExpression[1].argument
+
+        const subContextForFunction = {
+          ...context,
+          location: [...context.location, '1', 'function'],
+        }
+        const subContextForArgument = {
+          ...context,
+          location: [...context.location, '1', 'argument'],
+        }
+
+        const argumentTypeCheck = either.flatMap(
+          either.sequence([
+            either.mapLeft(
+              inferType(functionToApply, subContextForFunction),
+              attachSpanIfAbsent(subContextForFunction),
+            ),
             either.mapLeft(
               inferType(argument, subContextForArgument),
               attachSpanIfAbsent(subContextForArgument),
             ),
-            argumentType =>
-              either.mapLeft(
-                checkApplication(
-                  argument,
-                  functionType,
-                  argumentType,
-                  rigidTypeParameterIdentities(context),
-                ),
-                error =>
-                  // A `typeMismatch` here means the argument didn't fit the
-                  // parameter, so blame the argument specifically.
-                  error.kind === 'typeMismatch' ?
-                    attachSpanIfAbsent(subContextForArgument)(error)
-                  : error,
+          ]),
+          ([functionType, argumentType]) =>
+            either.mapLeft(
+              checkApplication(
+                argument,
+                functionType,
+                argumentType,
+                rigidTypeParameterIdentities(context),
               ),
-          ),
-      )
+              error =>
+                // A `typeMismatch` here means the argument didn't fit the
+                // parameter, so blame the argument specifically.
+                error.kind === 'typeMismatch' ?
+                  attachSpanIfAbsent(subContextForArgument)(error)
+                : error,
+            ),
+        )
 
-      return either.flatMap(
-        argumentTypeCheck,
-        (): Either<ElaborationError, SemanticGraph> => {
-          if (containsAnyUnelaboratedNodes(argument)) {
-            // The argument isn't ready, so keep the @apply unelaborated.
-            return either.makeRight(applyExpression)
-          } else if (isFunctionNode(functionToApply)) {
-            const result = functionToApply(argument, context)
-            if (either.isLeft(result)) {
-              if (result.value.kind === 'dependencyUnavailable') {
-                // Keep the @apply unelaborated.
-                return either.makeRight(applyExpression)
-              } else {
-                return either.makeLeft(result.value)
-              }
-            } else {
-              return result
-            }
-          } else if (containsAnyUnelaboratedNodes(functionToApply)) {
-            // The function isn't ready, so keep the @apply unelaborated.
-            return either.makeRight(applyExpression)
-          } else {
-            return either.makeLeft({
-              kind: 'invalidExpression',
-              message: 'only functions can be applied',
-            })
-          }
-        },
-      )
-    },
+        return either.map(argumentTypeCheck, _ => applyExpression)
+      }),
   )

--- a/src/language/compiling/semantics/keyword-handlers/check-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/check-handler.ts
@@ -2,13 +2,13 @@ import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
   attachSpanIfAbsent,
+  elaborateOperands,
   isAssignable,
   readCheckExpression,
   stringifySemanticGraphForEndUser,
   stringifyTypeForEndUser,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 import {
@@ -61,10 +61,15 @@ const check = ({
   )
 }
 
-export const checkKeywordHandler: KeywordHandler = (
+export const checkKeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(readCheckExpression(expression), ({ 1: { value, type } }) =>
-    check({ value, type, context }),
+  either.flatMap(
+    elaborateOperands(expression, context),
+    ({ expression, context }) =>
+      either.flatMap(
+        readCheckExpression(expression),
+        ({ 1: { value, type } }) => check({ value, type, context }),
+      ),
   )

--- a/src/language/compiling/semantics/keyword-handlers/function-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/function-handler.ts
@@ -4,6 +4,7 @@ import type { ElaborationError } from '../../../errors.js'
 import type { Atom } from '../../../parsing.js'
 import {
   asSemanticGraph,
+  elaborateOperands,
   elaborateWithContext,
   getParameterName,
   getParameterTypeAnnotation,
@@ -20,9 +21,9 @@ import {
   updateValueAtKeyPathInSemanticGraph,
   type Expression,
   type ExpressionContext,
+  type ExpressionWithElaboratedOperands,
   type FunctionExpression,
   type FunctionNode,
-  type KeywordHandler,
   type SemanticGraph,
   type Type,
 } from '../../../semantics.js'
@@ -37,8 +38,28 @@ import {
 } from '../../../semantics/semantic-graph.js'
 import { makeTypeParameter } from '../../../semantics/type-system.js'
 
-export const functionKeywordHandler: KeywordHandler = (
+export const functionKeywordHandler = (
   expression: Expression,
+  context: ExpressionContext,
+): Either<ElaborationError, FunctionNode> =>
+  either.flatMap(
+    elaborateOperands(expression, {
+      ...context,
+      // `@panic`s inside functions shouldn't fire while elaborating the body,
+      // only when the function is eventually called.
+      panicsAreDeferred: true,
+    }),
+    ({ expression, context: operandContext }) =>
+      makeFunctionFromElaboratedExpression(expression, {
+        // The original `context` is used here; `panicsAreDeferred` applies only
+        // to the operands.
+        ...context,
+        program: operandContext.program,
+      }),
+  )
+
+const makeFunctionFromElaboratedExpression = (
+  expression: ExpressionWithElaboratedOperands,
   context: ExpressionContext,
 ): Either<ElaborationError, FunctionNode> =>
   either.flatMap(readFunctionExpression(expression), functionExpression =>

--- a/src/language/compiling/semantics/keyword-handlers/hole-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/hole-handler.ts
@@ -1,15 +1,18 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
-import type {
-  Expression,
-  ExpressionContext,
-  KeywordHandler,
-  SemanticGraph,
+import {
+  elaborateOperands,
+  type Expression,
+  type ExpressionContext,
+  type SemanticGraph,
 } from '../../../semantics.js'
 
-export const holeKeywordHandler: KeywordHandler = (
+export const holeKeywordHandler = (
   expression: Expression,
-  _context: ExpressionContext,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   // This is currently only used in types and doesn't need transformation here.
-  either.makeRight(expression)
+  either.map(
+    elaborateOperands(expression, context),
+    ({ expression }) => expression,
+  )

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.test.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.test.ts
@@ -105,4 +105,10 @@ elaborationSuite('@if', [
     },
     success({ a: 'it works!', b: 'true' }),
   ],
+  [{ 0: '@if', 1: { 0: 'true', 1: 'yes', 2: 'no' } }, success('yes')],
+  [
+    { 0: '@if', 1: { 0: 'false', 1: { 0: '@panic' }, 2: 'it works!' } },
+    success('it works!'),
+  ],
+  [{ 0: '@if', 1: { 0: 'true', 1: '@@lookup', 2: 'no' } }, success('@lookup')],
 ])

--- a/src/language/compiling/semantics/keyword-handlers/if-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/if-handler.ts
@@ -3,6 +3,7 @@ import type { ElaborationError } from '../../../errors.js'
 import {
   asSemanticGraph,
   containsAnyUnelaboratedNodes,
+  elaborateOperands,
   elaborateWithContext,
   inferType,
   isAssignable,
@@ -21,8 +22,9 @@ import {
   type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
+import { readAndAnalyzeApplyExpression } from './apply-handler.js'
 
-export const ifKeywordHandler: KeywordHandler = (
+export const ifKeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
@@ -88,24 +90,24 @@ export const ifKeywordHandler: KeywordHandler = (
                 // where referenced properties that are higher up in the program
                 // get erased before the `@if` can be fully elaborated.
 
-                const doNotElaborate = either.makeRight
                 const partiallyElaboratingContext: ExpressionContext = {
                   ...context,
                   keywordHandlers: {
                     '@lookup': context.keywordHandlers['@lookup'],
                     '@index': context.keywordHandlers['@index'],
                     '@check': context.keywordHandlers['@check'],
-                    '@apply': analyzeButPreserveExpression(
-                      context.keywordHandlers['@apply'],
-                    ),
-                    '@function': doNotElaborate,
-                    '@hole': doNotElaborate,
-                    '@if': doNotElaborate,
-                    '@object': doNotElaborate,
-                    '@panic': doNotElaborate,
-                    '@runtime': doNotElaborate,
-                    '@todo': doNotElaborate,
-                    '@union': doNotElaborate,
+                    '@apply': readAndAnalyzeApplyExpression,
+
+                    // For nested `@if`s, not even the operands get elaborated.
+                    '@if': either.makeRight,
+
+                    '@function': elaborateOperandsOnly,
+                    '@hole': elaborateOperandsOnly,
+                    '@object': elaborateOperandsOnly,
+                    '@panic': elaborateOperandsOnly,
+                    '@runtime': elaborateOperandsOnly,
+                    '@todo': elaborateOperandsOnly,
+                    '@union': elaborateOperandsOnly,
                   },
                 }
 
@@ -194,15 +196,12 @@ const evaluateSubexpression = (
     }),
   )
 
-// Run a keyword handler for its static analysis, but preserve the original
-// expression.
-const analyzeButPreserveExpression =
-  (handler: KeywordHandler): KeywordHandler =>
-  (expression, context) =>
-    either.match(handler(expression, context), {
-      right: _ => either.makeRight(expression),
-      left: error =>
-        error.kind === 'typeMismatch' ?
-          either.makeLeft(error)
-        : either.makeRight(expression),
-    })
+/**
+ * Elaborate the expression's operands, but don't apply keyword-specific
+ * handling.
+ */
+const elaborateOperandsOnly: KeywordHandler = (expression, context) =>
+  either.map(
+    elaborateOperands(expression, context),
+    ({ expression }) => expression,
+  )

--- a/src/language/compiling/semantics/keyword-handlers/index-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/index-handler.ts
@@ -5,12 +5,12 @@ import {
   applyKeyPathToType,
   attachSpanIfAbsent,
   containsAnyUnelaboratedNodes,
+  elaborateOperands,
   inferType,
   readIndexExpression,
   stringifyTypeForEndUser,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 import { applyTypeKeyPathToSemanticGraph } from '../../../semantics/semantic-graph.js'
@@ -59,52 +59,56 @@ const checkKeyPathExistsInType = (
     },
   )
 
-export const indexKeywordHandler: KeywordHandler = (
+export const indexKeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(readIndexExpression(expression), indexExpression => {
-    const {
-      1: { object, query },
-    } = indexExpression
-    return either.flatMap(
-      typeKeyPathFromObjectNode(
-        query,
-        { ...context, location: [...context.location, '1', 'query'] },
-        inferType,
-      ),
-      typeKeyPath => {
+  either.flatMap(
+    elaborateOperands(expression, context),
+    ({ expression, context }) =>
+      either.flatMap(readIndexExpression(expression), indexExpression => {
+        const {
+          1: { object, query },
+        } = indexExpression
         return either.flatMap(
-          checkKeyPathExistsInType(object, typeKeyPath, context),
-          _ =>
-            (
-              containsAnyUnelaboratedNodes(object) ||
-              containsAnyUnelaboratedNodes(query)
-            ) ?
-              // The object isn't ready, so keep the @index unelaborated.
-              either.makeRight(indexExpression)
-            : option.match(
-                applyTypeKeyPathToSemanticGraph(object, typeKeyPath),
-                {
-                  none: _ =>
-                    // This error is less specific than the one from
-                    // `checkKeyPathExistsInType`, but since that's used for
-                    // static analysis this isn't expected to ever surface.
-                    either.makeLeft(
-                      attachSpanIfAbsent({
-                        ...context,
-                        location: [...context.location, '1', 'query'],
-                      })({
-                        kind: 'typeMismatch',
-                        message: `property \`${stringifyTypeKeyPathForEndUser(
-                          typeKeyPath,
-                        )}\` not found`,
-                      }),
-                    ),
-                  some: either.makeRight,
-                },
-              ),
+          typeKeyPathFromObjectNode(
+            query,
+            { ...context, location: [...context.location, '1', 'query'] },
+            inferType,
+          ),
+          typeKeyPath => {
+            return either.flatMap(
+              checkKeyPathExistsInType(object, typeKeyPath, context),
+              _ =>
+                (
+                  containsAnyUnelaboratedNodes(object) ||
+                  containsAnyUnelaboratedNodes(query)
+                ) ?
+                  // The object isn't ready, so keep the @index unelaborated.
+                  either.makeRight(indexExpression)
+                : option.match(
+                    applyTypeKeyPathToSemanticGraph(object, typeKeyPath),
+                    {
+                      none: _ =>
+                        // This error is less specific than the one from
+                        // `checkKeyPathExistsInType`, but since that's used for
+                        // static analysis this isn't expected to ever surface.
+                        either.makeLeft(
+                          attachSpanIfAbsent({
+                            ...context,
+                            location: [...context.location, '1', 'query'],
+                          })({
+                            kind: 'typeMismatch',
+                            message: `property \`${stringifyTypeKeyPathForEndUser(
+                              typeKeyPath,
+                            )}\` not found`,
+                          }),
+                        ),
+                      some: either.makeRight,
+                    },
+                  ),
+            )
+          },
         )
-      },
-    )
-  })
+      }),
+  )

--- a/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/lookup-handler.ts
@@ -2,6 +2,7 @@ import either, { type Either } from '@matt.kantor/either'
 import option from '@matt.kantor/option'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  elaborateOperands,
   isObjectNode,
   lookup,
   readHoleExpression,
@@ -9,41 +10,44 @@ import {
   stringifySemanticGraphForEndUser,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 
-export const lookupKeywordHandler: KeywordHandler = (
+export const lookupKeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(readLookupExpression(expression), ({ 1: { key } }) => {
-    if (isObjectNode(context.program)) {
-      return either.flatMap(lookup({ context, key }), successfulLookup =>
-        option.match(successfulLookup, {
-          none: _ =>
-            either.makeLeft({
-              kind: 'invalidExpression',
-              message: `cannot find a value for \`${stringifySemanticGraphForEndUser(expression)}\``,
+  either.flatMap(
+    elaborateOperands(expression, context),
+    ({ expression, context }) =>
+      either.flatMap(readLookupExpression(expression), ({ 1: { key } }) => {
+        if (isObjectNode(context.program)) {
+          return either.flatMap(lookup({ context, key }), successfulLookup =>
+            option.match(successfulLookup, {
+              none: _ =>
+                either.makeLeft({
+                  kind: 'invalidExpression',
+                  message: `cannot find a value for \`${stringifySemanticGraphForEndUser(expression)}\``,
+                }),
+              some: ({ foundValue }) =>
+                either.makeRight(
+                  either.match(readHoleExpression(foundValue), {
+                    // `@hole`s are kept as `@lookup`s rather than being inlined as
+                    // values, otherwise a looked-up hole would be indistinguishable
+                    // from its declaration. It's necessary to know where type
+                    // parameters are introduced during instantiation (to handle
+                    // rigidity/flexibility).
+                    right: _hole => expression,
+                    left: _ => foundValue,
+                  }),
+                ),
             }),
-          some: ({ foundValue }) =>
-            either.makeRight(
-              either.match(readHoleExpression(foundValue), {
-                // `@hole`s are kept as `@lookup`s rather than being inlined as
-                // values, otherwise a looked-up hole would be indistinguishable
-                // from its declaration. It's necessary to know where type
-                // parameters are introduced during instantiation (to handle
-                // rigidity/flexibility).
-                right: _hole => expression,
-                left: _ => foundValue,
-              }),
-            ),
-        }),
-      )
-    } else {
-      return either.makeLeft({
-        kind: 'invalidExpression',
-        message: 'the program has no properties',
-      })
-    }
-  })
+          )
+        } else {
+          return either.makeLeft({
+            kind: 'invalidExpression',
+            message: 'the program has no properties',
+          })
+        }
+      }),
+  )

--- a/src/language/compiling/semantics/keyword-handlers/object-type-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/object-type-handler.ts
@@ -1,24 +1,26 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
-import type {
-  Expression,
-  ExpressionContext,
-  KeywordHandler,
-  SemanticGraph,
+import {
+  elaborateOperands,
+  type Expression,
+  type ExpressionContext,
+  type SemanticGraph,
 } from '../../../semantics.js'
 import {
   readExcessClauses,
   readObjectTypeExpression,
 } from '../../../semantics/expressions/object-type-expression.js'
 
-export const objectTypeKeywordHandler: KeywordHandler = (
+export const objectTypeKeywordHandler = (
   expression: Expression,
-  _context: ExpressionContext,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   // This is only used in types and doesn't need transformation here, but it's
   // validated so that malformed `@object`s fail during elaboration rather than
   // surfacing later as surprising types.
-  either.map(
-    either.flatMap(readObjectTypeExpression(expression), readExcessClauses),
-    _ => expression,
+  either.flatMap(elaborateOperands(expression, context), ({ expression }) =>
+    either.map(
+      either.flatMap(readObjectTypeExpression(expression), readExcessClauses),
+      _ => expression,
+    ),
   )

--- a/src/language/compiling/semantics/keyword-handlers/panic-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/panic-handler.ts
@@ -1,20 +1,24 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  elaborateOperands,
   stringifySemanticGraphForEndUser,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 
-export const panicKeywordHandler: KeywordHandler = (
+export const panicKeywordHandler = (
   expression: Expression,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  context.panicsAreDeferred ?
-    either.makeRight(expression)
-  : either.makeLeft({
-      kind: 'panic',
-      message: stringifySemanticGraphForEndUser(expression),
-    })
+  either.flatMap(
+    elaborateOperands(expression, context),
+    ({ expression, context }) =>
+      context.panicsAreDeferred ?
+        either.makeRight(expression)
+      : either.makeLeft({
+          kind: 'panic',
+          message: stringifySemanticGraphForEndUser(expression),
+        }),
+  )

--- a/src/language/compiling/semantics/keyword-handlers/runtime-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/runtime-handler.ts
@@ -1,6 +1,7 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  elaborateOperands,
   isAssignable,
   isFunctionNode,
   makeRuntimeExpression,
@@ -9,40 +10,41 @@ import {
   types,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 
-export const runtimeKeywordHandler: KeywordHandler = (
+export const runtimeKeywordHandler = (
   expression: Expression,
-  _context: ExpressionContext,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  either.flatMap(
-    readRuntimeExpression(expression),
-    ({
-      1: { function: runtimeFunction },
-    }): Either<ElaborationError, SemanticGraph> => {
-      if (isFunctionNode(runtimeFunction)) {
-        const runtimeFunctionSignature = runtimeFunction.signature
-        return (
-            !isAssignable({
-              source: types.runtimeContext,
-              target: replaceAllTypeParametersWithTheirConstraints(
-                runtimeFunctionSignature.parameter,
-              ),
-            })
-          ) ?
-            either.makeLeft({
-              kind: 'typeMismatch',
-              message:
-                '@runtime function must accept a runtime context argument',
-            })
-          : either.makeRight(makeRuntimeExpression(runtimeFunction))
-      } else {
-        return either.makeLeft({
-          kind: 'invalidExpression',
-          message: '@runtime function was not a function',
-        })
-      }
-    },
+  either.flatMap(elaborateOperands(expression, context), ({ expression }) =>
+    either.flatMap(
+      readRuntimeExpression(expression),
+      ({
+        1: { function: runtimeFunction },
+      }): Either<ElaborationError, SemanticGraph> => {
+        if (isFunctionNode(runtimeFunction)) {
+          const runtimeFunctionSignature = runtimeFunction.signature
+          return (
+              !isAssignable({
+                source: types.runtimeContext,
+                target: replaceAllTypeParametersWithTheirConstraints(
+                  runtimeFunctionSignature.parameter,
+                ),
+              })
+            ) ?
+              either.makeLeft({
+                kind: 'typeMismatch',
+                message:
+                  '@runtime function must accept a runtime context argument',
+              })
+            : either.makeRight(makeRuntimeExpression(runtimeFunction))
+        } else {
+          return either.makeLeft({
+            kind: 'invalidExpression',
+            message: '@runtime function was not a function',
+          })
+        }
+      },
+    ),
   )

--- a/src/language/compiling/semantics/keyword-handlers/todo-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/todo-handler.ts
@@ -1,15 +1,18 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
 import {
+  elaborateOperands,
   objectNodeFromOrderedEntries,
   type Expression,
   type ExpressionContext,
-  type KeywordHandler,
   type SemanticGraph,
 } from '../../../semantics.js'
 
-export const todoKeywordHandler: KeywordHandler = (
-  _expression: Expression,
-  _context: ExpressionContext,
+export const todoKeywordHandler = (
+  expression: Expression,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
-  either.makeRight(objectNodeFromOrderedEntries([]))
+  // Operands are elaborated only so that errors within them surface.
+  either.map(elaborateOperands(expression, context), _ =>
+    objectNodeFromOrderedEntries([]),
+  )

--- a/src/language/compiling/semantics/keyword-handlers/union-handler.ts
+++ b/src/language/compiling/semantics/keyword-handlers/union-handler.ts
@@ -1,15 +1,18 @@
 import either, { type Either } from '@matt.kantor/either'
 import type { ElaborationError } from '../../../errors.js'
-import type {
-  Expression,
-  ExpressionContext,
-  KeywordHandler,
-  SemanticGraph,
+import {
+  elaborateOperands,
+  type Expression,
+  type ExpressionContext,
+  type SemanticGraph,
 } from '../../../semantics.js'
 
-export const unionKeywordHandler: KeywordHandler = (
+export const unionKeywordHandler = (
   expression: Expression,
-  _context: ExpressionContext,
+  context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> =>
   // This is currently only used in types and doesn't need transformation here.
-  either.makeRight(expression)
+  either.map(
+    elaborateOperands(expression, context),
+    ({ expression }) => expression,
+  )

--- a/src/language/runtime/keywords.ts
+++ b/src/language/runtime/keywords.ts
@@ -5,6 +5,7 @@ import type { RemoveIndexSignatures } from '../../utility-types.js'
 import { writeOutput } from '../cli/output.js'
 import { keywordHandlers as compilerKeywordHandlers } from '../compiling.js'
 import {
+  elaborateOperands,
   isFunctionNode,
   keyPathToLookupExpression,
   makeFunctionNode,
@@ -159,29 +160,33 @@ export const keywordHandlers: KeywordHandlers = {
   /**
    * Evaluates the given function, passing runtime context captured in `world`.
    */
-  '@runtime': (expression, expressionContext) =>
+  '@runtime': (expression, dispatchContext) =>
     either.flatMap(
-      readRuntimeExpression(expression),
-      ({ 1: { function: runtimeFunction } }) => {
-        if (!isFunctionNode(runtimeFunction)) {
-          return either.makeLeft({
-            kind: 'panic',
-            message:
-              'a function must be provided via the property `function` or `0`',
-          })
-        } else {
-          const result = runtimeFunction(
-            runtimeContext(runtimeFunction.parameterName),
-            expressionContext,
-          )
-          return either.mapLeft(result, error => ({
-            // The runtime function panicked or had an unavailable dependency
-            // (which results in a panic anyway in this context).
-            kind: 'panic',
-            message: error.message,
-          }))
-        }
-      },
+      elaborateOperands(expression, dispatchContext),
+      ({ expression, context: expressionContext }) =>
+        either.flatMap(
+          readRuntimeExpression(expression),
+          ({ 1: { function: runtimeFunction } }) => {
+            if (!isFunctionNode(runtimeFunction)) {
+              return either.makeLeft({
+                kind: 'panic',
+                message:
+                  'a function must be provided via the property `function` or `0`',
+              })
+            } else {
+              const result = runtimeFunction(
+                runtimeContext(runtimeFunction.parameterName),
+                expressionContext,
+              )
+              return either.mapLeft(result, error => ({
+                // The runtime function panicked or had an unavailable
+                // dependency (which results in a panic anyway in this context).
+                kind: 'panic',
+                message: error.message,
+              }))
+            }
+          },
+        ),
     ),
 }
 

--- a/src/language/semantics.ts
+++ b/src/language/semantics.ts
@@ -1,9 +1,11 @@
 export {
   attachSpanIfAbsent,
   elaborate,
+  elaborateOperands,
   elaborateWithContext,
   type ElaboratedSemanticGraph,
   type ExpressionContext,
+  type ExpressionWithElaboratedOperands,
   type FunctionParameterTypeInfo,
   type KeywordElaborationResult,
   type KeywordHandler,

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -11,6 +11,7 @@ import type {
 } from '../parsing.js'
 import {
   asSemanticGraph,
+  isSemanticGraph,
   stringifyKeyPathForInternalUse,
   type Type,
 } from '../semantics.js'
@@ -25,6 +26,7 @@ import { isKeyword, type Keyword } from './keyword.js'
 import {
   objectNodeFromMolecule,
   objectNodeFromOrderedEntries,
+  orderedEntriesOfObjectNode,
   orderedKeys,
   withProperty,
   type ObjectNode,
@@ -130,7 +132,7 @@ export const elaborateWithContext = (
   )
 
 const elaborateWithinMolecule = (
-  molecule: Molecule,
+  molecule: Molecule | ObjectNode,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> => {
   const moleculeAsSemanticGraph = asSemanticGraph(molecule)
@@ -157,176 +159,114 @@ const elaborateWithinMolecule = (
           panicsAreDeferred: true,
         }
       : context
-    const possibleExpressionAsObjectNode: Writable<ObjectNode> =
-      objectNodeFromOrderedEntries([])
 
-    // Used to initialize the resulting `ObjectNode`'s `orderedKeys` sidecar.
-    const orderedKeysAccumulator: Atom[] = []
+    const propertiesResult = elaborateProperties(
+      isSemanticGraph(molecule) ?
+        orderedEntriesOfObjectNode(molecule)
+      : molecule.entries,
+      childrenContext,
+      {
+        keyPathPrefix: [],
+        skipReelaboration: context.skipReelaboration,
+        propertyZeroMayBeAKeyword: true,
+      },
+    )
 
-    let updatedProgram = context.program
-    const keysNeedingReelaboration = new Set<Atom>()
-    let moleculeIsKeywordExpression = false
-
-    for (const [key, value] of molecule.entries) {
-      const keyUpdateResult = handleAtomWhichMayNotBeAKeyword(key)
-      if (either.isLeft(keyUpdateResult)) {
-        // Immediately bail on error.
-        return keyUpdateResult
-      } else {
-        const updatedKey = keyUpdateResult.value
-        if (typeof value === 'string') {
-          if (!(updatedKey in possibleExpressionAsObjectNode)) {
-            orderedKeysAccumulator.push(updatedKey)
-          }
-          possibleExpressionAsObjectNode[updatedKey] = value
-          if (key === '0' && isKeyword(value)) {
-            moleculeIsKeywordExpression = true
-          }
-        } else {
-          const elaborationResult = elaborateWithinMolecule(value, {
-            ...childrenContext,
-            location: [...context.location, key],
-            program: updatedProgram,
-            skipReelaboration:
-              context.skipReelaboration || moleculeIsKeywordExpression ?
-                true
-              : undefined,
-          })
-          if (either.isLeft(elaborationResult)) {
-            // Immediately bail on error.
-            return elaborationResult
-          }
-
-          const programUpdateResult = updateValueAtKeyPathInSemanticGraph(
-            updatedProgram,
-            [...context.location, key],
-            _ => elaborationResult.value,
-          )
-          if (either.isRight(programUpdateResult)) {
-            updatedProgram = programUpdateResult.value
-          }
-          if (!(updatedKey in possibleExpressionAsObjectNode)) {
-            orderedKeysAccumulator.push(updatedKey)
-          }
-          possibleExpressionAsObjectNode[updatedKey] = elaborationResult.value
-          if (
-            typeof elaborationResult.value !== 'string' &&
-            containsAnyUnelaboratedNodes(elaborationResult.value)
-          ) {
-            keysNeedingReelaboration.add(updatedKey)
-          }
-        }
-      }
-    }
-    possibleExpressionAsObjectNode[orderedKeys] = orderedKeysAccumulator
-
-    const {
-      0: _possibleKeywordAsNode,
-      ...propertiesInNeedOfFinalizationAsNodes
-    } = possibleExpressionAsObjectNode
-
-    // At this point `possibleExpressionAsObjectNode` may still have raw escape
-    // sequences at the top level (whether it is an expression or not).
-    for (const [key, value] of Object.entries(
-      propertiesInNeedOfFinalizationAsNodes,
-    )) {
-      const cannotBeKeyword = extractStringValueIfPossible(value)
-      if (!option.isNone(cannotBeKeyword)) {
-        const valueUpdateResult = handleAtomWhichMayNotBeAKeyword(
-          cannotBeKeyword.value,
-        )
-        if (either.isLeft(valueUpdateResult)) {
-          // Immediately bail on error.
-          return valueUpdateResult
-        } else {
-          const updatedValue = valueUpdateResult.value
-          possibleExpressionAsObjectNode[key] = updatedValue
-        }
-      }
-    }
-
-    // Re-elaborate nodes which are still not fully-elaborated now that sibling
-    // properties have been processed. This resolves forward references where a
-    // `@lookup` is elaborated before its target (e.g. in a program like
-    // `{ a: :b, b: :identity(42) }`, the `:b` lookup originally resolved to the
-    // raw `:identity` application rather than its return value.
-    //
-    // Re-elaboration repeats until a fixed point is reached where no progress
-    // is made (a chain of forward references may require multiple passes, and
-    // cycles like `{ a: :a }` simply don't make progress). Only properties
-    // whose elaboration produced unelaborated nodes are re-elaborated.
-    //
-    // The nested `elaborateWithContext` call uses `skipReelaboration` to
-    // prevent cascading: without it, each re-elaborated subtree would run
-    // its own re-elaboration loops, causing exponential blowup in recursive
-    // programs.
-    //
-    // TODO: Consider less-imperative/more-functional approaches for this (and
-    // also for elaboration as a whole).
-    if (!context.skipReelaboration && !moleculeIsKeywordExpression) {
-      let madeProgress = true
-      while (madeProgress && keysNeedingReelaboration.size > 0) {
-        madeProgress = false
-        for (const key of keysNeedingReelaboration) {
-          const value = possibleExpressionAsObjectNode[key]
-          if (value === undefined) {
-            keysNeedingReelaboration.delete(key)
-            continue
-          }
-          const serialized = serialize(value)
-          if (either.isLeft(serialized)) {
-            continue
-          }
-          const reelaborationResult = elaborateWithContext(serialized.value, {
-            ...childrenContext,
-            location: [...context.location, key],
-            program: updatedProgram,
-            skipReelaboration: true,
-          })
-          if (
-            either.isLeft(reelaborationResult) ||
-            containsAnyUnelaboratedNodes(reelaborationResult.value)
-          ) {
-            continue
-          }
-          possibleExpressionAsObjectNode[key] = reelaborationResult.value
-          const programUpdateResult = updateValueAtKeyPathInSemanticGraph(
-            updatedProgram,
-            [...context.location, key],
-            _ => reelaborationResult.value,
-          )
-          if (either.isRight(programUpdateResult)) {
-            updatedProgram = programUpdateResult.value
-          }
-          keysNeedingReelaboration.delete(key)
-          madeProgress = true
-        }
-      }
-    }
-
-    const possibleKeyword = possibleExpressionAsObjectNode['0']
-    if (possibleKeyword === undefined) {
-      // The input didn't have a `0` property, so it's not an expression.
-      return either.makeRight(possibleExpressionAsObjectNode)
+    if (either.isLeft(propertiesResult)) {
+      // Immediately bail on error.
+      return propertiesResult
     } else {
-      return option.match(extractStringValueIfPossible(possibleKeyword), {
-        none: () => {
-          // The `0` property was not a string, so it's not an expression.
-          return either.makeRight(possibleExpressionAsObjectNode)
-        },
-        some: possibleKeywordAsString =>
-          handleObjectNodeWhichMayBeAExpression(
-            {
-              ...possibleExpressionAsObjectNode,
-              0: possibleKeywordAsString,
-            },
-            {
+      const possibleExpressionAsObjectNode = propertiesResult.value.properties
+      const keysNeedingReelaboration =
+        propertiesResult.value.keysNeedingReelaboration
+      let updatedProgram = propertiesResult.value.program
+
+      // Re-elaborate nodes which are still not fully-elaborated now that
+      // sibling properties have been processed. This resolves forward
+      // references where a `@lookup` is elaborated before its target (e.g. in a
+      // program like `{ a: :b, b: :identity(42) }`, the `:b` lookup originally
+      // resolved to the raw `:identity` application rather than its return
+      // value.
+      //
+      // Re-elaboration repeats until a fixed point is reached where no progress
+      // is made (a chain of forward references may require multiple passes, and
+      // cycles like `{ a: :a }` simply don't make progress). Only properties
+      // whose elaboration produced unelaborated nodes are re-elaborated.
+      //
+      // The nested `elaborateWithContext` call uses `skipReelaboration` to
+      // prevent cascading: without it, each re-elaborated subtree would run
+      // its own re-elaboration loops, causing exponential blowup in recursive
+      // programs.
+      //
+      // TODO: Consider less-imperative/more-functional approaches for this (and
+      // also for elaboration as a whole).
+      if (
+        !context.skipReelaboration &&
+        !propertiesResult.value.propertiesFormAKeywordExpression
+      ) {
+        let madeProgress = true
+        while (madeProgress && keysNeedingReelaboration.size > 0) {
+          madeProgress = false
+          for (const key of keysNeedingReelaboration) {
+            const value = possibleExpressionAsObjectNode[key]
+            if (value === undefined) {
+              keysNeedingReelaboration.delete(key)
+              continue
+            }
+            const serialized = serialize(value)
+            if (either.isLeft(serialized)) {
+              continue
+            }
+            const reelaborationResult = elaborateWithContext(serialized.value, {
               ...childrenContext,
+              location: [...context.location, key],
               program: updatedProgram,
-              location: context.location,
-            },
-          ),
-      })
+              skipReelaboration: true,
+            })
+            if (
+              either.isLeft(reelaborationResult) ||
+              containsAnyUnelaboratedNodes(reelaborationResult.value)
+            ) {
+              continue
+            }
+            possibleExpressionAsObjectNode[key] = reelaborationResult.value
+            updatedProgram = programWithValueAtKeyPath(
+              updatedProgram,
+              [...context.location, key],
+              reelaborationResult.value,
+            )
+            keysNeedingReelaboration.delete(key)
+            madeProgress = true
+          }
+        }
+      }
+
+      // Directly-written keyword expressions were already handled above, but a
+      // `0` property which elaborated to a string may be a computed keyword.
+      const possibleKeyword = possibleExpressionAsObjectNode['0']
+      if (possibleKeyword === undefined) {
+        // The input didn't have a `0` property, so it's not an expression.
+        return either.makeRight(possibleExpressionAsObjectNode)
+      } else {
+        return option.match(extractStringValueIfPossible(possibleKeyword), {
+          none: () => {
+            // The `0` property was not a string, so it's not an expression.
+            return either.makeRight(possibleExpressionAsObjectNode)
+          },
+          some: possibleKeywordAsString =>
+            handleObjectNodeWhichMayBeAExpression(
+              {
+                ...possibleExpressionAsObjectNode,
+                0: possibleKeywordAsString,
+              },
+              {
+                ...childrenContext,
+                program: updatedProgram,
+                location: context.location,
+              },
+            ),
+        })
+      }
     }
   }
 }
@@ -352,6 +292,132 @@ const handleObjectNodeWhichMayBeAExpression = (
       )
 
   return either.mapLeft(result, attachSpanIfAbsent(context))
+}
+
+/**
+ * Elaborate each of the given properties, updating the program.
+ *
+ * The returned `properties` and `keysNeedingReelaboration` are freshly-created
+ * and may be safely mutated at return sites.
+ */
+const elaborateProperties = (
+  propertiesToElaborate: readonly (readonly [Atom, SemanticGraph | Molecule])[],
+  context: ExpressionContext,
+  options: {
+    /** Appended to `context.location` to locate the properties themselves. */
+    readonly keyPathPrefix: KeyPath
+    readonly skipReelaboration: true | undefined
+    /**
+     * When `true`, property `0` is left escaped (it may be a keyword, in which
+     * case `handleObjectNodeWhichMayBeAExpression` unescapes it instead).
+     */
+    readonly propertyZeroMayBeAKeyword: boolean
+  },
+): Either<
+  ElaborationError,
+  {
+    readonly properties: Writable<ObjectNode>
+    readonly program: SemanticGraph
+    readonly keysNeedingReelaboration: Set<Atom>
+    readonly propertiesFormAKeywordExpression: boolean
+  }
+> => {
+  const properties: Writable<ObjectNode> = objectNodeFromOrderedEntries([])
+
+  // Used to initialize the resulting `ObjectNode`'s `orderedKeys` sidecar.
+  const orderedKeysAccumulator: Atom[] = []
+
+  let updatedProgram = context.program
+  const keysNeedingReelaboration = new Set<Atom>()
+
+  // Set once a keyword has been seen at `0`, which makes the properties
+  // following it that keyword's operands. Neither they nor the expression they
+  // belong to may run re-elaboration loops.
+  let propertiesFormAKeywordExpression = false
+
+  for (const [key, value] of propertiesToElaborate) {
+    const keyUpdateResult = handleAtomWhichMayNotBeAKeyword(key)
+    if (either.isLeft(keyUpdateResult)) {
+      // Immediately bail on error.
+      return keyUpdateResult
+    } else {
+      const updatedKey = keyUpdateResult.value
+      if (
+        typeof value === 'string' ||
+        typeof value === 'symbol' ||
+        typeof value === 'function'
+      ) {
+        // No elaboration is required.
+        if (!(updatedKey in properties)) {
+          orderedKeysAccumulator.push(updatedKey)
+        }
+        properties[updatedKey] = value
+        if (
+          options.propertyZeroMayBeAKeyword &&
+          key === '0' &&
+          typeof value === 'string' &&
+          isKeyword(value)
+        ) {
+          propertiesFormAKeywordExpression = true
+        }
+      } else {
+        const location = [...context.location, ...options.keyPathPrefix, key]
+        const elaborationResult = elaborateWithinMolecule(value, {
+          ...context,
+          location,
+          program: updatedProgram,
+          skipReelaboration:
+            options.skipReelaboration || propertiesFormAKeywordExpression ?
+              true
+            : undefined,
+        })
+        if (either.isLeft(elaborationResult)) {
+          // Immediately bail on error.
+          return elaborationResult
+        } else {
+          updatedProgram = programWithValueAtKeyPath(
+            updatedProgram,
+            location,
+            elaborationResult.value,
+          )
+          if (!(updatedKey in properties)) {
+            orderedKeysAccumulator.push(updatedKey)
+          }
+          properties[updatedKey] = elaborationResult.value
+          if (
+            options.skipReelaboration === undefined &&
+            !propertiesFormAKeywordExpression &&
+            typeof elaborationResult.value !== 'string' &&
+            containsAnyUnelaboratedNodes(elaborationResult.value)
+          ) {
+            keysNeedingReelaboration.add(updatedKey)
+          }
+        }
+      }
+    }
+  }
+  properties[orderedKeys] = orderedKeysAccumulator
+
+  // At this point `properties` may still have raw escape sequences.
+  for (const [key, value] of Object.entries(properties)) {
+    const valueUpdateResult =
+      options.propertyZeroMayBeAKeyword && key === '0' ?
+        either.makeRight(value)
+      : unescapeIfAtom(value)
+    if (either.isLeft(valueUpdateResult)) {
+      // Immediately bail on error.
+      return valueUpdateResult
+    } else {
+      properties[key] = valueUpdateResult.value
+    }
+  }
+
+  return either.makeRight({
+    properties,
+    program: updatedProgram,
+    keysNeedingReelaboration,
+    propertiesFormAKeywordExpression,
+  })
 }
 
 /**
@@ -388,6 +454,29 @@ const spanForLocation = (
       undefined
     : spanForLocation(spans, location.slice(0, -1))))
   )
+
+/**
+ * Write `value` into `program` at `keyPath`, leaving the program unchanged if
+ * the path doesn't resolve (elaboration also runs on expressions which aren't
+ * located in `program`, e.g. user functions called from the standard library).
+ */
+const programWithValueAtKeyPath = (
+  program: SemanticGraph,
+  keyPath: KeyPath,
+  value: SemanticGraph,
+): SemanticGraph =>
+  either.unwrapOrElse(
+    updateValueAtKeyPathInSemanticGraph(program, keyPath, _ => value),
+    _ => program,
+  )
+
+const unescapeIfAtom = (
+  value: SemanticGraph,
+): Either<InvalidSyntaxTreeError, SemanticGraph> =>
+  option.match(extractStringValueIfPossible(value), {
+    none: _ => either.makeRight(value),
+    some: handleAtomWhichMayNotBeAKeyword,
+  })
 
 const handleAtomWhichMayNotBeAKeyword = (
   atom: Atom,

--- a/src/language/semantics/expression-elaboration.ts
+++ b/src/language/semantics/expression-elaboration.ts
@@ -16,11 +16,7 @@ import {
   type Type,
 } from '../semantics.js'
 import type { Span } from '../source-location.js'
-import {
-  isExpression,
-  isKeywordExpressionWithArgument,
-  type Expression,
-} from './expression.js'
+import { isExpression, type Expression } from './expression.js'
 import type { KeyPath } from './key-path.js'
 import { isKeyword, type Keyword } from './keyword.js'
 import {
@@ -43,6 +39,13 @@ import type { TypeKeyPathStringifiedForInternalUse } from './type-system.js'
 declare const _elaborated: unique symbol
 type Elaborated = { readonly [_elaborated]: true }
 export type ElaboratedSemanticGraph = WithPhantomData<SemanticGraph, Elaborated>
+
+declare const _operandsElaborated: unique symbol
+type OperandsElaborated = { readonly [_operandsElaborated]: true }
+export type ExpressionWithElaboratedOperands = WithPhantomData<
+  Expression,
+  OperandsElaborated
+>
 
 /**
  * The (possibly genericized) type of a function's parameter, plus the
@@ -131,47 +134,109 @@ export const elaborateWithContext = (
     withPhantomData<Elaborated>(),
   )
 
+/**
+ * Elaborate a keyword expression's operands (the sub-properties within its `1`
+ * property), returning the expression with its operands elaborated together
+ * with a context whose `program` reflects those elaborations.
+ *
+ * Most keyword handlers are expected to call this (though some like `@if`
+ * handle subexpression elaboration more granularly) before reading/using the
+ * operands. Handlers must proceed with the returned context (the original
+ * context doesn't capture the operands' elaborated values, so lookups made
+ * against it would resolve to stale forms).
+ */
+export const elaborateOperands = (
+  expression: Expression,
+  context: ExpressionContext,
+): Either<
+  ElaborationError,
+  {
+    readonly expression: ExpressionWithElaboratedOperands
+    readonly context: ExpressionContext
+  }
+> => {
+  const operands = expression[1]
+  if (operands === undefined) {
+    return either.makeRight({
+      expression: withPhantomData<OperandsElaborated>()(expression),
+      context,
+    })
+  } else if (typeof operands === 'string') {
+    return either.map(
+      handleAtomWhichMayNotBeAKeyword(operands),
+      unescapedOperands => ({
+        expression: withPhantomData<OperandsElaborated>()(
+          withProperty(
+            withProperty(expression, '1', unescapedOperands),
+            '0',
+            expression[0],
+          ),
+        ),
+        context,
+      }),
+    )
+  } else if (typeof operands === 'symbol' || typeof operands === 'function') {
+    // The operands are already elaborated.
+    return either.makeRight({
+      expression: withPhantomData<OperandsElaborated>()(expression),
+      context,
+    })
+  } else {
+    return either.map(
+      elaborateProperties(orderedEntriesOfObjectNode(operands), context, {
+        keyPathPrefix: ['1'],
+        skipReelaboration: true,
+        propertyZeroMayBeAKeyword: false,
+      }),
+      ({ properties: elaboratedOperands, program }) => ({
+        expression: withPhantomData<OperandsElaborated>()(
+          withProperty(
+            withProperty(expression, '1', elaboratedOperands),
+            '0',
+            expression[0],
+          ),
+        ),
+        context: {
+          ...context,
+          program: programWithValueAtKeyPath(
+            program,
+            [...context.location, '1'],
+            elaboratedOperands,
+          ),
+        },
+      }),
+    )
+  }
+}
+
 const elaborateWithinMolecule = (
   molecule: Molecule | ObjectNode,
   context: ExpressionContext,
 ): Either<ElaborationError, SemanticGraph> => {
   const moleculeAsSemanticGraph = asSemanticGraph(molecule)
 
-  // `@if` needs to be eagerly expanded to avoid evaluating the falsy branch.
-  // TODO: Handle keywords in a generalized way, without hardcoding specific
-  // keywords here.
   if (
     isExpression(moleculeAsSemanticGraph) &&
-    moleculeAsSemanticGraph['0'] === '@if'
+    isKeyword(moleculeAsSemanticGraph['0'])
   ) {
-    const expandedResult = either.flatMap(
-      handleObjectNodeWhichMayBeAExpression(moleculeAsSemanticGraph, context),
-      serialize,
+    // Keyword handlers are passed the raw expression; each handler explicitly
+    // elaborates its own operands (typically via `elaborateOperands`).
+    return handleObjectNodeWhichMayBeAExpression(
+      moleculeAsSemanticGraph,
+      context,
     )
-    return either.map(expandedResult, asSemanticGraph)
   } else {
-    const childrenContext: ExpressionContext =
-      isKeywordExpressionWithArgument('@function', moleculeAsSemanticGraph) ?
-        {
-          ...context,
-          // `@panic`s inside functions shouldn't fire while elaborating the
-          // body, only when the function is eventually called.
-          panicsAreDeferred: true,
-        }
-      : context
-
     const propertiesResult = elaborateProperties(
       isSemanticGraph(molecule) ?
         orderedEntriesOfObjectNode(molecule)
       : molecule.entries,
-      childrenContext,
+      context,
       {
         keyPathPrefix: [],
         skipReelaboration: context.skipReelaboration,
         propertyZeroMayBeAKeyword: true,
       },
     )
-
     if (either.isLeft(propertiesResult)) {
       // Immediately bail on error.
       return propertiesResult
@@ -200,10 +265,7 @@ const elaborateWithinMolecule = (
       //
       // TODO: Consider less-imperative/more-functional approaches for this (and
       // also for elaboration as a whole).
-      if (
-        !context.skipReelaboration &&
-        !propertiesResult.value.propertiesFormAKeywordExpression
-      ) {
+      if (!context.skipReelaboration) {
         let madeProgress = true
         while (madeProgress && keysNeedingReelaboration.size > 0) {
           madeProgress = false
@@ -218,7 +280,7 @@ const elaborateWithinMolecule = (
               continue
             }
             const reelaborationResult = elaborateWithContext(serialized.value, {
-              ...childrenContext,
+              ...context,
               location: [...context.location, key],
               program: updatedProgram,
               skipReelaboration: true,
@@ -260,7 +322,7 @@ const elaborateWithinMolecule = (
                 0: possibleKeywordAsString,
               },
               {
-                ...childrenContext,
+                ...context,
                 program: updatedProgram,
                 location: context.location,
               },
@@ -319,7 +381,6 @@ const elaborateProperties = (
     readonly properties: Writable<ObjectNode>
     readonly program: SemanticGraph
     readonly keysNeedingReelaboration: Set<Atom>
-    readonly propertiesFormAKeywordExpression: boolean
   }
 > => {
   const properties: Writable<ObjectNode> = objectNodeFromOrderedEntries([])
@@ -329,11 +390,6 @@ const elaborateProperties = (
 
   let updatedProgram = context.program
   const keysNeedingReelaboration = new Set<Atom>()
-
-  // Set once a keyword has been seen at `0`, which makes the properties
-  // following it that keyword's operands. Neither they nor the expression they
-  // belong to may run re-elaboration loops.
-  let propertiesFormAKeywordExpression = false
 
   for (const [key, value] of propertiesToElaborate) {
     const keyUpdateResult = handleAtomWhichMayNotBeAKeyword(key)
@@ -352,24 +408,13 @@ const elaborateProperties = (
           orderedKeysAccumulator.push(updatedKey)
         }
         properties[updatedKey] = value
-        if (
-          options.propertyZeroMayBeAKeyword &&
-          key === '0' &&
-          typeof value === 'string' &&
-          isKeyword(value)
-        ) {
-          propertiesFormAKeywordExpression = true
-        }
       } else {
         const location = [...context.location, ...options.keyPathPrefix, key]
         const elaborationResult = elaborateWithinMolecule(value, {
           ...context,
           location,
           program: updatedProgram,
-          skipReelaboration:
-            options.skipReelaboration || propertiesFormAKeywordExpression ?
-              true
-            : undefined,
+          skipReelaboration: options.skipReelaboration,
         })
         if (either.isLeft(elaborationResult)) {
           // Immediately bail on error.
@@ -386,7 +431,6 @@ const elaborateProperties = (
           properties[updatedKey] = elaborationResult.value
           if (
             options.skipReelaboration === undefined &&
-            !propertiesFormAKeywordExpression &&
             typeof elaborationResult.value !== 'string' &&
             containsAnyUnelaboratedNodes(elaborationResult.value)
           ) {
@@ -416,7 +460,6 @@ const elaborateProperties = (
     properties,
     program: updatedProgram,
     keysNeedingReelaboration,
-    propertiesFormAKeywordExpression,
   })
 }
 


### PR DESCRIPTION
Previously `@if` and `@function` both had special cases in elaboration: typical elaboration was bottom-up (leaf nodes elaborated before their parents), but `@if` was handled on the way down (with unelaborated subexpressions) because which branch should be elaborated depended on the condition, and `@function` had special context management to defer `@panic`s until functions were called.

Now all keywords are handled similar to how `@if` was before: their handlers are given the unelaborated expression node and it's up to them to explicitly elaborate children as necessary.

A shared `elaborateOperands` library function has been extracted for the common case where handlers want to immediately elaborate their operands (values beneath the `1` property).

There are no behavioral changes in this pull request; it's a pure refactor.

The diff is greatly improved by ignoring whitespace changes.